### PR TITLE
Potential fix for code scanning alert no. 10: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/scc.c
+++ b/src/scc.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <limits.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 /* ── Format constants ───────────────────────────────────────────────────── */
 
@@ -575,9 +576,11 @@ static int write_scc(const char *scc_path, const char *src_path,
 
     ok = ok && wu32(f, SCC_SENTINEL);
 
+    if (executable)
+        ok = ok && (fchmod(fileno(f), 0755) == 0);
+
     fclose(f);
     if (!ok) { remove(scc_path); return -1; }
-    if (executable) chmod(scc_path, 0755);
     return 0;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/deconstructo/curry/security/code-scanning/10](https://github.com/deconstructo/curry/security/code-scanning/10)

Use descriptor-based permission change on the open file handle before closing it.  
Specifically in `src/scc.c` inside `write_scc(...)`, replace the post-`fclose` `chmod(scc_path, 0755)` with an `fchmod(fileno(f), 0755)` while `f` is still open and fold its result into `ok`. This removes the race on `scc_path` and keeps functionality (mark executable when requested).  
You need:
- `#include <unistd.h>` for `fchmod`/`fileno` declarations.
- small logic adjustment so close happens after optional `fchmod`, and error cleanup remains intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
