### PR TITLE
fix(network): tcp-connect/tcp-accept now actually return ports

### DIFF
--- a/docs/reference/module-network.md
+++ b/docs/reference/module-network.md
@@ -19,29 +19,39 @@ No extra packages required. Enabled by default (`-DBUILD_MODULE_NETWORK=ON`).
 ### Client
 
 ```scheme
-(tcp-connect host port)     ; connect to host:port, return socket handle
-(tcp-close sock)            ; close the socket
+(tcp-connect host port)     ; connect to host:port, return (in-port . out-port)
 ```
 
-Once connected, use `read`/`write` on the socket as a port, or use the raw procedures below.
+`tcp-connect` returns a **pair of ports** — `(in-port . out-port)` — not a
+single socket handle. A Curry port is one-directional, and a TCP connection
+needs both read and write, so you get two independent ports over the same
+underlying connection. Close each with `close-port` when done.
 
 ### Server
 
 ```scheme
-(tcp-listen port)           ; listen on port (all interfaces)
+(tcp-listen port)           ; listen on port (all interfaces), return a raw socket handle
 (tcp-listen port backlog)   ; listen with explicit backlog
-(tcp-accept listen-sock)    ; block until a client connects, return socket handle
-(tcp-close sock)
+(tcp-accept listen-sock)    ; block until a client connects, return (in-port . out-port)
+(tcp-close listen-sock)     ; close the *listening* socket (not a port pair)
 ```
+
+`tcp-listen`'s own return value is a raw listening-socket handle (not a
+stream, so not a port) — close it with `tcp-close`. Each accepted
+connection from `tcp-accept` is a port pair like `tcp-connect`'s, closed
+with `close-port` on each end.
 
 ## UDP
 
 ```scheme
 (udp-socket)                    ; create a UDP socket
 (udp-bind sock port)            ; bind to a local port
-(udp-send sock host port data)  ; send bytevector data to host:port
+(udp-send sock data host port)  ; send bytevector data to host:port
 (udp-recv sock max-bytes)       ; receive up to max-bytes; returns (data host port)
 ```
+
+UDP is datagram-oriented, not stream-oriented, so `udp-socket` stays a raw
+handle — there's no port wrapping for it.
 
 ## Examples
 
@@ -50,15 +60,20 @@ Once connected, use `read`/`write` on the socket as a port, or use the raw proce
 ```scheme
 (import (curry network))
 
-(define sock (tcp-connect "example.com" 80))
-; send request
-(write-string "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n" sock)
-; read response
-(let loop ((line (read-line sock)))
+(define conn (tcp-connect "example.com" 80))
+(define in  (car conn))
+(define out (cdr conn))
+
+(write-string "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n" out)
+(flush-output-port out)
+
+(let loop ((line (read-line in)))
   (unless (eof-object? line)
     (display line) (newline)
-    (loop (read-line sock))))
-(tcp-close sock)
+    (loop (read-line in))))
+
+(close-port in)
+(close-port out)
 ```
 
 ### Echo server
@@ -71,19 +86,29 @@ Once connected, use `read`/`write` on the socket as a port, or use the raw proce
 (display "Listening on port 7777...\n")
 
 (let loop ()
-  (define client (tcp-accept listener))
+  (define conn (tcp-accept listener))
+  (define in  (car conn))
+  (define out (cdr conn))
   (spawn (lambda ()
     (let echo ()
-      (define line (read-line client))
+      (define line (read-line in))
       (unless (eof-object? line)
-        (write-string line client)
-        (write-string "\n" client)
+        (write-string line out)
+        (write-string "\n" out)
+        (flush-output-port out)
         (echo)))
-    (tcp-close client)))
+    (close-port in)
+    (close-port out)))
   (loop))
 ```
 
 ### UDP echo
+
+> **Currently broken** — `udp-recv` uses `recv()`, not `recvfrom()`, so it
+> cannot actually report the sender's address; it returns only the raw
+> bytevector today, not `(data host port)` as shown below. This example
+> documents the intended contract. See
+> [issue #16](https://github.com/deconstructo/curry/issues/16).
 
 ```scheme
 (import (curry network))
@@ -93,12 +118,19 @@ Once connected, use `read`/`write` on the socket as a port, or use the raw proce
 
 (let loop ()
   (define-values (data host port) (apply values (udp-recv sock 1024)))
-  (udp-send sock host port data)
+  (udp-send sock data host port)
   (loop))
 ```
 
 ## Notes
 
-- Socket handles are opaque values. They can be passed to port-based procedures (`read-line`, `write-string`, `read-char`, etc.) since they are implemented as Curry ports.
-- `tcp-listen` binds to `0.0.0.0` (all interfaces). To bind to a specific interface, use the raw C extension API.
-- For TLS, wrap a `tcp-connect` socket with the crypto module (OpenSSL BIO) — this is not yet exposed in the Scheme API; use `system` to call `openssl s_client` as a workaround.
+- `tcp-connect`/`tcp-accept` return `(in-port . out-port)` pairs — real
+  Curry ports usable with `read-line`, `write-string`, `read-char`, etc.
+  Remember to `flush-output-port` after writing before expecting a reply
+  (output ports are buffered by default, same as any other Curry port).
+- `tcp-listen` binds to `0.0.0.0`/`::` (all interfaces, dual-stack). To
+  bind to a specific interface, use the raw C extension API.
+- For TLS, wrap a `tcp-connect` socket with the crypto module (OpenSSL BIO)
+  — not yet exposed in the Scheme API; use `system` to call
+  `openssl s_client` as a workaround. See
+  [issue #14](https://github.com/deconstructo/curry/issues/14).

--- a/include/curry.h
+++ b/include/curry.h
@@ -128,6 +128,14 @@ curry_val  curry_make_octonion(const double e[8]);
 /* ---- List building helpers ---- */
 curry_val  curry_list(int n, ...);  /* curry_list(3, a, b, c) -> (a b c) */
 
+/* ---- Ports ----
+ * Wrap an existing file descriptor (e.g. a socket) as a Curry port, usable
+ * directly with read-line/write-string/read-char/etc. Takes ownership of
+ * fd (closes it via GC finalizer, or when the returned port is explicitly
+ * closed) — do not close fd yourself after this call. Returns a false-y
+ * value (curry_is_true false) if fdopen() fails. */
+curry_val  curry_make_port_from_fd(int fd, bool output, bool binary);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -4,12 +4,18 @@
  * Scheme API:
  *   (tcp-connect host port)         -> port-pair (in-port . out-port)
  *   (tcp-listen port backlog)       -> server-socket
- *   (tcp-accept server)             -> port-pair
- *   (tcp-close server)              -> void
+ *   (tcp-accept server)             -> port-pair (in-port . out-port)
+ *   (tcp-close server)              -> void      (closes tcp-listen's raw socket;
+ *                                                  port pairs use close-port)
  *   (udp-socket)                    -> socket
  *   (udp-bind sock port)            -> void
  *   (udp-send sock data host port)  -> void
  *   (udp-recv sock maxbytes)        -> bytevector
+ *
+ * tcp-connect/tcp-accept return an actual (in-port . out-port) pair now
+ * (see curry_make_port_from_fd in the public API) — close each end with
+ * close-port. tcp-listen's own listening socket is not a stream and stays
+ * a raw handle, closed with tcp-close.
  *
  * Non-blocking I/O and async support are planned via integration
  * with the actor system (each connection runs in its own actor).
@@ -75,12 +81,17 @@ static curry_val fn_tcp_connect(int ac, curry_val *av, void *ud) {
     }
     freeaddrinfo(res);
 
-    /* Wrap as FILE* for use as Scheme ports */
-    FILE *rfp = fdopen((int)fd, "r");
-    FILE *wfp = fdopen((int)dup((int)fd), "w");
-    (void)rfp; (void)wfp;
-    /* Return sock handle; caller uses port wrappers */
-    return sock_to_val(fd);
+    /* Wrap as a port pair: (in-port . out-port). Two independent FILE*
+     * streams over dup()'d fds (not one bidirectional stream) since a
+     * Curry port is one-directional — matches the doc comment's
+     * `-> port-pair (in-port . out-port)` contract. */
+    int wfd = dup((int)fd);
+    if (wfd < 0) { sock_close(fd); curry_error("tcp-connect: dup failed"); }
+    curry_val in_port  = curry_make_port_from_fd((int)fd, false, false);
+    curry_val out_port = curry_make_port_from_fd(wfd, true, false);
+    if (!curry_is_true(in_port) || !curry_is_true(out_port))
+        curry_error("tcp-connect: fdopen failed");
+    return curry_make_pair(in_port, out_port);
 }
 
 static curry_val fn_tcp_listen(int ac, curry_val *av, void *ud) {
@@ -117,7 +128,15 @@ static curry_val fn_tcp_accept(int ac, curry_val *av, void *ud) {
     struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
     sock_t client = accept((int)server, (struct sockaddr *)&addr, &addrlen);
     if (client == SOCK_INVALID) curry_error("tcp-accept: accept failed");
-    return sock_to_val(client);
+
+    /* Port pair, same rationale as fn_tcp_connect. */
+    int wfd = dup((int)client);
+    if (wfd < 0) { sock_close(client); curry_error("tcp-accept: dup failed"); }
+    curry_val in_port  = curry_make_port_from_fd((int)client, false, false);
+    curry_val out_port = curry_make_port_from_fd(wfd, true, false);
+    if (!curry_is_true(in_port) || !curry_is_true(out_port))
+        curry_error("tcp-accept: fdopen failed");
+    return curry_make_pair(in_port, out_port);
 }
 
 static curry_val fn_tcp_close(int ac, curry_val *av, void *ud) {

--- a/src/api.c
+++ b/src/api.c
@@ -15,6 +15,7 @@
 #include "vm.h"
 #include "builtins.h"
 #include "gc.h"
+#include "port.h"
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -162,6 +163,13 @@ curry_val curry_make_octonion(const double e[8]) {
 }
 
 /* ---- List helpers ---- */
+
+/* ---- Ports ---- */
+
+curry_val curry_make_port_from_fd(int fd, bool output, bool binary) {
+    int flags = (output ? PORT_OUTPUT : PORT_INPUT) | (binary ? PORT_BINARY : 0);
+    return port_wrap_fd(fd, flags);
+}
 
 curry_val curry_list(int n, ...) {
     va_list ap;

--- a/src/port.c
+++ b/src/port.c
@@ -60,6 +60,21 @@ val_t port_open_file(const char *path, int flags) {
     return v;
 }
 
+val_t port_wrap_fd(int fd, int flags) {
+    const char *mode;
+    if ((flags & PORT_BINARY)) {
+        mode = (flags & PORT_OUTPUT) ? "wb" : "rb";
+    } else {
+        mode = (flags & PORT_OUTPUT) ? "w" : "r";
+    }
+    FILE *fp = fdopen(fd, mode);
+    if (!fp) return V_FALSE;
+    val_t v = make_port(flags);
+    as_port(v)->u.fp = fp;
+    gc_finalizer(as_port(v), port_gc_finalize, NULL);
+    return v;
+}
+
 val_t port_open_input_string(const char *str, uint32_t len) {
     val_t v = make_port(PORT_INPUT | PORT_STRING);
     Port *p = as_port(v);

--- a/src/port.h
+++ b/src/port.h
@@ -23,6 +23,12 @@ val_t port_open_input_bytevector(const uint8_t *data, uint32_t len);
 val_t port_open_output_bytevector(void);
 val_t port_wrap_file(FILE *fp, int flags);
 
+/* Wrap an existing file descriptor (e.g. a socket) as a port: fdopen()s it
+ * with a mode string chosen from flags (mirroring port_open_file's mode
+ * logic) and registers a GC finalizer to close it, same as a file opened
+ * via port_open_file. Returns V_FALSE if fdopen fails. */
+val_t port_wrap_fd(int fd, int flags);
+
 /* ---- Standard ports ---- */
 extern val_t PORT_STDIN, PORT_STDOUT, PORT_STDERR;
 void port_init(void);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,11 @@ if(BUILD_LLVM)
     add_test(NAME jit COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/jit_tests.scm)
 endif()
 
+if(BUILD_MODULE_NETWORK AND TARGET curry_network)
+    add_test(NAME network COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/network_tests.scm)
+    set_tests_properties(network PROPERTIES ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
 # Pure-Scheme scientific I/O modules (fits/netcdf) plus the FFI-based hdf5
 # wrapper (requires BUILD_FFI=ON to compile; libhdf5 itself is a
 # runtime-only dlopen dependency, so hdf5_tests.scm skips cleanly if it's

--- a/tests/network_tests.scm
+++ b/tests/network_tests.scm
@@ -1,0 +1,80 @@
+;;; (curry network) tests — TCP socket-as-port round-trip.
+;;;
+;;; Self-contained: listens on loopback, connects to itself, exercises
+;;; read-line/write-string bidirectionally. No external network access
+;;; needed. Regression coverage for tcp-connect/tcp-accept actually
+;;; returning ports (they used to silently discard the FILE* streams
+;;; they created and return a raw fd pair instead).
+
+(import (curry network))
+(import (scheme base))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define test-port 17999)
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 1  tcp-listen/tcp-accept/tcp-connect return real ports
+;;; ════════════════════════════════════════════════════════════
+
+(define listener (tcp-listen test-port))
+
+(define server-thread
+  (spawn (lambda ()
+           (let* ((conn (tcp-accept listener))
+                  (in (car conn)) (out (cdr conn)))
+             (let loop ()
+               (let ((line (read-line in)))
+                 (unless (eof-object? line)
+                   (write-string (string-append "echo:" line) out)
+                   (write-string "\n" out)
+                   (flush-output-port out)
+                   (loop))))
+             (close-port in)
+             (close-port out)))))
+
+;; No delay needed: tcp-listen's listen() call already puts the socket in
+;; a listening state accepting the OS backlog before tcp-accept is ever
+;; called — connect() succeeds regardless of whether the accepting actor
+;; has reached its accept() call yet.
+(define client (tcp-connect "127.0.0.1" test-port))
+(define cin (car client))
+(define cout (cdr client))
+
+(check "in port is a port"  (port? cin) #t)
+(check "out port is a port" (port? cout) #t)
+
+(write-string "hello" cout)
+(write-string "\n" cout)
+(flush-output-port cout)
+
+(check "echo round-trip" (read-line cin) "echo:hello")
+
+(write-string "second" cout)
+(write-string "\n" cout)
+(flush-output-port cout)
+(check "second round-trip" (read-line cin) "echo:second")
+
+(close-port cin)
+(close-port cout)
+(tcp-close listener)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

- `tcp-connect`/`tcp-accept` opened `FILE*` read/write streams via `fdopen`/`dup` and then discarded them (`(void)rfp; (void)wfp;`), returning a raw `(symbol 'socket . fd-bytevector)` pair instead of a Curry port — contradicting the docs' claim that sockets "are implemented as Curry ports."
- Root cause: `include/curry.h` had no function to wrap a `FILE*`/fd as a port for modules. Adds `curry_make_port_from_fd` (public API) on top of a new `port_wrap_fd` (internal, mirrors `port_open_file`'s structure).
- `tcp-connect`/`tcp-accept` now return a real `(in-port . out-port)` pair, matching the doc comment's original intended contract.
- Caught a second bug while verifying the fix: initially created the ports with `binary=true`, which silently broke `read-line`/`write-string` (`port_read_char` short-circuits binary ports to EOF, correctly per R7RS). Fixed to `binary=false` — sockets used for text protocols need text ports.
- Adds `tests/network_tests.scm` — no test coverage existed for this module at all before this PR.
- Found (not fixed here — filed as #16, sequenced after #14/#15): `udp-recv` uses `recv()` not `recvfrom()`, so it can't return sender address despite docs/example assuming `(data host port)`. Added an inline doc caveat so the example doesn't silently mislead until #16 lands.

## Test plan

- [x] `cmake --build build -DBUILD_FFI=ON && ctest --test-dir build` — 41/41 suites pass (40 previous + new `network` suite)
- [x] Manual: loopback echo server/client round-trip via Python socket client — multi-line `read-line`/`write-string` cycle works correctly
- [x] Manual: `tcp-connect` client side against a real HTTP server (example.com:80) — `GET /` request/response round-trip via ports
- [x] Manual: confirmed the exact bug before the fix (`read-line` silently returning EOF despite data being sent and buffered in the kernel socket buffer — confirmed via `ConnectionResetError` on the client when data was left unread)

Fixes #13.
