### PR TITLE
fix(network): udp-recv reports sender host/port via recvfrom()

### DIFF
--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -9,7 +9,7 @@
  *   (udp-socket)                    -> socket
  *   (udp-bind sock port)            -> void
  *   (udp-send sock data host port)  -> void
- *   (udp-recv sock maxbytes)        -> bytevector
+ *   (udp-recv sock maxbytes)        -> (data host port)
  *
  * Non-blocking I/O and async support are planned via integration
  * with the actor system (each connection runs in its own actor).
@@ -130,6 +130,11 @@ static curry_val fn_udp_socket(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac; (void)av;
     sock_t fd = socket(AF_INET6, SOCK_DGRAM, 0);
     if (fd == SOCK_INVALID) curry_error("udp-socket: failed");
+    /* Dual-stack: udp-send resolves IPv4 destinations as v4-mapped IPv6
+     * addresses, which a V6ONLY socket rejects on BSD/macOS (the default
+     * there, unlike Linux) even before any udp-bind call. */
+    int off = 0;
+    setsockopt((int)fd, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
     return sock_to_val(fd);
 }
 
@@ -150,16 +155,23 @@ static curry_val fn_udp_send(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
     sock_t fd = val_to_sock(av[0]);
     uint32_t dlen = curry_bytevector_length(av[1]);
-    uint8_t *data = malloc(dlen);
+    uint8_t *data = malloc(dlen > 0 ? dlen : 1);
+    if (!data) curry_error("udp-send: out of memory");
     for (uint32_t i = 0; i < dlen; i++) data[i] = curry_bytevector_ref(av[1], i);
     const char *host = curry_string(av[2]);
     int port = (int)curry_fixnum(av[3]);
     char port_str[16]; snprintf(port_str, sizeof(port_str), "%d", port);
     struct addrinfo hints = {0}, *res;
-    hints.ai_family = AF_UNSPEC; hints.ai_socktype = SOCK_DGRAM;
-    getaddrinfo(host, port_str, &hints, &res);
-    sendto((int)fd, data, dlen, 0, res->ai_addr, (socklen_t)res->ai_addrlen);
+    hints.ai_family   = AF_INET6;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_flags    = AI_V4MAPPED | AI_ALL;
+    if (getaddrinfo(host, port_str, &hints, &res) != 0) {
+        free(data);
+        curry_error("udp-send: could not resolve %s", host);
+    }
+    ssize_t sent = sendto((int)fd, data, dlen, 0, res->ai_addr, (socklen_t)res->ai_addrlen);
     freeaddrinfo(res); free(data);
+    if (sent < 0) curry_error("udp-send: sendto failed");
     return curry_void();
 }
 
@@ -167,13 +179,30 @@ static curry_val fn_udp_recv(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
     sock_t fd = val_to_sock(av[0]);
     int maxbytes = (int)curry_fixnum(av[1]);
+    if (maxbytes <= 0) curry_error("udp-recv: maxbytes must be positive");
     uint8_t *buf = malloc((size_t)maxbytes);
-    ssize_t n = recv((int)fd, buf, (size_t)maxbytes, 0);
-    if (n < 0) { free(buf); curry_error("udp-recv: recv failed"); }
+    if (!buf) curry_error("udp-recv: out of memory");
+    struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
+    ssize_t n = recvfrom((int)fd, buf, (size_t)maxbytes, 0,
+                          (struct sockaddr *)&addr, &addrlen);
+    if (n < 0) { free(buf); curry_error("udp-recv: recvfrom failed"); }
     curry_val bv = curry_make_bytevector((uint32_t)n, 0);
     for (ssize_t i = 0; i < n; i++) curry_bytevector_set(bv, (uint32_t)i, buf[i]);
     free(buf);
-    return bv;
+
+    char hostbuf[NI_MAXHOST], portbuf[NI_MAXSERV];
+    if (getnameinfo((struct sockaddr *)&addr, addrlen, hostbuf, sizeof(hostbuf),
+                     portbuf, sizeof(portbuf), NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
+        curry_error("udp-recv: getnameinfo failed");
+    }
+
+    /* Our sockets are dual-stack (IPV6_V6ONLY off), so an IPv4 sender shows up
+     * as an IPv4-mapped IPv6 address ("::ffff:1.2.3.4"). Report the plain
+     * dotted-quad form instead, since that's what the caller actually dialed. */
+    const char *host = hostbuf;
+    if (strncmp(hostbuf, "::ffff:", 7) == 0) host = hostbuf + 7;
+
+    return curry_list(3, bv, curry_make_string(host), curry_make_fixnum(atoi(portbuf)));
 }
 
 void curry_module_init(CurryVM *vm) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,9 @@ add_test(NAME sets_module  COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sets_module
 if(BUILD_MPFR)
   add_test(NAME mpfr COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/mpfr_tests.scm)
 endif()
+if(TARGET curry_network)
+  add_test(NAME network COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/network_tests.scm)
+endif()
 add_test(NAME cli
     COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cli.sh
             $<TARGET_FILE:curry>)

--- a/tests/network_tests.scm
+++ b/tests/network_tests.scm
@@ -1,0 +1,64 @@
+;;; Network module tests — currently covers UDP sender-address reporting (issue #16).
+;;; TCP/TLS/non-blocking coverage lives on the fix/tcp-connect-ports, feat/tls-sockets,
+;;; and feat/socket-nonblocking branches and will merge in alongside this file.
+
+(import (curry network))
+(import (curry sync))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label result expected)
+  (if (equal? result expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " got ") (write result)
+             (display " expected ") (write expected)
+             (newline)
+             (set! fail (+ fail 1)))))
+
+;;; udp-recv returns (data host port), where host/port identify the sender
+(define server (udp-socket))
+(udp-bind server 19191)
+
+(define client (udp-socket))
+(udp-bind client 19192)
+
+(define payload (string->utf8 "hello"))
+
+(define sem (make-semaphore 0))
+(define received #f)
+
+(spawn (lambda ()
+         (set! received (udp-recv server 1024))
+         (sem-post! sem)))
+
+(udp-send client payload "127.0.0.1" 19191)
+(sem-wait! sem)
+
+(check "udp-recv data"        (utf8->string (car received)) "hello")
+(check "udp-recv sender host" (cadr received) "127.0.0.1")
+(check "udp-recv sender port" (caddr received) 19192)
+
+;;; udp-send must work on a bare udp-socket (no prior udp-bind) sending to an
+;;; IPv4 destination — regression test for the dual-stack V6ONLY fix.
+(define unbound-client (udp-socket))
+(define received2 #f)
+(define sem2 (make-semaphore 0))
+
+(spawn (lambda ()
+         (set! received2 (udp-recv server 1024))
+         (sem-post! sem2)))
+
+(udp-send unbound-client (string->utf8 "world") "127.0.0.1" 19191)
+(sem-wait! sem2)
+
+(check "udp-send from unbound socket" (utf8->string (car received2)) "world")
+
+;;; Summary
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

- `udp-recv` used `recv()`, which discards the sender's address and returns a bare bytevector — contradicting the documented `(data host port)` return contract (`docs/reference/module-network.md`). Switched to `recvfrom()` + `getnameinfo()`.
- IPv4-mapped IPv6 sender addresses (`::ffff:x.x.x.x`) are normalized back to plain dotted-quad in the returned host string, since that's the address a caller actually dialed.
- Found and fixed while implementing: UDP sockets weren't reliably dual-stack. `udp-socket` now disables `IPV6_V6ONLY` at creation time — previously only `udp-bind` did, so a bare `udp-socket` used to send before any bind could fail on BSD/macOS (where `IPV6_V6ONLY` defaults on, unlike Linux). `udp-send` now resolves IPv4 destinations as V4-mapped IPv6 addresses (`AI_V4MAPPED | AI_ALL` hint) to match the dual-stack socket. Caught via independent security/correctness review after the first pass only disabled V6ONLY in `udp-bind`.
- Added missing error checking on `getaddrinfo`/`sendto`/`malloc` in the UDP send/recv path (previously silently ignored, could crash on OOM or resolve failure with garbage state).

## Test plan

- [x] `cmake --build build && ctest --test-dir build` — 41/41 suites pass
- [x] `tests/network_tests.scm` (new): udp-recv returns correct sender host/port; udp-send works from a bare `udp-socket` with no prior `udp-bind` (regression test for the V6ONLY fix)
- [x] Independent subagent review of the C changes (bounds/lifecycle/overflow) — two real findings addressed (V6ONLY scoping, missing malloc/size checks), rest confirmed clean

Fixes #16.
