### PR TITLE
feat(network): TLS client + non-blocking mode (recovering PR #18/#19)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,11 @@ endif()
 
 if(BUILD_MODULE_NETWORK)
   curry_c_module(network)
+  # TLS client support (tcp-connect-tls) lives in its own file to keep
+  # OpenSSL's includes/link isolated from the plain-socket code, but
+  # compiles into the same curry_network.so target.
+  target_sources(curry_network PRIVATE modules/network/tls.c)
+  target_link_libraries(curry_network PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 endif()
 
 if(BUILD_MODULE_CRYPTO)

--- a/docs/reference/module-network.md
+++ b/docs/reference/module-network.md
@@ -1,8 +1,8 @@
 # Module: (curry network)
 
-*v1.2.2 — 2026-06-07*
+*v1.2.2 — 2026-06-07; TLS client support added later.*
 
-TCP and UDP socket primitives. Uses POSIX sockets on Linux/macOS and Winsock2 on Windows.
+TCP, TLS, and UDP socket primitives. Uses POSIX sockets on Linux/macOS and Winsock2 on Windows; TLS via OpenSSL.
 
 ## Installation
 
@@ -41,6 +41,24 @@ stream, so not a port) — close it with `tcp-close`. Each accepted
 connection from `tcp-accept` is a port pair like `tcp-connect`'s, closed
 with `close-port` on each end.
 
+### TLS client
+
+```scheme
+(tcp-connect-tls host port)   ; connect + TLS handshake, return (in-port . out-port)
+```
+
+Same port-pair contract as `tcp-connect`, but the connection is TLS-wrapped
+via OpenSSL. Certificate verification is **on** by default (system trust
+store, `SSL_VERIFY_PEER`) — connecting to a host with an invalid or
+self-signed certificate raises rather than silently connecting insecurely.
+SNI (`SSL_set_tlsext_host_name`) is sent automatically using the `host`
+argument, needed by most modern HTTPS servers that multiplex by hostname.
+
+No TLS server side (`tls-listen`/`tls-accept`) yet — client-side was the
+actually-blocking gap (talking to HTTPS-only APIs over raw sockets); see
+[issue #14](https://github.com/deconstructo/curry/issues/14) if you need
+server-side TLS.
+
 ## UDP
 
 ```scheme
@@ -65,6 +83,27 @@ handle — there's no port wrapping for it.
 (define out (cdr conn))
 
 (write-string "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n" out)
+(flush-output-port out)
+
+(let loop ((line (read-line in)))
+  (unless (eof-object? line)
+    (display line) (newline)
+    (loop (read-line in))))
+
+(close-port in)
+(close-port out)
+```
+
+### HTTPS GET (manual, TLS)
+
+```scheme
+(import (curry network))
+
+(define conn (tcp-connect-tls "example.com" 443))
+(define in  (car conn))
+(define out (cdr conn))
+
+(write-string "GET / HTTP/1.0\r\nHost: example.com\r\nConnection: close\r\n\r\n" out)
 (flush-output-port out)
 
 (let loop ((line (read-line in)))
@@ -130,7 +169,5 @@ handle — there's no port wrapping for it.
   (output ports are buffered by default, same as any other Curry port).
 - `tcp-listen` binds to `0.0.0.0`/`::` (all interfaces, dual-stack). To
   bind to a specific interface, use the raw C extension API.
-- For TLS, wrap a `tcp-connect` socket with the crypto module (OpenSSL BIO)
-  — not yet exposed in the Scheme API; use `system` to call
-  `openssl s_client` as a workaround. See
-  [issue #14](https://github.com/deconstructo/curry/issues/14).
+- `tcp-connect-tls` requires `BUILD_MODULE_NETWORK=ON` (default) and links
+  OpenSSL (already a dependency via `(curry crypto)`) — no extra CMake flag.

--- a/docs/reference/module-network.md
+++ b/docs/reference/module-network.md
@@ -1,8 +1,9 @@
 # Module: (curry network)
 
-*v1.2.2 — 2026-06-07*
+*v1.2.2 — 2026-06-07; non-blocking mode + readiness check added later.*
 
-TCP and UDP socket primitives. Uses POSIX sockets on Linux/macOS and Winsock2 on Windows.
+TCP and UDP socket primitives, plus non-blocking mode and readiness
+polling. Uses POSIX sockets on Linux/macOS and Winsock2 on Windows.
 
 ## Installation
 
@@ -53,6 +54,29 @@ with `close-port` on each end.
 UDP is datagram-oriented, not stream-oriented, so `udp-socket` stays a raw
 handle — there's no port wrapping for it.
 
+## Non-blocking mode and readiness
+
+```scheme
+(socket-set-nonblocking! sock)     ; fcntl O_NONBLOCK
+(socket-ready? sock)               ; immediate poll, #t if data/connection pending
+(socket-ready? sock timeout-ms)    ; block up to timeout-ms waiting for readiness
+```
+
+Both accept either a raw socket handle (`tcp-listen`'s/`udp-socket`'s
+return value) or a port (`tcp-connect`'s/`tcp-accept`'s in-port or
+out-port) — whichever you have on hand. `socket-ready?` on a listening
+socket means "`tcp-accept` would not block"; on a connected port it means
+"there's data to read without blocking."
+
+This is deliberately **not** a full epoll/kqueue event-loop reactor.
+curry's actors are real OS threads (not green threads/coroutines — those
+are a separate, unimplemented roadmap item), so a full reactor integration
+wouldn't buy much over the current thread-per-actor model yet. What's here
+covers a real, immediately useful case: multiplexing a handful of sockets
+on one thread without needing an actor per connection. See
+[issue #15](https://github.com/deconstructo/curry/issues/15) for the
+fuller reactor, if/when green threads make it worthwhile.
+
 ## Examples
 
 ### HTTP GET (manual)
@@ -99,6 +123,36 @@ handle — there's no port wrapping for it.
         (echo)))
     (close-port in)
     (close-port out)))
+  (loop))
+```
+
+### Single-threaded multiplexed server (no actor per connection)
+
+```scheme
+(import (curry network))
+(import (scheme base))
+
+(define listener (tcp-listen 7778))
+(define conns '())   ; list of (in . out) pairs currently connected
+
+(let loop ()
+  ;; Accept a new connection if one is pending, without blocking.
+  (when (socket-ready? listener)
+    (set! conns (cons (tcp-accept listener) conns)))
+  ;; Service whichever existing connections have data ready.
+  (set! conns
+    (filter
+      (lambda (conn)
+        (if (socket-ready? (car conn))
+            (let ((line (read-line (car conn))))
+              (if (eof-object? line)
+                  (begin (close-port (car conn)) (close-port (cdr conn)) #f)
+                  (begin (write-string line (cdr conn))
+                         (write-string "\n" (cdr conn))
+                         (flush-output-port (cdr conn))
+                         #t)))
+            #t))
+      conns))
   (loop))
 ```
 

--- a/include/curry.h
+++ b/include/curry.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -135,6 +136,13 @@ curry_val  curry_list(int n, ...);  /* curry_list(3, a, b, c) -> (a b c) */
  * closed) — do not close fd yourself after this call. Returns a false-y
  * value (curry_is_true false) if fdopen() fails. */
 curry_val  curry_make_port_from_fd(int fd, bool output, bool binary);
+
+/* Wrap an already-open FILE* (e.g. a funopen/fopencookie custom stream
+ * backed by something other than a plain fd, such as a TLS session) as a
+ * port, taking ownership — the port's GC finalizer (or an explicit
+ * close-port) will fclose(fp), which for a custom stream invokes
+ * whatever close callback it was created with. */
+curry_val  curry_make_port_from_file(FILE *fp, bool output, bool binary);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/curry.h
+++ b/include/curry.h
@@ -136,6 +136,11 @@ curry_val  curry_list(int n, ...);  /* curry_list(3, a, b, c) -> (a b c) */
  * value (curry_is_true false) if fdopen() fails. */
 curry_val  curry_make_port_from_fd(int fd, bool output, bool binary);
 
+/* Extract the underlying OS file descriptor from a file-backed port, for
+ * callers that want to poll/select on its readiness. Returns -1 for a
+ * string port or a closed port. */
+int        curry_port_fd(curry_val port);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -195,6 +195,12 @@ static curry_val fn_udp_recv(int ac, curry_val *av, void *ud) {
     return bv;
 }
 
+/* Defined in tls.c, compiled into this same module target -- registers
+ * tcp-connect-tls. Kept as a separate init function (not curry_module_init
+ * itself, since only one symbol by that name can exist per .so) so the
+ * TLS code's OpenSSL includes/link stay isolated in their own file. */
+void curry_tls_module_init(CurryVM *vm);
+
 void curry_module_init(CurryVM *vm) {
     curry_define_fn(vm, "tcp-connect", fn_tcp_connect, 2, 2, NULL);
     curry_define_fn(vm, "tcp-listen",  fn_tcp_listen,  1, 2, NULL);
@@ -204,4 +210,5 @@ void curry_module_init(CurryVM *vm) {
     curry_define_fn(vm, "udp-bind",    fn_udp_bind,    2, 2, NULL);
     curry_define_fn(vm, "udp-send",    fn_udp_send,    4, 4, NULL);
     curry_define_fn(vm, "udp-recv",    fn_udp_recv,    2, 2, NULL);
+    curry_tls_module_init(vm);
 }

--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -40,6 +40,8 @@ typedef SOCKET sock_t;
 #  include <netdb.h>
 #  include <unistd.h>
 #  include <arpa/inet.h>
+#  include <fcntl.h>
+#  include <sys/select.h>
 typedef int sock_t;
 #  define SOCK_INVALID (-1)
 #  define sock_close close
@@ -195,6 +197,60 @@ static curry_val fn_udp_recv(int ac, curry_val *av, void *ud) {
     return bv;
 }
 
+/* ---- Non-blocking mode + readiness check ----
+ *
+ * Scoped down from a full epoll/kqueue reactor: curry's actors are real
+ * OS threads (not green threads/coroutines), so a full event-loop
+ * integration wouldn't buy much over the current thread-per-actor model
+ * until green threads exist (a separate, unimplemented roadmap item).
+ * This gives single-threaded multiplexing (check several sockets, only
+ * read/accept the ones that are ready) without needing an actor per
+ * connection -- useful today, doesn't presuppose or block on unbuilt
+ * infrastructure. See docs/reference/module-network.md.
+ *
+ * Both functions accept either a raw socket handle (tcp-listen's/
+ * udp-socket's return value) or a port (tcp-connect's/tcp-accept's
+ * in-port or out-port) -- extract_fd dispatches on which it got. */
+
+static bool is_raw_socket_handle(curry_val v) {
+    return curry_is_pair(v) && curry_is_symbol(curry_car(v)) &&
+           strcmp(curry_symbol(curry_car(v)), "socket") == 0;
+}
+
+static int extract_fd(curry_val v, const char *who) {
+    if (is_raw_socket_handle(v)) return (int)val_to_sock(v);
+    int fd = curry_port_fd(v);
+    if (fd < 0) curry_error("%s: not a socket handle or file-backed port", who);
+    return fd;
+}
+
+static curry_val fn_socket_set_nonblocking(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    int fd = extract_fd(av[0], "socket-set-nonblocking!");
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0)
+        curry_error("socket-set-nonblocking!: fcntl failed");
+    return curry_void();
+}
+
+static curry_val fn_socket_ready_p(int ac, curry_val *av, void *ud) {
+    (void)ud;
+    int fd = extract_fd(av[0], "socket-ready?");
+    struct timeval tv = {0, 0};
+    struct timeval *tvp = &tv;
+    if (ac > 1) {
+        double ms = curry_float(av[1]);
+        tv.tv_sec  = (long)(ms / 1000.0);
+        tv.tv_usec = (long)(((long long)ms % 1000) * 1000);
+    }
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+    int r = select(fd + 1, &rfds, NULL, NULL, tvp);
+    if (r < 0) curry_error("socket-ready?: select failed");
+    return curry_make_bool(r > 0 && FD_ISSET(fd, &rfds));
+}
+
 void curry_module_init(CurryVM *vm) {
     curry_define_fn(vm, "tcp-connect", fn_tcp_connect, 2, 2, NULL);
     curry_define_fn(vm, "tcp-listen",  fn_tcp_listen,  1, 2, NULL);
@@ -204,4 +260,6 @@ void curry_module_init(CurryVM *vm) {
     curry_define_fn(vm, "udp-bind",    fn_udp_bind,    2, 2, NULL);
     curry_define_fn(vm, "udp-send",    fn_udp_send,    4, 4, NULL);
     curry_define_fn(vm, "udp-recv",    fn_udp_recv,    2, 2, NULL);
+    curry_define_fn(vm, "socket-set-nonblocking!", fn_socket_set_nonblocking, 1, 1, NULL);
+    curry_define_fn(vm, "socket-ready?", fn_socket_ready_p, 1, 2, NULL);
 }

--- a/modules/network/tls.c
+++ b/modules/network/tls.c
@@ -1,0 +1,204 @@
+/*
+ * tls.c — TLS client support for (curry network), via OpenSSL.
+ *
+ * Scheme API:
+ *   (tcp-connect-tls host port)  -> port-pair (in-port . out-port)
+ *
+ * Compiles into the same curry_network.so target as network.c (see
+ * CMakeLists.txt) but lives in its own file to keep OpenSSL's includes
+ * and link isolated from the plain-socket code.
+ *
+ * Design: an SSL* session is wrapped as two Curry ports (input/output)
+ * by making it masquerade as two FILE* streams via funopen (macOS/BSD)
+ * or fopencookie (Linux/glibc) — SSL_read/SSL_write become the stream's
+ * read/write callbacks. This reuses 100% of curry's existing FILE*-based
+ * Port machinery (src/port.c) with zero changes there; the only public
+ * API addition needed was curry_make_port_from_file (added alongside
+ * curry_make_port_from_fd for the plain-socket port-pair fix), since a
+ * funopen/fopencookie stream isn't backed by a plain fd curry_make_port_
+ * from_fd could fdopen.
+ *
+ * Both directions share one SSL* (SSL_read/SSL_write on the same object,
+ * per OpenSSL's own design — a single session isn't actually split into
+ * two half-duplex objects), so the two FILE*s share one ref-counted
+ * cookie; the underlying SSL/fd are only torn down once both ports have
+ * been closed.
+ */
+
+#include <curry.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+typedef struct {
+    SSL *ssl;
+    int  fd;
+    int  refcount;   /* two FILE*s (in/out) share one session; tear down
+                      * SSL_shutdown/SSL_free/close(fd) only once both
+                      * have been closed, not on the first close-port. */
+} TlsCookie;
+
+static SSL_CTX *g_tls_ctx = NULL;
+
+static SSL_CTX *tls_ctx(void) {
+    if (g_tls_ctx) return g_tls_ctx;
+    g_tls_ctx = SSL_CTX_new(TLS_client_method());
+    if (!g_tls_ctx) curry_error("tcp-connect-tls: SSL_CTX_new failed");
+    if (!SSL_CTX_set_default_verify_paths(g_tls_ctx))
+        curry_error("tcp-connect-tls: could not load system trust store");
+    /* Verification on by default -- no silent downgrade to unverified TLS. */
+    SSL_CTX_set_verify(g_tls_ctx, SSL_VERIFY_PEER, NULL);
+    return g_tls_ctx;
+}
+
+/* ---- funopen (macOS/BSD) / fopencookie (Linux/glibc) callbacks ---- */
+
+#ifdef __APPLE__
+
+static int tls_read_cb(void *cookie, char *buf, int n) {
+    TlsCookie *c = (TlsCookie *)cookie;
+    int got = SSL_read(c->ssl, buf, n);
+    if (got > 0) return got;
+    int err = SSL_get_error(c->ssl, got);
+    if (err == SSL_ERROR_ZERO_RETURN) return 0;   /* clean EOF */
+    errno = EIO;
+    return -1;
+}
+
+static int tls_write_cb(void *cookie, const char *buf, int n) {
+    TlsCookie *c = (TlsCookie *)cookie;
+    int written = SSL_write(c->ssl, buf, n);
+    if (written > 0) return written;
+    errno = EIO;
+    return -1;
+}
+
+static int tls_close_cb(void *cookie) {
+    TlsCookie *c = (TlsCookie *)cookie;
+    if (--c->refcount == 0) {
+        SSL_shutdown(c->ssl);
+        SSL_free(c->ssl);
+        close(c->fd);
+        free(c);
+    }
+    return 0;
+}
+
+static FILE *tls_fopen(TlsCookie *c, bool for_write) {
+    return funopen(c, for_write ? NULL : tls_read_cb,
+                      for_write ? tls_write_cb : NULL,
+                      NULL, tls_close_cb);
+}
+
+#else /* Linux / glibc */
+
+static ssize_t tls_read_cb(void *cookie, char *buf, size_t n) {
+    TlsCookie *c = (TlsCookie *)cookie;
+    int got = SSL_read(c->ssl, buf, (int)n);
+    if (got > 0) return (ssize_t)got;
+    int err = SSL_get_error(c->ssl, got);
+    if (err == SSL_ERROR_ZERO_RETURN) return 0;
+    errno = EIO;
+    return -1;
+}
+
+static ssize_t tls_write_cb(void *cookie, const char *buf, size_t n) {
+    TlsCookie *c = (TlsCookie *)cookie;
+    int written = SSL_write(c->ssl, buf, (int)n);
+    if (written > 0) return (ssize_t)written;
+    errno = EIO;
+    return -1;
+}
+
+static int tls_close_cb(void *cookie) {
+    TlsCookie *c = (TlsCookie *)cookie;
+    if (--c->refcount == 0) {
+        SSL_shutdown(c->ssl);
+        SSL_free(c->ssl);
+        close(c->fd);
+        free(c);
+    }
+    return 0;
+}
+
+static FILE *tls_fopen(TlsCookie *c, bool for_write) {
+    cookie_io_functions_t io = {0};
+    if (for_write) io.write = tls_write_cb;
+    else           io.read  = tls_read_cb;
+    io.close = tls_close_cb;
+    return fopencookie(c, for_write ? "w" : "r", io);
+}
+
+#endif
+
+/* ---- (tcp-connect-tls host port) ---- */
+
+static curry_val fn_tcp_connect_tls(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    const char *host = curry_string(av[0]);
+    int port = (int)curry_fixnum(av[1]);
+    char port_str[16]; snprintf(port_str, sizeof(port_str), "%d", port);
+
+    struct addrinfo hints = {0}, *res;
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    if (getaddrinfo(host, port_str, &hints, &res) != 0)
+        curry_error("tcp-connect-tls: could not resolve %s", host);
+
+    int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (fd < 0) { freeaddrinfo(res); curry_error("tcp-connect-tls: socket failed"); }
+    if (connect(fd, res->ai_addr, (socklen_t)res->ai_addrlen) != 0) {
+        close(fd); freeaddrinfo(res);
+        curry_error("tcp-connect-tls: connect failed");
+    }
+    freeaddrinfo(res);
+
+    SSL *ssl = SSL_new(tls_ctx());
+    if (!ssl) { close(fd); curry_error("tcp-connect-tls: SSL_new failed"); }
+    SSL_set_fd(ssl, fd);
+    SSL_set_tlsext_host_name(ssl, host);   /* SNI */
+
+    if (SSL_connect(ssl) != 1) {
+        unsigned long e = ERR_get_error();
+        char errbuf[256];
+        ERR_error_string_n(e, errbuf, sizeof(errbuf));
+        SSL_free(ssl); close(fd);
+        curry_error("tcp-connect-tls: handshake with %s failed: %s", host, errbuf);
+    }
+    if (SSL_get_verify_result(ssl) != X509_V_OK) {
+        const char *reason = X509_verify_cert_error_string(SSL_get_verify_result(ssl));
+        SSL_shutdown(ssl); SSL_free(ssl); close(fd);
+        curry_error("tcp-connect-tls: certificate verification failed for %s: %s",
+                    host, reason);
+    }
+
+    TlsCookie *cookie = malloc(sizeof(TlsCookie));
+    cookie->ssl = ssl;
+    cookie->fd  = fd;
+    cookie->refcount = 2;   /* one per direction */
+
+    FILE *rfp = tls_fopen(cookie, false);
+    FILE *wfp = tls_fopen(cookie, true);
+    if (!rfp || !wfp) {
+        if (rfp) fclose(rfp); else if (wfp) fclose(wfp);
+        else { SSL_shutdown(ssl); SSL_free(ssl); close(fd); free(cookie); }
+        curry_error("tcp-connect-tls: could not create stream wrapper");
+    }
+
+    curry_val in_port  = curry_make_port_from_file(rfp, false, false);
+    curry_val out_port = curry_make_port_from_file(wfp, true, false);
+    return curry_make_pair(in_port, out_port);
+}
+
+void curry_tls_module_init(CurryVM *vm) {
+    curry_define_fn(vm, "tcp-connect-tls", fn_tcp_connect_tls, 2, 2, NULL);
+}

--- a/modules/network/tls.c
+++ b/modules/network/tls.c
@@ -38,6 +38,7 @@
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/x509v3.h>
 
 typedef struct {
     SSL *ssl;
@@ -166,6 +167,19 @@ static curry_val fn_tcp_connect_tls(int ac, curry_val *av, void *ud) {
     if (!ssl) { close(fd); curry_error("tcp-connect-tls: SSL_new failed"); }
     SSL_set_fd(ssl, fd);
     SSL_set_tlsext_host_name(ssl, host);   /* SNI */
+
+    /* SSL_get_verify_result alone only checks that the certificate chain
+     * is trusted -- it says nothing about whether the certificate is
+     * actually FOR this host. Without hostname verification, any host
+     * holding a valid cert for any domain could impersonate `host` via
+     * a MITM'd connection. SSL_set1_host makes the handshake itself fail
+     * on a mismatch, matching what SSL_get_verify_result's callers below
+     * assume it already covers. */
+    SSL_set_hostflags(ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    if (!SSL_set1_host(ssl, host)) {
+        SSL_free(ssl); close(fd);
+        curry_error("tcp-connect-tls: SSL_set1_host failed");
+    }
 
     if (SSL_connect(ssl) != 1) {
         unsigned long e = ERR_get_error();

--- a/src/api.c
+++ b/src/api.c
@@ -162,14 +162,19 @@ curry_val curry_make_octonion(const double e[8]) {
     return num_make_oct(e);
 }
 
-/* ---- List helpers ---- */
-
 /* ---- Ports ---- */
 
 curry_val curry_make_port_from_fd(int fd, bool output, bool binary) {
     int flags = (output ? PORT_OUTPUT : PORT_INPUT) | (binary ? PORT_BINARY : 0);
     return port_wrap_fd(fd, flags);
 }
+
+curry_val curry_make_port_from_file(FILE *fp, bool output, bool binary) {
+    int flags = (output ? PORT_OUTPUT : PORT_INPUT) | (binary ? PORT_BINARY : 0);
+    return port_wrap_file_owned(fp, flags);
+}
+
+/* ---- List helpers ---- */
 
 curry_val curry_list(int n, ...) {
     va_list ap;

--- a/src/api.c
+++ b/src/api.c
@@ -171,6 +171,18 @@ curry_val curry_make_port_from_fd(int fd, bool output, bool binary) {
     return port_wrap_fd(fd, flags);
 }
 
+/* Extract the underlying OS file descriptor from a file-backed port (not
+ * a string port). Needed by callers that want to poll/select on a port's
+ * readiness (e.g. socket-ready? in (curry network)) without curry itself
+ * needing to know about select()/poll() at the port layer. Returns -1 for
+ * a string port or a closed port. */
+int curry_port_fd(curry_val port) {
+    if (!vis_port(port)) return -1;
+    Port *p = as_port(port);
+    if ((p->flags & PORT_STRING) || (p->flags & PORT_CLOSED) || !p->u.fp) return -1;
+    return fileno(p->u.fp);
+}
+
 curry_val curry_list(int n, ...) {
     va_list ap;
     va_start(ap, n);

--- a/src/port.c
+++ b/src/port.c
@@ -45,34 +45,33 @@ static void port_gc_finalize(void *obj, void *cd) {
     }
 }
 
-val_t port_open_file(const char *path, int flags) {
-    const char *mode;
-    if ((flags & PORT_BINARY)) {
-        mode = (flags & PORT_OUTPUT) ? "wb" : "rb";
-    } else {
-        mode = (flags & PORT_OUTPUT) ? "w" : "r";
-    }
-    FILE *fp = fopen(path, mode);
-    if (!fp) return V_FALSE;
+/* Wrap an already-open FILE* (any kind — plain fd, funopen/fopencookie
+ * custom stream, etc.) as a port and register the auto-close finalizer,
+ * same as port_open_file's own bookkeeping. The single place that owns
+ * "this port is responsible for eventually fclose()-ing its FILE*". */
+val_t port_wrap_file_owned(FILE *fp, int flags) {
     val_t v = make_port(flags);
     as_port(v)->u.fp = fp;
     gc_finalizer(as_port(v), port_gc_finalize, NULL);
     return v;
 }
 
-val_t port_wrap_fd(int fd, int flags) {
-    const char *mode;
-    if ((flags & PORT_BINARY)) {
-        mode = (flags & PORT_OUTPUT) ? "wb" : "rb";
-    } else {
-        mode = (flags & PORT_OUTPUT) ? "w" : "r";
-    }
-    FILE *fp = fdopen(fd, mode);
+static const char *mode_str(int flags) {
+    if ((flags & PORT_BINARY))
+        return (flags & PORT_OUTPUT) ? "wb" : "rb";
+    return (flags & PORT_OUTPUT) ? "w" : "r";
+}
+
+val_t port_open_file(const char *path, int flags) {
+    FILE *fp = fopen(path, mode_str(flags));
     if (!fp) return V_FALSE;
-    val_t v = make_port(flags);
-    as_port(v)->u.fp = fp;
-    gc_finalizer(as_port(v), port_gc_finalize, NULL);
-    return v;
+    return port_wrap_file_owned(fp, flags);
+}
+
+val_t port_wrap_fd(int fd, int flags) {
+    FILE *fp = fdopen(fd, mode_str(flags));
+    if (!fp) return V_FALSE;
+    return port_wrap_file_owned(fp, flags);
 }
 
 val_t port_open_input_string(const char *str, uint32_t len) {

--- a/src/port.h
+++ b/src/port.h
@@ -29,6 +29,14 @@ val_t port_wrap_file(FILE *fp, int flags);
  * via port_open_file. Returns V_FALSE if fdopen fails. */
 val_t port_wrap_fd(int fd, int flags);
 
+/* Wrap an already-open FILE* (e.g. a funopen/fopencookie custom stream
+ * backed by something other than a plain fd, such as a TLS session) as a
+ * port, taking ownership: registers the same auto-close-on-GC finalizer
+ * port_open_file/port_wrap_fd do. Unlike port_wrap_file (used only for
+ * stdin/stdout/stderr, which must never be auto-closed), this is for
+ * "this FILE* is the port's exclusive property." */
+val_t port_wrap_file_owned(FILE *fp, int flags);
+
 /* ---- Standard ports ---- */
 extern val_t PORT_STDIN, PORT_STDOUT, PORT_STDERR;
 void port_init(void);

--- a/tests/network_tests.scm
+++ b/tests/network_tests.scm
@@ -70,6 +70,39 @@
 (tcp-close listener)
 
 ;;; ════════════════════════════════════════════════════════════
+;;; § 2  tcp-connect-tls: cert verification (badssl.com — a public
+;;;      service purpose-built for exactly this kind of test) and a real
+;;;      HTTPS request/response round-trip. Skips cleanly if there's no
+;;;      network access (DNS/connect failure), rather than failing the
+;;;      whole suite on an offline CI runner.
+;;; ════════════════════════════════════════════════════════════
+
+(define (network-reachable?)
+  (guard (e (#t #f))
+    (let ((conn (tcp-connect "example.com" 80)))
+      (close-port (car conn)) (close-port (cdr conn))
+      #t)))
+
+(if (not (network-reachable?))
+    (begin (display "SKIP: no network access — skipping TLS tests") (newline))
+    (begin
+      (check "self-signed cert is rejected"
+        (guard (e (#t #t)) (tcp-connect-tls "self-signed.badssl.com" 443) #f)
+        #t)
+
+      (check "valid cert is accepted, HTTPS round-trip works"
+        (let* ((conn (tcp-connect-tls "example.com" 443))
+               (in (car conn)) (out (cdr conn)))
+          (write-string "GET / HTTP/1.0\r\nHost: example.com\r\nConnection: close\r\n\r\n" out)
+          (flush-output-port out)
+          (let ((status-line (read-line in)))
+            (close-port in) (close-port out)
+            (and (string? status-line)
+                 (>= (string-length status-line) 12)
+                 (string=? (substring status-line 0 5) "HTTP/"))))
+        #t)))
+
+;;; ════════════════════════════════════════════════════════════
 ;;; Summary
 ;;; ════════════════════════════════════════════════════════════
 

--- a/tests/network_tests.scm
+++ b/tests/network_tests.scm
@@ -90,6 +90,13 @@
         (guard (e (#t #t)) (tcp-connect-tls "self-signed.badssl.com" 443) #f)
         #t)
 
+      ;; A valid, chain-trusted cert issued for a *different* hostname —
+      ;; the specific case SSL_get_verify_result alone does not catch;
+      ;; only SSL_set1_host's hostname verification does.
+      (check "valid-but-wrong-hostname cert is rejected"
+        (guard (e (#t #t)) (tcp-connect-tls "wrong.host.badssl.com" 443) #f)
+        #t)
+
       (check "valid cert is accepted, HTTPS round-trip works"
         (let* ((conn (tcp-connect-tls "example.com" 443))
                (in (car conn)) (out (cdr conn)))

--- a/tests/network_tests.scm
+++ b/tests/network_tests.scm
@@ -70,6 +70,48 @@
 (tcp-close listener)
 
 ;;; ════════════════════════════════════════════════════════════
+;;; § 2  socket-ready? / socket-set-nonblocking!
+;;;
+;;; Scoped-down non-blocking support (see docs/reference/module-network.md):
+;;; select()-based readiness check working on both a raw socket handle
+;;; (tcp-listen's return) and a port (tcp-accept's/tcp-connect's).
+;;; ════════════════════════════════════════════════════════════
+
+(define test-port2 18099)
+(define listener2 (tcp-listen test-port2))
+
+(check "listener not ready with no pending connection"
+  (socket-ready? listener2) #f)
+
+(spawn (lambda ()
+         (define conn (tcp-connect "127.0.0.1" test-port2))
+         (write-string "ping\n" (cdr conn))
+         (flush-output-port (cdr conn))
+         (close-port (car conn)) (close-port (cdr conn))))
+
+;; socket-ready?'s own timeout blocks in select() until ready or the
+;; timeout elapses -- waits correctly without a racing busy-loop.
+(check "listener ready within timeout after a connection arrives"
+  (socket-ready? listener2 2000) #t)
+
+(define accepted2 (tcp-accept listener2))
+(define ain (car accepted2))
+
+(check "accepted port ready once data arrives"
+  (socket-ready? ain 500) #t)
+(check "accepted port data readable"
+  (read-line ain) "ping")
+
+(close-port ain)
+(close-port (cdr accepted2))
+
+(check "socket-set-nonblocking! does not error"
+  (guard (e (#t #f)) (socket-set-nonblocking! listener2) #t)
+  #t)
+
+(tcp-close listener2)
+
+;;; ════════════════════════════════════════════════════════════
 ;;; Summary
 ;;; ════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Brings TLS client support (#14) and scoped non-blocking mode (#15) into `main` — both were previously merged (PRs #18/#19) into `fix/tcp-connect-ports` rather than `main` directly, and since that branch's own PR (#17) had already landed on `main` beforehand, the later work never made it in despite showing "MERGED" on GitHub.

While reconciling this branch with `main` (which has since gained #13 and #16), found and fixed a second, more serious problem: **PR #19's own merge (`feat/socket-nonblocking` → `fix/tcp-connect-ports`) had silently dropped real code**. A bad 3-way merge left `curry_define_fn` registration calls for `socket-set-nonblocking!`/`socket-ready?` in place while deleting the C function bodies they point to (`fn_socket_set_nonblocking`, `fn_socket_ready_p`, plus their `is_raw_socket_handle`/`extract_fd` helpers) — meaning **this branch hasn't actually built since PR #19 merged**, and nobody caught it because nobody rebuilt afterward. The same merge also dropped `curry_port_fd`'s declaration from `include/curry.h` (its definition in `src/api.c` was untouched) and the socket-ready?/non-blocking test section from `tests/network_tests.scm`.

All three are restored verbatim from the original authoring commit. The four previously-conflicting test sections (TCP port-pairs, non-blocking/socket-ready, TLS, UDP) are now combined into one `tests/network_tests.scm` instead of each merge silently clobbering the ones before it.

## Test plan

- [x] Full clean rebuild (`cmake -B build -DBUILD_FFI=ON && cmake --build build`) — succeeds (previously did not, silently, since PR #19)
- [x] `ctest --test-dir build` — 40/40 suites pass
- [x] `tests/network_tests.scm` — 16/16 assertions pass, covering TCP port-pairs, `socket-ready?`/`socket-set-nonblocking!`, TLS (self-signed rejection, wrong-hostname rejection, real HTTPS round-trip against example.com), and UDP sender-address/dual-stack
- [x] Independent subagent review of the restored code and the four-way test-file merge — no bugs found; one pre-existing gap flagged (non-blocking primitives are POSIX-only, no `_WIN32` fcntl/select path — out of scope here, worth a follow-up issue if Windows networking is ever exercised)

Fixes #14, #15.
