### PR TITLE
feat: implement SRFI-14 (Character-Set Library)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ The test suites registered in `ctest`:
 | `load_dir_context_thread_safety` | `fixtures/load_dir_context/thread_safety/main.scm` | The directory-context stack is `_Thread_local` and a spawned actor inherits its spawning thread's stack (`load_dir_snapshot`/`load_dir_adopt_snapshot`) — 20 concurrent actors, each verified correct on every one of 30 iterations |
 | `syntax_rules` | `syntax_rules_tests.scm` | `syntax-rules`/`define-syntax`/`let-syntax`/`letrec-syntax`, plus the "Partial hygiene" per-expansion renaming of template-introduced symbols in `src/syntax_rules.c` (recursive macros that accumulate fresh bindings, quoted symbolic data staying literal, a library-local macro's self-reference resolving in its own defining environment, not `GLOBAL_ENV`) |
 | `srfi_s26_cut` | `srfi_s26_cut_tests.scm` | `(srfi 26)` `cut`/`cute` — the reference implementation verbatim; doubles as the motivating regression suite for the `syntax-rules` hygiene fix above |
+| `srfi_s14_char_sets` | `srfi_s14_char_sets_tests.scm` | `(srfi 14)` char-sets — construction, iteration, set algebra, comparisons, and the standard predefined sets (full-Unicode letter/digit/whitespace/upper/lower-case backed by curry's own classification tables; ASCII-only punctuation/symbol/control/etc) |
 | `numeric_ext` | `numeric_ext_tests.scm` | Clifford algebra, symbolic CAS, surreal numbers, auto-diff, numeric tower |
 | `actors` | `actors_tests.scm` | Concurrency primitives (spawn/send!/receive) |
 | `dynamic_wind` | `dynamic_wind_tests.scm` | `dynamic-wind`, `call/cc` interactions |

--- a/docs/reference/srfi/index.md
+++ b/docs/reference/srfi/index.md
@@ -31,6 +31,7 @@ The same import-collision caveat as `(srfi N)` above applies identically here (i
 |---------|------|-------------|
 | [`(srfi s1 lists)`](s1.md) | [SRFI-1](https://srfi.schemers.org/srfi-1/) | List library |
 | [`(srfi s8 receive)`](s8.md) | [SRFI-8](https://srfi.schemers.org/srfi-8/) | `receive` multiple-values binding macro — shadows curry's own actor `receive` special form when imported |
+| [`(srfi s14 char-sets)`](s14.md) | [SRFI-14](https://srfi.schemers.org/srfi-14/) | Character sets — construction, iteration, set algebra, and the standard predefined sets (`char-set:letter`, `char-set:whitespace`, etc), backed by a sorted-range representation over curry's full Unicode codepoint space |
 | [`(srfi s18 multithreading)`](s18.md) | [SRFI-18](https://srfi.schemers.org/srfi-18/) | Thread/mutex/condition-variable naming over curry's actor `spawn` and `(curry sync)` |
 | [`(srfi s19 time)`](s19.md) | [SRFI-19](https://srfi.schemers.org/srfi-19/) | Time/date objects, Julian Day conversions, `strftime`-style formatting — requires `-DBUILD_MODULE_POSIX=ON` (default) for `current-time` |
 | [`(srfi s26 cut)`](s26.md) | [SRFI-26](https://srfi.schemers.org/srfi-26/) | `cut`/`cute` — partial application without writing `lambda` by hand; the reference implementation verbatim (its recursive-macro shape found and drove a real curry `syntax-rules` hygiene fix — see the doc page) |

--- a/docs/reference/srfi/s14.md
+++ b/docs/reference/srfi/s14.md
@@ -1,0 +1,51 @@
+# `(srfi s14 char-sets)` — SRFI-14
+
+```scheme
+(import (srfi s14 char-sets))   ; or (srfi 14) / (srfi srfi-14)
+```
+
+[SRFI-14](https://srfi.schemers.org/srfi-14/): character sets — an unordered collection of characters, with construction, iteration, membership, set algebra, and a battery of predefined sets (`char-set:letter`, `char-set:whitespace`, etc).
+
+This is a curry-native implementation, not a port of SRFI-14's own reference implementation — that reference implementation assumes a fixed-size bitstring representation, which doesn't fit curry's chars (full Unicode codepoints, `0`..`#x10FFFF` minus the surrogate gap). Instead, a char-set here is a sorted, non-overlapping, non-adjacent vector of inclusive codepoint ranges (`(lo . hi)`), giving `char-set-contains?` an O(log n) binary search and letting the set-algebra operations (union/intersection/difference/xor/complement) run as simple sweeps over already-sorted ranges rather than per-character walks.
+
+```scheme
+(char-set-contains? char-set:letter #\a)     ; => #t
+(char-set->string (char-set-union (char-set #\a #\b) (char-set #\b #\c)))  ; => "abc"
+```
+
+## Unicode coverage
+
+Five of the predefined sets are backed by curry's actual Unicode classification tables — the same tables `char-alphabetic?`/`char-numeric?`/`char-whitespace?`/`char-upper-case?`/`char-lower-case?` use (`src/unicode.c`, `src/unicode_tables.c`), exposed in range form via the `unicode-property-ranges` builtin rather than scanned character-by-character:
+
+- `char-set:letter`, `char-set:digit`, `char-set:whitespace`, `char-set:upper-case`, `char-set:lower-case` — full Unicode, not just ASCII. `char-set:digit` intentionally matches curry's own (full-Unicode) `char-numeric?`, so it also recognizes non-ASCII decimal digits, not just `0`-`9`.
+- `char-set:letter+digit` is `(char-set-union char-set:letter char-set:digit)`.
+
+Everything else is **ASCII-only**, because curry has no generated Unicode General-Category tables (Pc/Pd/Ps/.../Sm/Sc/Sk/So/Cc/Lt) to draw on:
+
+- `char-set:punctuation` and `char-set:symbol` split ASCII `ispunct` (`!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~`) along Unicode's Sm/Sc/Sk/So ("symbol") vs. everything else ("punctuation") — e.g. `$` and `+` are symbols, `!` and `,` are punctuation.
+- `char-set:iso-control` = `[0,31] ∪ {127}`. `char-set:blank` = space and tab. `char-set:hex-digit` = `0-9A-Fa-f`. `char-set:ascii` = `[0,127]`.
+- `char-set:graphic` = `char-set:letter+digit ∪ char-set:punctuation ∪ char-set:symbol` (so it's full-Unicode for letters/digits, ASCII-only for punctuation/symbols). `char-set:printing` = `char-set:graphic ∪ {space}`.
+- `char-set:title-case` is **empty** — curry has no titlecase table at all (a small, rare Unicode category; most codepoints have no distinct titlecase form).
+
+This matches curry's own existing convention in `unicode.c`: an ASCII fast path plus full-Unicode coverage only where a real table exists, rather than silently mis-classifying non-ASCII input.
+
+`char-set:full` is every valid codepoint (`0..#xD7FF` and `#xE000..#x10FFFF` — the same domain `integer->char` accepts); `char-set:empty` has none.
+
+## Set algebra
+
+```scheme
+(char-set-union cs ...) (char-set-intersection cs ...) (char-set-difference cs1 cs2 ...)
+(char-set-xor cs ...)   (char-set-complement cs)
+(char-set-adjoin cs char ...)  (char-set-delete cs char ...)
+```
+
+Each has a `!` mutating variant (`char-set-union!`, `char-set-adjoin!`, ...) that replaces the first argument's contents in place rather than allocating a new char-set. `char-set-diff+intersection`/`char-set-diff+intersection!` return both the difference and the intersection as two values in one pass.
+
+## Iteration
+
+A cursor-based protocol (`char-set-cursor`, `char-set-ref`, `char-set-cursor-next`, `end-of-char-set?`) walks members in ascending codepoint order without materializing a list; `char-set-fold`, `char-set-for-each`, `char-set-map`, and `char-set-unfold`/`char-set-unfold!` are built on top of it. `char-set->list`/`char-set->string` materialize the full membership — fine for `(char-set #\a #\b #\c)`, but `(char-set->list char-set:letter)` allocates on the order of a million characters, since that set really does have that many Unicode members.
+
+## See also
+
+- [`srfi/index.md`](index.md) — full SRFI availability table
+- `(curry sets)` (`lib/curry/modules/curry/sets.scm`) — general-purpose finite sets over any equality, not specialized to characters

--- a/lib/curry/modules/srfi/14.scm
+++ b/lib/curry/modules/srfi/14.scm
@@ -1,0 +1,26 @@
+(define-library (srfi 14)
+  (import (srfi s14 char-sets))
+  (export
+    char-set? char-set= char-set<= char-set-hash
+    char-set-cursor char-set-ref char-set-cursor-next end-of-char-set?
+    char-set-fold char-set-unfold char-set-unfold!
+    char-set-for-each char-set-map
+    char-set list->char-set list->char-set!
+    string->char-set string->char-set!
+    char-set-filter char-set-filter!
+    ->char-set ucs-range->char-set ucs-range->char-set! char-set-copy
+    char-set->list char-set->string char-set-size char-set-count
+    char-set-contains? char-set-every char-set-any
+    char-set-adjoin char-set-adjoin! char-set-delete char-set-delete!
+    char-set-complement char-set-complement!
+    char-set-union char-set-union!
+    char-set-intersection char-set-intersection!
+    char-set-difference char-set-difference!
+    char-set-xor char-set-xor!
+    char-set-diff+intersection char-set-diff+intersection!
+    char-set:lower-case char-set:upper-case char-set:title-case
+    char-set:letter char-set:digit char-set:letter+digit
+    char-set:graphic char-set:printing char-set:whitespace
+    char-set:iso-control char-set:punctuation char-set:symbol
+    char-set:hex-digit char-set:blank char-set:ascii
+    char-set:empty char-set:full))

--- a/lib/curry/modules/srfi/s14/char-sets.scm
+++ b/lib/curry/modules/srfi/s14/char-sets.scm
@@ -1,0 +1,398 @@
+;;; SRFI-14: Character-Set Library.
+;;; https://srfi.schemers.org/srfi-14/
+;;;
+;;; A char-set is an unordered collection of characters. Internally, a
+;;; char-set is a sorted, non-overlapping, non-adjacent vector of
+;;; inclusive codepoint ranges (lo . hi) -- a run-length representation
+;;; chosen because curry chars span the full Unicode codepoint space
+;;; (0..#x10FFFF, minus the surrogate gap), where a bitmap or per-char
+;;; hash-table would be enormous for sets like char-set:letter. Range
+;;; lists also make char-set-contains? an O(log n) binary search and
+;;; the set-algebra operations (union/intersection/difference/xor/
+;;; complement) simple sweeps over already-sorted ranges, rather than
+;;; per-character hash-table walks.
+;;;
+;;; This is a curry-native implementation (not a port of SRFI-14's own
+;;; reference implementation, which assumes a fixed-size bitstring
+;;; representation ill-suited to full Unicode) built on two data
+;;; sources:
+;;;   - char-set:letter, char-set:digit, char-set:whitespace,
+;;;     char-set:upper-case, and char-set:lower-case are backed by
+;;;     curry's actual Unicode classification tables (the same tables
+;;;     char-alphabetic?/char-numeric?/char-whitespace?/char-upper-case?/
+;;;     char-lower-case? use -- see src/unicode.c, src/unicode_tables.c),
+;;;     exposed in range form via the unicode-property-ranges builtin.
+;;;     char-set:digit intentionally matches curry's own (full-Unicode)
+;;;     char-numeric?, not just ASCII 0-9.
+;;;   - char-set:title-case, char-set:punctuation, char-set:symbol,
+;;;     char-set:iso-control, char-set:blank, char-set:hex-digit,
+;;;     char-set:ascii and the char-set:graphic/:printing sets derived
+;;;     from them are ASCII-only: curry has no generated Unicode
+;;;     General-Category (Pc/Pd/Ps/.../Sm/Sc/Sk/So/Cc/Lt) tables, so
+;;;     these classes only recognize their ASCII repertoire.
+;;;     char-set:title-case is empty for the same reason (no titlecase
+;;;     table at all). This matches curry's own existing convention in
+;;;     unicode.c of an ASCII fast path plus full-Unicode coverage only
+;;;     where a table exists, rather than silently mis-classifying.
+
+(define-library (srfi s14 char-sets)
+  (export
+    ;; predicates / comparison
+    char-set? char-set= char-set<= char-set-hash
+    ;; iteration
+    char-set-cursor char-set-ref char-set-cursor-next end-of-char-set?
+    char-set-fold char-set-unfold char-set-unfold!
+    char-set-for-each char-set-map
+    ;; creation
+    char-set list->char-set list->char-set!
+    string->char-set string->char-set!
+    char-set-filter char-set-filter!
+    ->char-set ucs-range->char-set ucs-range->char-set! char-set-copy
+    ;; querying
+    char-set->list char-set->string char-set-size char-set-count
+    char-set-contains? char-set-every char-set-any
+    ;; set algebra
+    char-set-adjoin char-set-adjoin! char-set-delete char-set-delete!
+    char-set-complement char-set-complement!
+    char-set-union char-set-union!
+    char-set-intersection char-set-intersection!
+    char-set-difference char-set-difference!
+    char-set-xor char-set-xor!
+    char-set-diff+intersection char-set-diff+intersection!
+    ;; standard char-sets
+    char-set:lower-case char-set:upper-case char-set:title-case
+    char-set:letter char-set:digit char-set:letter+digit
+    char-set:graphic char-set:printing char-set:whitespace
+    char-set:iso-control char-set:punctuation char-set:symbol
+    char-set:hex-digit char-set:blank char-set:ascii
+    char-set:empty char-set:full)
+  (import (scheme base))
+  (import (srfi s1 lists))
+  (import (srfi s132 sorting))
+  (begin
+
+;;; ── representation ──────────────────────────────────────────────────
+;;; rvec: a vector of (lo . hi) pairs, sorted ascending by lo, with no
+;;; two entries overlapping or touching (adjacent ranges are always
+;;; merged) -- the canonical form every constructor/mutator maintains.
+
+(define-record-type <char-set>
+  (%make-cs-raw rvec)
+  char-set?
+  (rvec %cs-rvec %cs-set-rvec!))
+
+;; 0..#xD7FF, #xE000..#x10FFFF -- the full valid codepoint domain,
+;; matching integer->char's own validity check (src/builtins.c).
+(define %full-domain-ranges (list (cons 0 #xD7FF) (cons #xE000 #x10FFFF)))
+
+(define (%merge-sorted-ranges sorted)
+  (if (null? sorted)
+      '()
+      (let loop ((cur (car sorted)) (rest (cdr sorted)) (acc '()))
+        (if (null? rest)
+            (reverse (cons cur acc))
+            (let ((nxt (car rest)))
+              (if (<= (car nxt) (+ (cdr cur) 1))
+                  (loop (cons (car cur) (max (cdr cur) (cdr nxt))) (cdr rest) acc)
+                  (loop nxt (cdr rest) (cons cur acc))))))))
+
+(define (%normalize-ranges ranges)
+  (%merge-sorted-ranges (list-sort (lambda (a b) (< (car a) (car b))) ranges)))
+
+(define (%make-cs ranges) (%make-cs-raw (list->vector (%normalize-ranges ranges))))
+
+(define (%cs-ranges-list cs) (vector->list (%cs-rvec cs)))
+
+;; char->integer (like most char primitives) doesn't itself check its
+;; argument is really a char -- a bad value would otherwise either
+;; silently produce a garbage-but-in-range codepoint or defer a clean
+;; error to some unrelated later operation (e.g. char-set->string), far
+;; from the actual mistake. Every codepoint entering a char-set's ranges
+;; goes through here, so this is the one place that needs to check.
+(define (%char->cp c)
+  (unless (char? c) (error "char-set: not a char" c))
+  (char->integer c))
+(define (%chars->ranges chars) (map (lambda (c) (cons (%char->cp c) (%char->cp c))) chars))
+
+;;; ── membership (binary search over the sorted range vector) ────────
+
+(define (%vec-range-contains? rv cp)
+  (let loop ((lo 0) (hi (vector-length rv)))
+    (if (>= lo hi)
+        #f
+        (let* ((mid (quotient (+ lo hi) 2)) (r (vector-ref rv mid)))
+          (cond ((< cp (car r)) (loop lo mid))
+                ((> cp (cdr r)) (loop (+ mid 1) hi))
+                (else #t))))))
+
+(define (char-set-contains? cs ch) (%vec-range-contains? (%cs-rvec cs) (%char->cp ch)))
+
+;;; ── range-list set algebra (inputs assumed normalized) ──────────────
+
+;; a minus b, both sorted/merged range lists -> sorted/merged result.
+(define (%ranges-difference a b)
+  (let loop ((a a) (b b) (acc '()))
+    (cond
+      ((null? a) (reverse acc))
+      ((null? b) (append (reverse acc) a))
+      (else
+       (let ((ra (car a)) (rb (car b)))
+         (cond
+           ((< (cdr rb) (car ra)) (loop a (cdr b) acc))
+           ((> (car rb) (cdr ra)) (loop (cdr a) b (cons ra acc)))
+           (else
+            (let ((left  (and (< (car ra) (car rb)) (cons (car ra) (- (car rb) 1))))
+                  (right (and (> (cdr ra) (cdr rb)) (cons (+ (cdr rb) 1) (cdr ra)))))
+              (if right
+                  (loop (cons right (cdr a)) (cdr b) (if left (cons left acc) acc))
+                  (loop (cdr a) b (if left (cons left acc) acc)))))))))))
+
+(define (%ranges-union a b) (%normalize-ranges (append a b)))
+;; A ∩ B = A - (A - B) — avoids a third sweep algorithm.
+(define (%ranges-intersection a b) (%ranges-difference a (%ranges-difference a b)))
+(define (%ranges-xor a b) (%ranges-union (%ranges-difference a b) (%ranges-difference b a)))
+(define (%ranges-complement a) (%ranges-difference %full-domain-ranges a))
+
+;;; ── copy / mutators ──────────────────────────────────────────────────
+
+(define (char-set-copy cs) (%make-cs-raw (%cs-rvec cs)))  ; rvec is never mutated in place
+
+(define (%cs-replace! cs ranges) (%cs-set-rvec! cs (list->vector (%normalize-ranges ranges))) cs)
+
+;;; ── creation ─────────────────────────────────────────────────────────
+
+(define (char-set . chars) (%make-cs (%chars->ranges chars)))
+
+(define (list->char-set chars . opt)
+  (%make-cs (append (%chars->ranges chars) (if (pair? opt) (%cs-ranges-list (car opt)) '()))))
+
+(define (list->char-set! chars base-cs)
+  (%cs-replace! base-cs (append (%chars->ranges chars) (%cs-ranges-list base-cs))))
+
+(define (string->char-set s . opt) (apply list->char-set (string->list s) opt))
+(define (string->char-set! s base-cs) (list->char-set! (string->list s) base-cs))
+
+(define (char-set-filter pred cs . opt)
+  (%make-cs (append (%chars->ranges (filter pred (char-set->list cs)))
+                     (if (pair? opt) (%cs-ranges-list (car opt)) '()))))
+
+(define (char-set-filter! pred cs base-cs)
+  (%cs-replace! base-cs (append (%chars->ranges (filter pred (char-set->list cs)))
+                                 (%cs-ranges-list base-cs))))
+
+(define (->char-set x)
+  (cond ((char-set? x) x)
+        ((char? x) (char-set x))
+        ((string? x) (string->char-set x))
+        (else (error "->char-set: not a char, string, or char-set" x))))
+
+;; SRFI-14 range is half-open [lower, upper); clipped to the valid
+;; codepoint domain (splitting around the surrogate gap if straddled).
+(define (%valid-subranges lo hi)
+  (filter (lambda (r) (<= (car r) (cdr r)))
+          (list (cons (max lo 0) (min hi #xD7FF))
+                (cons (max lo #xE000) (min hi #x10FFFF)))))
+
+(define (%ucs-range-ranges lower upper error?)
+  (when (and error? (or (< lower 0) (> upper (+ #x10FFFF 1))
+                         (and (< lower #xE000) (> upper #xD800))))
+    (error "ucs-range->char-set: range includes invalid code points" lower upper))
+  (%valid-subranges lower (- upper 1)))
+
+(define (ucs-range->char-set lower upper . opt)
+  (let ((error? (if (pair? opt) (car opt) #f))
+        (base   (if (and (pair? opt) (pair? (cdr opt))) (cadr opt) #f)))
+    (%make-cs (append (%ucs-range-ranges lower upper error?)
+                       (if base (%cs-ranges-list base) '())))))
+
+(define (ucs-range->char-set! lower upper error? base-cs)
+  (%cs-replace! base-cs (append (%ucs-range-ranges lower upper error?) (%cs-ranges-list base-cs))))
+
+;;; ── set algebra ──────────────────────────────────────────────────────
+
+;; NOTE: this codebase's `fold` is aliased to `fold-left` (src/builtins.c),
+;; so the callback is called as (proc acc element) -- SRFI-1's canonical
+;; `fold` calls it (proc element acc) instead. Every fold below uses the
+;; local (acc x) order accordingly.
+
+;; Collect every operand's ranges and normalize ONCE at the end, rather
+;; than folding through %ranges-union (itself a full re-sort) once per
+;; operand -- union doesn't care which input set a range came from, so
+;; concatenate-then-merge is exactly equivalent to iterated pairwise
+;; union, just O(k log k) over all ranges instead of O(k) re-sorts of
+;; a growing accumulator. (Unlike union, xor below is NOT safe to
+;; flatten this way -- see its own comment.)
+(define (char-set-union . css)
+  (%make-cs (fold (lambda (acc cs) (append (%cs-ranges-list cs) acc)) '() css)))
+
+(define (char-set-union! cs1 . css)
+  (%cs-replace! cs1 (fold (lambda (acc cs) (append (%cs-ranges-list cs) acc))
+                           (%cs-ranges-list cs1) css)))
+
+(define (char-set-intersection cs1 . css)
+  (%make-cs (fold (lambda (acc cs) (%ranges-intersection acc (%cs-ranges-list cs)))
+                   (%cs-ranges-list cs1) css)))
+
+(define (char-set-intersection! cs1 . css)
+  (%cs-replace! cs1 (fold (lambda (acc cs) (%ranges-intersection acc (%cs-ranges-list cs)))
+                           (%cs-ranges-list cs1) css)))
+
+(define (char-set-difference cs1 . css)
+  (%make-cs (fold (lambda (acc cs) (%ranges-difference acc (%cs-ranges-list cs)))
+                   (%cs-ranges-list cs1) css)))
+
+(define (char-set-difference! cs1 . css)
+  (%cs-replace! cs1 (fold (lambda (acc cs) (%ranges-difference acc (%cs-ranges-list cs)))
+                           (%cs-ranges-list cs1) css)))
+
+;; xor genuinely needs sequential pairwise combination (unlike union
+;; above): a codepoint covered by exactly 2 of 3 input sets must NOT
+;; appear in the result, so it can't be reduced to a single flatten-
+;; and-merge over all operands' ranges -- parity matters, not just
+;; coverage.
+(define (char-set-xor . css)
+  (%make-cs (fold (lambda (acc cs) (%ranges-xor acc (%cs-ranges-list cs))) '() css)))
+
+(define (char-set-xor! cs1 . css)
+  (%cs-replace! cs1 (fold (lambda (acc cs) (%ranges-xor acc (%cs-ranges-list cs)))
+                           (%cs-ranges-list cs1) css)))
+
+(define (char-set-complement cs) (%make-cs (%ranges-complement (%cs-ranges-list cs))))
+(define (char-set-complement! cs) (%cs-replace! cs (%ranges-complement (%cs-ranges-list cs))))
+
+(define (char-set-diff+intersection cs1 . css)
+  (values (apply char-set-difference cs1 css) (apply char-set-intersection cs1 css)))
+
+(define (char-set-diff+intersection! cs1 cs2 . css)
+  (let ((d (apply char-set-difference cs1 cs2 css))
+        (i (apply char-set-intersection cs1 cs2 css)))
+    (%cs-replace! cs1 (%cs-ranges-list d))
+    (%cs-replace! cs2 (%cs-ranges-list i))
+    (values cs1 cs2)))
+
+(define (char-set-adjoin cs . chars) (char-set-union cs (apply char-set chars)))
+(define (char-set-adjoin! cs . chars) (char-set-union! cs (apply char-set chars)))
+(define (char-set-delete cs . chars) (char-set-difference cs (apply char-set chars)))
+(define (char-set-delete! cs . chars) (char-set-difference! cs (apply char-set chars)))
+
+;;; ── comparison ───────────────────────────────────────────────────────
+
+(define (char-set= . css)
+  (or (null? css)
+      (let ((r0 (%cs-ranges-list (car css))))
+        (every (lambda (cs) (equal? r0 (%cs-ranges-list cs))) (cdr css)))))
+
+(define (char-set<= . css)
+  (or (null? css)
+      (let loop ((cs1 (car css)) (rest (cdr css)))
+        (or (null? rest)
+            (and (null? (%ranges-difference (%cs-ranges-list cs1) (%cs-ranges-list (car rest))))
+                 (loop (car rest) (cdr rest)))))))
+
+(define (char-set-hash cs . opt)
+  ;; modulo at every step, not just the end -- otherwise the accumulator
+  ;; grows as a base-31 bignum across hundreds of ranges (e.g.
+  ;; char-set:letter) instead of staying bounded.
+  (let ((bound (max (if (pair? opt) (car opt) 4194304) 1)))
+    (fold (lambda (acc r) (modulo (+ (* acc 31) (car r) (* 31 (cdr r))) bound))
+          0 (%cs-ranges-list cs))))
+
+;;; ── iteration ────────────────────────────────────────────────────────
+;;; A cursor is (range-index . offset-within-range), or the unique
+;;; %cs-cursor-end marker once exhausted.
+
+(define %cs-cursor-end (list 'char-set-cursor-end))
+(define (end-of-char-set? cursor) (eq? cursor %cs-cursor-end))
+
+(define (char-set-cursor cs)
+  (if (zero? (vector-length (%cs-rvec cs))) %cs-cursor-end (cons 0 0)))
+
+(define (char-set-ref cs cursor)
+  (integer->char (+ (car (vector-ref (%cs-rvec cs) (car cursor))) (cdr cursor))))
+
+(define (char-set-cursor-next cs cursor)
+  (let* ((rv (%cs-rvec cs)) (ri (car cursor)) (off (cdr cursor)) (r (vector-ref rv ri)))
+    (if (< (+ (car r) off) (cdr r))
+        (cons ri (+ off 1))
+        (if (< (+ ri 1) (vector-length rv)) (cons (+ ri 1) 0) %cs-cursor-end))))
+
+(define (char-set-fold kons knil cs)
+  (let loop ((c (char-set-cursor cs)) (acc knil))
+    (if (end-of-char-set? c)
+        acc
+        (loop (char-set-cursor-next cs c) (kons (char-set-ref cs c) acc)))))
+
+(define (char-set-for-each proc cs)
+  (let loop ((c (char-set-cursor cs)))
+    (unless (end-of-char-set? c)
+      (proc (char-set-ref cs c))
+      (loop (char-set-cursor-next cs c)))))
+
+(define (char-set-map proc cs)
+  (%make-cs (%chars->ranges (map proc (char-set->list cs)))))
+
+(define (char-set-unfold p f g seed . opt)
+  (let loop ((seed seed) (chars '()))
+    (if (p seed)
+        (apply list->char-set chars opt)
+        (loop (g seed) (cons (f seed) chars)))))
+
+(define (char-set-unfold! p f g seed base-cs)
+  (let loop ((seed seed) (chars '()))
+    (if (p seed)
+        (list->char-set! chars base-cs)
+        (loop (g seed) (cons (f seed) chars)))))
+
+;;; ── querying ─────────────────────────────────────────────────────────
+
+(define (%range-chars-onto lo hi acc)
+  (if (> lo hi) acc (%range-chars-onto lo (- hi 1) (cons (integer->char hi) acc))))
+
+(define (char-set->list cs)
+  (fold-right (lambda (r acc) (%range-chars-onto (car r) (cdr r) acc)) '() (%cs-ranges-list cs)))
+
+(define (char-set->string cs) (list->string (char-set->list cs)))
+
+(define (char-set-size cs)
+  (fold (lambda (acc r) (+ acc 1 (- (cdr r) (car r)))) 0 (%cs-ranges-list cs)))
+
+(define (char-set-count pred cs) (count pred (char-set->list cs)))
+(define (char-set-every pred cs) (every pred (char-set->list cs)))
+(define (char-set-any pred cs) (any pred (char-set->list cs)))
+
+;;; ── standard char-sets ───────────────────────────────────────────────
+;;; letter/digit/whitespace/upper-case/lower-case are full-Unicode
+;;; (backed by curry's own classification tables); everything else here
+;;; is ASCII-only -- see the file header comment.
+
+(define char-set:upper-case (%make-cs (unicode-property-ranges "uppercase")))
+(define char-set:lower-case (%make-cs (unicode-property-ranges "lowercase")))
+(define char-set:letter     (%make-cs (unicode-property-ranges "alphabetic")))
+(define char-set:digit      (%make-cs (unicode-property-ranges "numeric")))
+(define char-set:whitespace (%make-cs (unicode-property-ranges "whitespace")))
+(define char-set:letter+digit (char-set-union char-set:letter char-set:digit))
+
+(define char-set:title-case (%make-cs '()))
+
+(define char-set:iso-control (%make-cs (list (cons 0 31) (cons 127 127))))
+(define char-set:blank       (%make-cs (list (cons 9 9) (cons 32 32))))
+(define char-set:hex-digit   (%make-cs (list (cons 48 57) (cons 65 70) (cons 97 102))))
+(define char-set:ascii       (%make-cs (list (cons 0 127))))
+
+;; ASCII ispunct (33-47,58-64,91-96,123-126) split into Unicode
+;; Sm/Sc/Sk/So ("symbol") vs. everything else ("punctuation").
+(define char-set:symbol
+  (%make-cs (list (cons 36 36) (cons 43 43) (cons 60 62)
+                   (cons 94 94) (cons 96 96) (cons 124 124) (cons 126 126))))
+(define char-set:punctuation
+  (%make-cs (list (cons 33 35) (cons 37 42) (cons 44 47) (cons 58 59)
+                   (cons 63 64) (cons 91 93) (cons 95 95) (cons 123 123) (cons 125 125))))
+
+(define char-set:graphic
+  (char-set-union char-set:letter+digit char-set:punctuation char-set:symbol))
+(define char-set:printing (char-set-union char-set:graphic (char-set #\space)))
+
+(define char-set:empty (%make-cs '()))
+(define char-set:full (%make-cs %full-domain-ranges))
+
+  )) ;; end begin, define-library

--- a/lib/curry/modules/srfi/srfi-14.scm
+++ b/lib/curry/modules/srfi/srfi-14.scm
@@ -1,0 +1,26 @@
+(define-library (srfi srfi-14)
+  (import (srfi s14 char-sets))
+  (export
+    char-set? char-set= char-set<= char-set-hash
+    char-set-cursor char-set-ref char-set-cursor-next end-of-char-set?
+    char-set-fold char-set-unfold char-set-unfold!
+    char-set-for-each char-set-map
+    char-set list->char-set list->char-set!
+    string->char-set string->char-set!
+    char-set-filter char-set-filter!
+    ->char-set ucs-range->char-set ucs-range->char-set! char-set-copy
+    char-set->list char-set->string char-set-size char-set-count
+    char-set-contains? char-set-every char-set-any
+    char-set-adjoin char-set-adjoin! char-set-delete char-set-delete!
+    char-set-complement char-set-complement!
+    char-set-union char-set-union!
+    char-set-intersection char-set-intersection!
+    char-set-difference char-set-difference!
+    char-set-xor char-set-xor!
+    char-set-diff+intersection char-set-diff+intersection!
+    char-set:lower-case char-set:upper-case char-set:title-case
+    char-set:letter char-set:digit char-set:letter+digit
+    char-set:graphic char-set:printing char-set:whitespace
+    char-set:iso-control char-set:punctuation char-set:symbol
+    char-set:hex-digit char-set:blank char-set:ascii
+    char-set:empty char-set:full))

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -16,6 +16,7 @@
 #include "profiling.h"
 #include "numtheory.h"
 #include "unicode.h"
+#include "unicode_tables.h"
 #include "lang_registry.h"
 #include "curry_features.h"
 #ifdef BUILD_MPFR
@@ -657,6 +658,32 @@ static val_t prim_char_foldcase(int ac, val_t *av, void *ud) {(void)ac;(void)ud;
 #define CHAR_PRED(nm,test) static val_t prim_char_##nm(int ac, val_t *av, void *ud){(void)ac;(void)ud; return vbool(test(vunchr(av[0])));}
 CHAR_PRED(alpha_p, unicode_is_alphabetic) CHAR_PRED(numeric_p, unicode_is_numeric) CHAR_PRED(whitespace_p, unicode_is_whitespace)
 CHAR_PRED(upper_p, unicode_is_upper) CHAR_PRED(lower_p, unicode_is_lower)
+/* Exposes the generated cp>=128 classification range tables (see
+ * unicode.c/unicode_tables.h) as a Scheme list of (lo . hi) fixnum
+ * pairs -- for (curry unicode-ranges), the data source behind
+ * (srfi 14)'s full-Unicode predefined char-sets (char-set:letter,
+ * char-set:upper-case, etc). Building those sets by scanning all
+ * ~1.1M codepoints at the Scheme level through char-alphabetic? and
+ * friends would be both slow and redundant: the C tables already ARE
+ * the merged range form for cp>=128, so this hands them over directly
+ * instead. The ASCII (cp<128) portion is cheap enough to scan at the
+ * Scheme level via the ordinary char predicates and isn't covered here. */
+static val_t prim_unicode_property_ranges(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_string(av[0])) scm_raise(V_FALSE, "unicode-property-ranges: not a string");
+    const char *name = str_data(as_str(av[0]));
+    const uint32_t (*ranges)[2]; size_t count;
+    if      (strcmp(name, "alphabetic") == 0) { ranges = unicode_alpha_ranges; count = unicode_alpha_ranges_count; }
+    else if (strcmp(name, "numeric")    == 0) { ranges = unicode_numeric_ranges; count = unicode_numeric_ranges_count; }
+    else if (strcmp(name, "whitespace") == 0) { ranges = unicode_space_ranges; count = unicode_space_ranges_count; }
+    else if (strcmp(name, "uppercase")  == 0) { ranges = unicode_upper_ranges; count = unicode_upper_ranges_count; }
+    else if (strcmp(name, "lowercase")  == 0) { ranges = unicode_lower_ranges; count = unicode_lower_ranges_count; }
+    else { scm_raise(V_FALSE, "unicode-property-ranges: unknown property"); return V_VOID; }
+    val_t result = V_NIL;
+    for (size_t i = count; i-- > 0; )
+        result = scm_cons(scm_cons(vfix((intptr_t)ranges[i][0]), vfix((intptr_t)ranges[i][1])), result);
+    return result;
+}
 static val_t prim_char_eq(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(vunchr(av[i-1])!=vunchr(av[i])) return V_FALSE; return V_TRUE;}
 static val_t prim_char_lt(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(vunchr(av[i-1])>=vunchr(av[i])) return V_FALSE; return V_TRUE;}
 
@@ -2812,6 +2839,7 @@ void builtins_register(val_t env) {
     DEF("char-ci=?",prim_char_ci_eq,2,-1); DEF("char-ci<?",prim_char_ci_lt,2,-1);
     DEF("char-ci<=?",prim_char_ci_le,2,-1); DEF("char-ci>?",prim_char_ci_gt,2,-1); DEF("char-ci>=?",prim_char_ci_ge,2,-1);
     DEF("digit-value",prim_digit_value,1,1);
+    DEF("unicode-property-ranges",prim_unicode_property_ranges,1,1);
 
     /* Strings */
     DEF("make-string",prim_make_string,1,2); DEF("string",prim_string,0,-1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_test(NAME load_dir_context_exception_safety
 add_test(NAME load_dir_context_thread_safety
     COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/load_dir_context/thread_safety/main.scm)
 add_test(NAME srfi_s26_cut COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s26_cut_tests.scm)
+add_test(NAME srfi_s14_char_sets COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s14_char_sets_tests.scm)
 add_test(NAME numeric_ext    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/numeric_ext_tests.scm)
 add_test(NAME actors         COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/actors_tests.scm)
 # Rare, non-deterministic hang observed once in CI (Ubuntu Debug, under

--- a/tests/srfi_s14_char_sets_tests.scm
+++ b/tests/srfi_s14_char_sets_tests.scm
@@ -1,0 +1,218 @@
+;;; Tests for (srfi s14 char-sets) / (srfi 14) -- char-sets. Covers
+;;; construction, membership, iteration, set algebra, comparisons, and
+;;; the standard predefined char-sets (both the full-Unicode ones backed
+;;; by curry's own classification tables, and the ASCII-only ones).
+
+(import (srfi 14) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label result expected)
+  (if (equal? result expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " got ") (write result)
+             (display " expected ") (write expected)
+             (newline)
+             (set! fail (+ fail 1)))))
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 1  construction / basic membership
+;;; ════════════════════════════════════════════════════════════
+
+(check "char-set? on a real char-set" (char-set? (char-set #\a #\b)) #t)
+(check "char-set? on a non-char-set" (char-set? 42) #f)
+(check "char-set contains its own members" (char-set-contains? (char-set #\a #\b #\c) #\b) #t)
+(check "char-set does not contain a non-member" (char-set-contains? (char-set #\a #\b) #\z) #f)
+(check "empty char-set contains nothing" (char-set-contains? char-set:empty #\a) #f)
+(check "list->char-set" (char-set->string (list->char-set (list #\c #\a #\b))) "abc")
+(check "string->char-set" (char-set->string (string->char-set "cab")) "abc")
+(check "duplicate members collapse" (char-set-size (char-set #\a #\a #\a)) 1)
+(check "char-set-copy is independent"
+  (let* ((cs (char-set #\a)) (cp (char-set-copy cs)))
+    (char-set-adjoin! cs #\b)
+    (list (char-set->string cs) (char-set->string cp)))
+  '("ab" "a"))
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 2  ->char-set / ucs-range->char-set
+;;; ════════════════════════════════════════════════════════════
+
+(check "->char-set on a char" (char-set->string (->char-set #\x)) "x")
+(check "->char-set on a string" (char-set->string (->char-set "zyx")) "xyz")
+(check "->char-set on a char-set is identity" (eq? (->char-set char-set:empty) char-set:empty) #t)
+(check "ucs-range->char-set is half-open [lo, hi)"
+  (char-set->list (ucs-range->char-set 65 68)) '(#\A #\B #\C))
+(check "ucs-range->char-set splits around the surrogate gap"
+  (char-set-size (ucs-range->char-set #xD7FE #xE002)) 4) ; D7FE,D7FF,E000,E001 -- D800..DFFF excluded
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 3  set algebra
+;;; ════════════════════════════════════════════════════════════
+
+(check "union" (char-set->string (char-set-union (char-set #\a #\b) (char-set #\b #\c))) "abc")
+(check "intersection" (char-set->string (char-set-intersection (char-set #\a #\b) (char-set #\b #\c))) "b")
+(check "difference" (char-set->string (char-set-difference (char-set #\a #\b #\c) (char-set #\b))) "ac")
+(check "xor" (char-set->string (char-set-xor (char-set #\a #\b) (char-set #\b #\c))) "ac")
+(check "complement of complement is identity"
+  (char-set= (char-set-complement (char-set-complement (char-set #\a #\b))) (char-set #\a #\b)) #t)
+(check "adjoin" (char-set->string (char-set-adjoin (char-set #\a) #\b #\c)) "abc")
+(check "delete" (char-set->string (char-set-delete (char-set #\a #\b #\c) #\b)) "ac")
+
+(check "union! mutates in place"
+  (let ((cs (char-set #\a))) (char-set-union! cs (char-set #\b)) (char-set->string cs)) "ab")
+(check "intersection! mutates in place"
+  (let ((cs (char-set #\a #\b))) (char-set-intersection! cs (char-set #\b #\c)) (char-set->string cs)) "b")
+(check "difference! mutates in place"
+  (let ((cs (char-set #\a #\b))) (char-set-difference! cs (char-set #\a)) (char-set->string cs)) "b")
+(check "complement! mutates in place"
+  (let ((cs (char-set #\a))) (char-set-complement! cs) (char-set-contains? cs #\a)) #f)
+
+(let-values (((d i) (char-set-diff+intersection (char-set #\a #\b #\c) (char-set #\b #\c #\d))))
+  (check "diff+intersection: difference" (char-set->string d) "a")
+  (check "diff+intersection: intersection" (char-set->string i) "bc"))
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 4  comparison
+;;; ════════════════════════════════════════════════════════════
+
+(check "char-set= reflexive/order-independent"
+  (char-set= (char-set #\a #\b) (char-set #\b #\a)) #t)
+(check "char-set= detects difference" (char-set= (char-set #\a) (char-set #\a #\b)) #f)
+(check "char-set<= subset" (char-set<= (char-set #\a) (char-set #\a #\b)) #t)
+(check "char-set<= non-subset" (char-set<= (char-set #\a #\z) (char-set #\a #\b)) #f)
+(check "char-set-hash is stable across equal sets"
+  (= (char-set-hash (char-set #\a #\b)) (char-set-hash (char-set #\b #\a))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 5  iteration: cursor protocol, fold, for-each, map, unfold
+;;; ════════════════════════════════════════════════════════════
+
+(check "cursor walk collects every member in order"
+  (let loop ((c (char-set-cursor (char-set #\c #\a #\b))) (acc '()))
+    (if (end-of-char-set? c) (reverse acc)
+        (loop (char-set-cursor-next (char-set #\c #\a #\b) c) (cons (char-set-ref (char-set #\c #\a #\b) c) acc))))
+  '(#\a #\b #\c))
+(check "end-of-char-set? on an empty set's cursor" (end-of-char-set? (char-set-cursor char-set:empty)) #t)
+
+(check "char-set-fold collects members"
+  (char-set-fold (lambda (c acc) (cons c acc)) '() (char-set #\a #\b #\c))
+  '(#\c #\b #\a))
+
+(check "char-set-for-each visits every member"
+  (let ((acc '()))
+    (char-set-for-each (lambda (c) (set! acc (cons c acc))) (char-set #\a #\b))
+    (reverse acc))
+  '(#\a #\b))
+
+(check "char-set-map transforms every member"
+  (char-set->string (char-set-map char-upcase (char-set #\a #\b))) "AB")
+(check "char-set-map raises cleanly if proc returns a non-char, rather than silently building a garbage range"
+  (guard (e (#t 'raised)) (char-set-map (lambda (c) 42) (char-set #\a)) 'not-raised)
+  'raised)
+
+(check "char-set-unfold builds from a generator"
+  (char-set->string
+    (char-set-unfold (lambda (i) (> i 2))
+                      (lambda (i) (integer->char (+ 97 i)))
+                      (lambda (i) (+ i 1))
+                      0))
+  "abc")
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 6  querying: ->list, ->string, size, count, every, any, filter
+;;; ════════════════════════════════════════════════════════════
+
+(define (char-vowel? c) (memv c '(#\a #\e #\i #\o #\u)))
+
+(check "char-set->list is sorted ascending" (char-set->list (char-set #\c #\a #\b)) '(#\a #\b #\c))
+(check "char-set-size" (char-set-size (char-set #\a #\b #\c)) 3)
+(check "char-set-count" (char-set-count char-vowel? (char-set #\a #\b #\c #\e)) 2)
+(check "char-set-every: true" (char-set-every char-alphabetic? (char-set #\a #\b)) #t)
+(check "char-set-every: false" (char-set-every char-alphabetic? (char-set #\a #\5)) #f)
+(check "char-set-any: true" (char-set-any char-numeric? (char-set #\a #\5)) #t)
+(check "char-set-any: false" (char-set-any char-numeric? (char-set #\a #\b)) #f)
+(check "char-set-filter" (char-set->string (char-set-filter char-numeric? (char-set #\a #\1 #\b #\2))) "12")
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 7  standard char-sets
+;;; ════════════════════════════════════════════════════════════
+
+(check "char-set:letter contains ASCII letters" (char-set-contains? char-set:letter #\q) #t)
+(check "char-set:letter excludes digits" (char-set-contains? char-set:letter #\5) #f)
+(check "char-set:digit contains ASCII digits" (char-set-contains? char-set:digit #\7) #t)
+(check "char-set:upper-case / lower-case are disjoint"
+  (char-set-size (char-set-intersection char-set:upper-case char-set:lower-case)) 0)
+(check "char-set:letter+digit is letter union digit"
+  (char-set= char-set:letter+digit (char-set-union char-set:letter char-set:digit)) #t)
+(check "char-set:whitespace contains space and tab"
+  (list (char-set-contains? char-set:whitespace #\space) (char-set-contains? char-set:whitespace #\tab))
+  '(#t #t))
+(check "char-set:ascii is exactly 0..127" (char-set-size char-set:ascii) 128)
+(check "char-set:iso-control contains NUL and DEL"
+  (list (char-set-contains? char-set:iso-control (integer->char 0))
+        (char-set-contains? char-set:iso-control (integer->char 127)))
+  '(#t #t))
+(check "char-set:blank contains space and tab, not newline"
+  (list (char-set-contains? char-set:blank #\space)
+        (char-set-contains? char-set:blank #\tab)
+        (char-set-contains? char-set:blank #\newline))
+  '(#t #t #f))
+(check "char-set:hex-digit contains 0-9a-fA-F, not g"
+  (list (char-set-contains? char-set:hex-digit #\9)
+        (char-set-contains? char-set:hex-digit #\a)
+        (char-set-contains? char-set:hex-digit #\F)
+        (char-set-contains? char-set:hex-digit #\g))
+  '(#t #t #t #f))
+(check "char-set:punctuation contains ! but not $ (a symbol)"
+  (list (char-set-contains? char-set:punctuation #\!) (char-set-contains? char-set:punctuation #\$))
+  '(#t #f))
+(check "char-set:symbol contains $ but not !"
+  (list (char-set-contains? char-set:symbol #\$) (char-set-contains? char-set:symbol #\!))
+  '(#t #f))
+(check "char-set:graphic excludes space, includes letters/digits/punct/symbol"
+  (list (char-set-contains? char-set:graphic #\space)
+        (char-set-contains? char-set:graphic #\a)
+        (char-set-contains? char-set:graphic #\!)
+        (char-set-contains? char-set:graphic #\$))
+  '(#f #t #t #t))
+(check "char-set:printing is graphic plus space"
+  (char-set= char-set:printing (char-set-union char-set:graphic (char-set #\space))) #t)
+(check "char-set:title-case is empty (no titlecase table available)"
+  (char-set-size char-set:title-case) 0)
+(check "char-set:empty really is empty" (char-set-size char-set:empty) 0)
+(check "char-set:full contains an arbitrary high codepoint, excludes surrogates"
+  (list (char-set-contains? char-set:full (integer->char #x1F600))
+        (char-set-size (char-set-intersection char-set:full (ucs-range->char-set #xD800 #xE000))))
+  '(#t 0))
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 8  full-Unicode coverage smoke test (not just ASCII)
+;;; ════════════════════════════════════════════════════════════
+
+;; Ω (U+03A9 GREEK CAPITAL LETTER OMEGA) and ω (U+03C9, lowercase) --
+;; exercises the >=128 portion of the underlying classification tables.
+(check "char-set:letter recognizes a non-ASCII letter"
+  (char-set-contains? char-set:letter (integer->char #x03A9)) #t)
+(check "char-set:upper-case recognizes non-ASCII uppercase"
+  (char-set-contains? char-set:upper-case (integer->char #x03A9)) #t)
+(check "char-set:lower-case recognizes non-ASCII lowercase"
+  (char-set-contains? char-set:lower-case (integer->char #x03C9)) #t)
+(check "char-set:letter excludes a non-ASCII non-letter (emoji)"
+  (char-set-contains? char-set:letter (integer->char #x1F600)) #f)
+
+;; U+20000 (a CJK Unified Ideograph in Extension B) -- exercises real
+;; classification-table data above the BMP (>0xFFFF), not just the
+;; surrogate-exclusion logic char-set:full's own test above already
+;; covers at U+1F600.
+(check "char-set:letter recognizes a supplementary-plane letter (>0xFFFF)"
+  (char-set-contains? char-set:letter (integer->char #x20000)) #t)
+
+;;; Summary
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

- Implements the full SRFI-14 public API (construction, membership, cursor iteration, set algebra, comparisons, and all standard predefined char-sets) as `(srfi 14)` / `(srfi s14 char-sets)` / `(srfi srfi-14)`.
- A char-set is a curry-native record wrapping a sorted, non-overlapping vector of inclusive codepoint ranges — not a port of SRFI-14's own bitstring-based reference implementation, which doesn't fit curry's full-Unicode chars.
- Adds one new C builtin, `unicode-property-ranges`, exposing curry's existing generated Unicode classification tables as Scheme data, so `char-set:letter`/`:digit`/`:whitespace`/`:upper-case`/`:lower-case` are full-Unicode (backed by the same tables `char-alphabetic?` etc. use) rather than ASCII-only or built by an expensive full-codepoint-space scan.
- Everything without a generated Unicode General-Category table (punctuation/symbol/iso-control/blank/hex-digit/ascii/graphic/printing) is ASCII-only, and `char-set:title-case` is empty (no titlecase table exists at all) — documented in the module's header comment.
- Independently code-reviewed and security-reviewed (fresh subagents, no shared context). Two real findings applied: a missing `char?` check in the one chokepoint every char-set codepoint passes through (`%char->cp`), and an O(k²) → O(k log k) fix for `char-set-union`/`char-set-union!` (with `char-set-xor` deliberately left alone and documented why — it's parity-sensitive, not safe to flatten the same way.
- 69 tests, including full-Unicode coverage above the BMP.

## Test plan

- [x] Test project /Volumes/Antennae/src/curry/.claude/worktrees/linked-jumping-moth/build
    Start 13: srfi_s14_char_sets
1/1 Test #13: srfi_s14_char_sets ...............   Passed    0.26 sec

100% tests passed out of 1

Total Test time (real) =   0.26 sec — 69/69 pass
- [x] Full suite: Test project /Volumes/Antennae/src/curry/.claude/worktrees/linked-jumping-moth/build
      Start 26: sicm
      Start 14: numeric_ext
      Start 55: tts
      Start 81: mqtt
 1/92 Test #81: mqtt .................................   Passed    3.30 sec
      Start 19: pde_numerical
 2/92 Test #19: pde_numerical ........................   Passed    2.69 sec
      Start 82: mcp
 3/92 Test #55: tts ..................................   Passed    6.09 sec
      Start 84: network
 4/92 Test #84: network ..............................   Passed    1.05 sec
      Start 72: srfi_s252_property_testing
 5/92 Test #14: numeric_ext ..........................   Passed    7.21 sec
      Start 76: cli
 6/92 Test #76: cli ..................................   Passed    0.75 sec
      Start 27: akkadian
 7/92 Test #27: akkadian .............................   Passed    0.31 sec
      Start  4: scheme_r7rs
 8/92 Test #82: mcp ..................................   Passed    2.39 sec
      Start 83: lsp
 9/92 Test #72: srfi_s252_property_testing ...........   Passed    1.32 sec
      Start 80: redis
10/92 Test #83: lsp ..................................   Passed    0.60 sec
      Start 53: dot_locking
11/92 Test  #4: scheme_r7rs ..........................   Passed    0.76 sec
      Start 88: posix
12/92 Test #80: redis ................................   Passed    0.72 sec
      Start 90: okf
13/92 Test #88: posix ................................   Passed    0.54 sec
      Start  1: core
14/92 Test #53: dot_locking ..........................   Passed    0.60 sec
      Start 52: atom
15/92 Test #90: okf ..................................   Passed    0.42 sec
      Start 66: srfi_numbered_shims
16/92 Test  #1: core .................................   Passed    0.14 sec
      Start 77: debugger
17/92 Test #52: atom .................................   Passed    0.20 sec
      Start 69: srfi_srfi_prefixed_shims
18/92 Test #66: srfi_numbered_shims ..................   Passed    0.20 sec
      Start  3: sqlite
19/92 Test  #3: sqlite ...............................   Passed    0.01 sec
      Start 51: rss
20/92 Test #77: debugger .............................   Passed    0.17 sec
      Start  2: json
21/92 Test  #2: json .................................   Passed    0.01 sec
      Start 50: xml
22/92 Test #69: srfi_srfi_prefixed_shims .............   Passed    0.17 sec
      Start 15: actors
23/92 Test #51: rss ..................................   Passed    0.15 sec
      Start 18: ode
24/92 Test #50: xml ..................................   Passed    0.13 sec
      Start 44: yaml
25/92 Test #15: actors ...............................   Passed    0.09 sec
      Start 13: srfi_s14_char_sets
26/92 Test #18: ode ..................................   Passed    0.11 sec
      Start 40: random
27/92 Test #44: yaml .................................   Passed    0.08 sec
      Start 79: plplot
28/92 Test #40: random ...............................   Passed    0.07 sec
      Start 78: git
29/92 Test #79: plplot ...............................   Passed    0.06 sec
      Start 38: naips
30/92 Test #78: git ..................................   Passed    0.06 sec
      Start  7: srfi_s279_inspect
31/92 Test #38: naips ................................   Passed    0.05 sec
      Start 17: syntax_rules
32/92 Test  #7: srfi_s279_inspect ....................   Passed    0.05 sec
      Start 11: load_dir_context_thread_safety
33/92 Test #11: load_dir_context_thread_safety .......   Passed    0.02 sec
      Start 48: schematic
34/92 Test #17: syntax_rules .........................   Passed    0.06 sec
      Start 39: base64
35/92 Test #13: srfi_s14_char_sets ...................   Passed    0.26 sec
      Start 45: toml
36/92 Test #48: schematic ............................   Passed    0.04 sec
      Start 85: fits
37/92 Test #39: base64 ...............................   Passed    0.05 sec
      Start 64: srfi_threads
38/92 Test #45: toml .................................   Passed    0.04 sec
      Start 68: srfi_numbered_shim_comparator_hash
39/92 Test #85: fits .................................   Passed    0.04 sec
      Start 87: profiling
40/92 Test #64: srfi_threads .........................   Passed    0.04 sec
      Start  5: scheme_r6rs
41/92 Test #68: srfi_numbered_shim_comparator_hash ...   Passed    0.03 sec
      Start 37: aviation_weather
42/92 Test #87: profiling ............................   Passed    0.03 sec
      Start 42: sets_module
43/92 Test  #5: scheme_r6rs ..........................   Passed    0.03 sec
      Start 73: srfi_s209_enums
44/92 Test #42: sets_module ..........................   Passed    0.02 sec
      Start 91: airports
45/92 Test #37: aviation_weather .....................   Passed    0.02 sec
      Start 25: pde_symbolic
46/92 Test #73: srfi_s209_enums ......................   Passed    0.02 sec
      Start 74: srfi_s210_multiple_values
47/92 Test #25: pde_symbolic .........................   Passed    0.02 sec
48/92 Test #74: srfi_s210_multiple_values ............   Passed    0.01 sec
      Start 43: oop
      Start 65: srfi_misc
49/92 Test #91: airports .............................   Passed    0.02 sec
      Start 86: netcdf
50/92 Test #43: oop ..................................   Passed    0.02 sec
      Start 49: graphviz
51/92 Test #86: netcdf ...............................   Passed    0.02 sec
      Start 70: srfi_s263_prototype_objects
52/92 Test #65: srfi_misc ............................   Passed    0.02 sec
      Start 36: logic
53/92 Test #70: srfi_s263_prototype_objects ..........   Passed    0.01 sec
      Start 67: srfi_numbered_shim_hash_family
54/92 Test #49: graphviz .............................   Passed    0.02 sec
      Start 60: srfi_hash_tables_125_126
55/92 Test #36: logic ................................   Passed    0.01 sec
      Start 89: time_srfi
56/92 Test #89: time_srfi ............................   Passed    0.02 sec
      Start 62: srfi_sets_bags
57/92 Test #67: srfi_numbered_shim_hash_family .......   Passed    0.02 sec
      Start 75: srfi_s54_cat
58/92 Test #60: srfi_hash_tables_125_126 .............   Passed    0.02 sec
      Start 47: csv
59/92 Test #75: srfi_s54_cat .........................   Passed    0.01 sec
      Start 30: sexagesimal
60/92 Test #62: srfi_sets_bags .......................   Passed    0.02 sec
      Start 46: matchable
61/92 Test #47: csv ..................................   Passed    0.01 sec
      Start 58: srfi_receive_assume_optional
62/92 Test #30: sexagesimal ..........................   Passed    0.01 sec
      Start 28: conditions
63/92 Test #46: matchable ............................   Passed    0.01 sec
      Start 54: zeromq
64/92 Test #58: srfi_receive_assume_optional .........   Passed    0.01 sec
      Start 29: numtheory
65/92 Test #28: conditions ...........................   Passed    0.01 sec
      Start 56: hash_tables_srfi
66/92 Test #54: zeromq ...............................   Passed    0.01 sec
      Start 31: babylonian_astronomy
67/92 Test #29: numtheory ............................   Passed    0.01 sec
      Start 12: srfi_s26_cut
68/92 Test #56: hash_tables_srfi .....................   Passed    0.01 sec
      Start 33: sx_algebra
69/92 Test #31: babylonian_astronomy .................   Passed    0.01 sec
      Start 71: srfi_s111_s195_boxes
70/92 Test #12: srfi_s26_cut .........................   Passed    0.01 sec
      Start  6: cond_expand
71/92 Test #33: sx_algebra ...........................   Passed    0.01 sec
      Start 21: tuples
72/92 Test #71: srfi_s111_s195_boxes .................   Passed    0.01 sec
      Start 23: trig
73/92 Test  #6: cond_expand ..........................   Passed    0.01 sec
      Start 61: srfi_sorting_vectors
74/92 Test #21: tuples ...............................   Passed    0.01 sec
      Start 59: srfi_comparators
75/92 Test #23: trig .................................   Passed    0.01 sec
      Start 22: partial
76/92 Test #59: srfi_comparators .....................   Passed    0.01 sec
      Start 20: d_operator
77/92 Test #61: srfi_sorting_vectors .................   Passed    0.01 sec
      Start 63: srfi_generators
78/92 Test #22: partial ..............................   Passed    0.01 sec
      Start  8: include_relative
79/92 Test #63: srfi_generators ......................   Passed    0.01 sec
      Start 41: sets
80/92 Test #20: d_operator ...........................   Passed    0.01 sec
      Start 57: timespec
81/92 Test  #8: include_relative .....................   Passed    0.01 sec
      Start 24: transcendental
82/92 Test #41: sets .................................   Passed    0.01 sec
      Start 34: sx_poly
83/92 Test #24: transcendental .......................   Passed    0.01 sec
      Start 35: sx_risch
84/92 Test #57: timespec .............................   Passed    0.01 sec
      Start 10: load_dir_context_exception_safety
85/92 Test #34: sx_poly ..............................   Passed    0.01 sec
      Start 32: sx_rules
86/92 Test #10: load_dir_context_exception_safety ....   Passed    0.01 sec
      Start 16: dynamic_wind
87/92 Test #35: sx_risch .............................   Passed    0.01 sec
      Start 92: codesets
88/92 Test #32: sx_rules .............................   Passed    0.01 sec
      Start  9: load_dir_context_script_relative
89/92 Test #16: dynamic_wind .........................   Passed    0.01 sec
90/92 Test #92: codesets .............................   Passed    0.01 sec
91/92 Test  #9: load_dir_context_script_relative .....   Passed    0.01 sec
92/92 Test #26: sicm .................................   Passed   12.42 sec

100% tests passed out of 92

Total Test time (real) =  12.42 sec — 92/92 pass
- [x] Independent code review (fresh subagent) — no correctness bugs found
- [x] Independent security review (fresh subagent) — no memory-safety issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)