### PR TITLE
feat: add procedure introspection (procedure-name/-arity/-arglist/-file/-line/-lambda/-closure)

### DIFF
--- a/lib/curry/modules/srfi/s279/inspect.scm
+++ b/lib/curry/modules/srfi/s279/inspect.scm
@@ -16,16 +16,21 @@
 ;;; by the new record?/record-rtd/record-type-name/record-type-field-names
 ;;; primitives added alongside this module -- curry previously had no way
 ;;; to ask "is this any record" without already knowing its RTD), error
-;;; objects, hash tables (srfi 69), boxes (srfi 111), and sets/bags
-;;; (srfi 113). Deliberately deferred, not forgotten:
-;;;   - procedure properties: curry exposes no procedure-name/arity/
-;;;     arglist introspection to Scheme at all yet (a real gap, tracked
-;;;     separately from this SRFI).
+;;; objects, hash tables (srfi 69), boxes (srfi 111), sets/bags (srfi 113),
+;;; and procedures (backed by the procedure-name/-arity/-arglist/-file/
+;;; -line/-lambda/-closure primitives added alongside this module -- see
+;;; their own header comment in src/builtins.c for exactly what each of
+;;; curry's three procedure representations, tree-walker closures,
+;;; bytecode-VM closures, and C primitives, can and can't report).
+;;; Deliberately deferred, not forgotten:
+;;;   - char-set properties: curry now HAS SRFI-14 (as of a later commit
+;;;     than this module's original version), but char-sets aren't wired
+;;;     into inspect-properties yet -- an easy, self-contained follow-up.
 ;;;   - numeric-vector (s8vector etc.) properties: curry has no SRFI 4/160.
-;;;   - char-set properties: curry has no SRFI 14.
 ;;;   - library/environment properties: modules.c's registry has no
 ;;;     Scheme-level enumeration API (module names/exports aren't queryable
 ;;;     from Scheme once loaded).
+;;;   - ports: no port-open?/-direction/-type/etc case at all yet.
 ;;; A `#f`-valued object-properties entry is never emitted for these —
 ;;; per the SRFI's own rule, an unsupported property is omitted, not
 ;;; filled with a dummy value.
@@ -247,6 +252,37 @@
               (list 'bag-unique-size (bag-unique-size object)))
         (map (lambda (kv) (list (car kv) (cdr kv))) (bag->alist object))))
 
+    ;;; ---- Procedure ----
+    ;;;
+    ;;; Each accessor already returns #f (or, for procedure-closure, '())
+    ;;; when curry has nothing to report for that procedure representation
+    ;;; (e.g. primitives have no source file/line/arglist/closure; the
+    ;;; tree-walker has no source location at all) -- %omit below turns
+    ;;; that into "key absent" rather than "key present with a dummy #f",
+    ;;; matching the SRFI's own rule for this exact situation.
+    ;;;
+    ;;; Known ambiguity (flagged by independent code review, accepted
+    ;;; rather than fixed): procedure-closure's '() means both "this
+    ;;; procedure genuinely captured nothing" (e.g. a top-level define)
+    ;;; and "this representation can't report captures at all" (every
+    ;;; primitive). Both collapse to an absent procedure-closure key
+    ;;; here, so a caller can't tell "verified empty" from "unknown" --
+    ;;; the same shape of collapse the SRFI's own omission rule already
+    ;;; accepts elsewhere (e.g. a #f digit-value is indistinguishable
+    ;;; from "not a digit" in %character-properties above).
+
+    (define (%omit key value) (if (or (eq? value #f) (null? value)) '() (list (list key value))))
+
+    (define (%procedure-properties object)
+      (append
+        (%omit 'procedure-name     (procedure-name object))
+        (list  (list 'procedure-arity (procedure-arity object)))
+        (%omit 'procedure-arglists (let ((a (procedure-arglist object))) (if a (list a) #f)))
+        (%omit 'procedure-file     (procedure-file object))
+        (%omit 'procedure-line     (procedure-line object))
+        (%omit 'procedure-lambda   (procedure-lambda object))
+        (%omit 'procedure-closure  (procedure-closure object))))
+
     ;;; ---- 0..N → type indexed-element inlining, shared by pair/string/
     ;;; vector properties above. ----
 
@@ -289,6 +325,7 @@
           ((error-object? object) (%error-properties object))
           ((record-type? object) (%rtd-properties object))
           ((record? object)  (%record-properties object))
+          ((procedure? object) (%procedure-properties object))
           (else '()))))
 
     (define (inspect-describe object . port-arg)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2428,6 +2428,194 @@ static val_t prim_make_record_type(int ac, val_t *av, void *ud) {
     return vptr(rtd);
 }
 
+/* ---- Procedure introspection ----
+ *
+ * Curry previously exposed no way for Scheme code to ask a procedure
+ * its own name, arity, or source form -- a real, previously-documented
+ * gap (see (srfi s279 inspect)'s own header comment, "curry exposes no
+ * procedure-name/arity/arglist introspection to Scheme at all yet").
+ * Three procedure representations exist and each carries different
+ * metadata:
+ *   - T_CLOSURE (tree-walker): params/body/name/env directly on the
+ *     struct -- no separate source-location tracking exists for this
+ *     path at all (confirmed by the debugger's own doc comment: "tree-
+ *     walker code (load, tree-eval) is invisible to it").
+ *   - T_BCCLOSURE (bytecode VM): wraps a Chunk, which already carries
+ *     name/arity/source_name/lines/src_lambda for the debugger's sake
+ *     -- this path has the richest metadata.
+ *   - T_PRIMITIVE (built-in C procedure): name/min_args/max_args only;
+ *     no source form, no named parameters, no captured closure to
+ *     report -- those properties are correctly absent, not defaulted.
+ * Continuations and JIT-compiled closures report nothing (V_FALSE)
+ * rather than raising, matching the SRFI's own "omit unknown
+ * properties" rule one layer up in the inspect module. */
+
+static val_t bi_cstr_to_string(const char *s) {
+    if (!s) return V_FALSE;
+    uint32_t len = (uint32_t)strlen(s);
+    String *str = (String *)gc_alloc_atomic(sizeof(String) + len + 1);
+    str->hdr.type = T_STRING; str->hdr.flags = 0;
+    str->len = len; str->hash = 0; str->orig_cap = len; str->ext = NULL;
+    memcpy(str->data, s, len + 1);
+    return vptr(str);
+}
+
+static val_t prim_procedure_name(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    val_t p = av[0];
+    if (!vis_proc(p)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "procedure-name: not a procedure");
+    if (vis_closure(p)) return as_clos(p)->name;
+    if (vis_bcclosure(p)) { const char *n = as_bcclosure(p)->chunk->name; return n ? sym_intern_cstr(n) : V_FALSE; }
+    if (vis_prim(p)) return sym_intern_cstr(as_prim(p)->name);
+    return V_FALSE;
+}
+
+/* Closure params: a symbol (all-rest), a proper list, or an improper
+ * list ending in a rest symbol -- no separate "optional" arity concept
+ * exists in curry, so min/max fall out of this shape alone.
+ *
+ * Floyd's cycle detection (tortoise/hare), not just a plain walk: a
+ * closure's params is ordinary user-reachable data (nothing validates
+ * it eagerly at closure-construction time), so `(eval (list 'lambda
+ * circular-list body) env)` builds a real T_CLOSURE with circular
+ * params -- confirmed by independent security review to hang this
+ * function forever with a plain `while (vis_pair(p))` walk, a genuine
+ * DoS reachable from pure Scheme (a REPL helper, notebook, MCP tool,
+ * or LSP hover calling procedure-arity/inspect-properties on
+ * attacker-influenced input). No hard iteration cap is used instead,
+ * since that would reject legitimately long (if unusual) finite
+ * parameter lists that happen to exceed the cap. */
+static void closure_params_arity(val_t params, int *min_out, bool *variadic_out) {
+    int n = 0;
+    val_t slow = params, fast = params;
+    while (vis_pair(fast)) {
+        n++; fast = vcdr(fast);
+        if (!vis_pair(fast)) break;
+        n++; fast = vcdr(fast);
+        slow = vcdr(slow);
+        if (fast == slow) { /* cycle: treat as an unbounded rest-arg list */
+            *min_out = n; *variadic_out = true;
+            return;
+        }
+    }
+    *min_out = n;
+    *variadic_out = !vis_nil(fast); /* symbol tail (rest) or the whole thing was a bare symbol */
+}
+
+static val_t prim_procedure_arity(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    val_t p = av[0];
+    if (!vis_proc(p)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "procedure-arity: not a procedure");
+    if (vis_closure(p)) {
+        int min; bool variadic;
+        closure_params_arity(as_clos(p)->params, &min, &variadic);
+        return scm_cons(vfix(min), variadic ? V_FALSE : vfix(min));
+    }
+    if (vis_bcclosure(p)) {
+        int arity = as_bcclosure(p)->chunk->arity;
+        if (arity >= 0) return scm_cons(vfix(arity), vfix(arity));
+        int min = -arity - 1;
+        return scm_cons(vfix(min), V_FALSE);
+    }
+    if (vis_prim(p)) {
+        Primitive *pr = as_prim(p);
+        return scm_cons(vfix(pr->min_args), pr->max_args < 0 ? V_FALSE : vfix(pr->max_args));
+    }
+    return V_FALSE;
+}
+
+static val_t prim_procedure_arglist(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    val_t p = av[0];
+    if (!vis_proc(p)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "procedure-arglist: not a procedure");
+    if (vis_closure(p)) return as_clos(p)->params;
+    if (vis_bcclosure(p)) {
+        val_t lam = as_bcclosure(p)->chunk->src_lambda;
+        return vis_pair(lam) && vis_pair(vcdr(lam)) ? vcar(vcdr(lam)) : V_FALSE;
+    }
+    return V_FALSE; /* primitives have no named formals to report */
+}
+
+static val_t prim_procedure_file(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    val_t p = av[0];
+    if (!vis_proc(p)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "procedure-file: not a procedure");
+    if (vis_bcclosure(p)) {
+        const char *sn = as_bcclosure(p)->chunk->source_name;
+        return sn ? bi_cstr_to_string(sn) : V_FALSE;
+    }
+    return V_FALSE;
+}
+
+static val_t prim_procedure_line(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    val_t p = av[0];
+    if (!vis_proc(p)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "procedure-line: not a procedure");
+    if (vis_bcclosure(p)) {
+        Chunk *ch = as_bcclosure(p)->chunk;
+        if (ch->lines && ch->code_len > 0) return vfix(ch->lines[0]);
+    }
+    return V_FALSE;
+}
+
+static val_t prim_procedure_lambda(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    val_t p = av[0];
+    if (!vis_proc(p)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "procedure-lambda: not a procedure");
+    if (vis_closure(p)) {
+        Closure *c = as_clos(p);
+        return scm_cons(S_LAMBDA, scm_cons(c->params, c->body));
+    }
+    if (vis_bcclosure(p)) {
+        val_t lam = as_bcclosure(p)->chunk->src_lambda;
+        return vis_pair(lam) ? lam : V_FALSE;
+    }
+    return V_FALSE;
+}
+
+/* Captured free variables as a ((name . value) ...) alist -- best
+ * effort, not exhaustive: a top-level closure's "env" is a ROOT frame
+ * (no parent) -- either GLOBAL_ENV itself, or (just as importantly,
+ * and originally missed here -- found by independent security review)
+ * any (curry X)/SRFI module's own env_new_root() frame, which holds
+ * every binding the module imported plus every private top-level
+ * define in that module, not a meaningful per-lambda "capture" either.
+ * A pointer-identity check against GLOBAL_ENV specifically let any
+ * exported procedure from ANY module leak its entire module scope
+ * (imports, siblings, even command-line-args) through this primitive
+ * and, transitively, through (srfi 279)'s inspect-properties/-describe,
+ * which calls this unconditionally. Guarding on env->parent == NULL
+ * (any root frame, not just the specific GLOBAL_ENV one) catches both.
+ * Tree-walker closures report their immediate defining frame only (not
+ * the full enclosing chain); BcClosures report their actual captured
+ * upvalues by name where the compiler recorded one. */
+static val_t prim_procedure_closure(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    val_t p = av[0];
+    if (!vis_proc(p)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "procedure-closure: not a procedure");
+    if (vis_closure(p)) {
+        EnvFrame *env = as_clos(p)->env;
+        if (env == NULL || env->parent == NULL) return V_NIL;
+        val_t out = V_NIL;
+        for (uint32_t i = env->size; i > 0; i--)
+            out = scm_cons(scm_cons(env->syms[i-1], env->vals[i-1]), out);
+        return out;
+    }
+    if (vis_bcclosure(p)) {
+        BcClosure *bc = as_bcclosure(p);
+        val_t *names = bc->chunk->upval_names;
+        if (!names) return V_NIL;
+        val_t out = V_NIL;
+        for (int i = bc->upval_count; i > 0; i--) {
+            val_t name = names[i-1];
+            if (vis_false(name)) continue; /* unrecorded upvalue name */
+            out = scm_cons(scm_cons(name, *bc->upvals[i-1]->location), out);
+        }
+        return out;
+    }
+    return V_NIL;
+}
+
 /* ---- Misc ---- */
 static val_t prim_gensym(int ac, val_t *av, void *ud) {
     (void)ud; static int counter = 0;
@@ -2990,6 +3178,15 @@ void builtins_register(val_t env) {
     DEF("record-rtd",           prim_record_rtd,             1,1);
     DEF("record-type-name",     prim_record_type_name,       1,1);
     DEF("record-type-field-names", prim_record_type_field_names, 1,1);
+
+    /* Procedure introspection */
+    DEF("procedure-name",     prim_procedure_name,     1,1);
+    DEF("procedure-arity",    prim_procedure_arity,    1,1);
+    DEF("procedure-arglist",  prim_procedure_arglist,  1,1);
+    DEF("procedure-file",     prim_procedure_file,     1,1);
+    DEF("procedure-line",     prim_procedure_line,     1,1);
+    DEF("procedure-lambda",   prim_procedure_lambda,   1,1);
+    DEF("procedure-closure",  prim_procedure_closure,  1,1);
 
     /* Misc */
     DEF("gensym",     prim_gensym,  0,1);

--- a/src/scc.c
+++ b/src/scc.c
@@ -43,7 +43,17 @@
 /* ── Format constants ───────────────────────────────────────────────────── */
 
 #define SCC_MAGIC       "CURRYBC"   /* 7 bytes, no NUL */
-#define SCC_FMT_VER     '\x05'   /* v5: OP_TAIL_CALL_WITH_VALUES inserted into the
+#define SCC_FMT_VER     '\x06'   /* v6: persist Chunk.src_lambda (the original
+                                    (lambda params . body) source form, used for
+                                    tiered-JIT hot-swap and now also for the
+                                    procedure-lambda/procedure-arglist introspection
+                                    primitives) -- previously never written, so a
+                                    cache HIT silently lost it (returned #f) even
+                                    though the same script's first-ever run (a cache
+                                    MISS, compiled fresh in memory) had it. Found via
+                                    the (srfi 279) inspect test suite failing only
+                                    on its second run, never its first.
+                                  v5: OP_TAIL_CALL_WITH_VALUES inserted into the
                                     opcode enum, shifting every subsequent opcode's
                                     numeric value -- any .scc compiled by an older
                                     binary encodes bytecode using the OLD numbering,
@@ -335,6 +345,22 @@ static bool write_chunk(FILE *f, const Chunk *c) {
         }
     }
 
+    /* Source lambda form (v6+): tiered-JIT hot-swap + procedure-lambda/
+     * procedure-arglist introspection. write_const already handles an
+     * arbitrary S-expression (including V_VOID when unavailable), so
+     * this is just one more constant, not a new serialization format.
+     * Independent security review noted write_const's CTAG_PAIR case
+     * recurses non-tail on cdr with no depth limit, and this is the
+     * first caller to hand it something that can be an entire lambda
+     * BODY (previously only ever short quoted literals from the
+     * constant pool) -- a pre-existing exposure in shared code, not new
+     * here, but this call makes it reachable more often. Not fixed as
+     * part of this change (would mean converting write_const/read_const's
+     * whole pair-recursion to iterative, a larger refactor of code this
+     * change doesn't otherwise touch); flagged here for whoever picks
+     * that up. */
+    if (!write_const(f, c->src_lambda)) return false;
+
     return true;
 }
 
@@ -587,6 +613,9 @@ static bool read_chunk(FILE *f, Chunk *c) {
             free(buf);
         }
     }
+
+    /* Source lambda form (v6+) */
+    if (!read_const(f, &c->src_lambda)) return false;
 
     return true;
 }

--- a/tests/srfi_s279_inspect_tests.scm
+++ b/tests/srfi_s279_inspect_tests.scm
@@ -233,6 +233,106 @@
   (has "record-type: rtd-field-names" p 'rtd-field-names '(x y)))
 
 ;;; ════════════════════════════════════════════════════════════
+;;; § 14.5  procedure-properties, and the underlying procedure-name /
+;;; -arity / -arglist / -file / -line / -lambda / -closure primitives.
+;;; Covers all three of curry's procedure representations: bytecode-VM
+;;; closures (ordinary top-level defines), tree-walker closures (an
+;;; internal define, which curry evaluates via tree-eval rather than
+;;; compiling), and C primitives.
+;;; ════════════════════════════════════════════════════════════
+
+(define (add-two x y) (+ x y))
+(define (make-adder n) (lambda (x) (+ x n)))
+(define add5 (make-adder 5))
+(define (varargs a . rest) (cons a rest))
+(define (all-rest . xs) xs)
+
+(check "procedure-name: named top-level define"    (procedure-name add-two) 'add-two)
+(check "procedure-name: anonymous closure is #f"    (procedure-name add5) #f)
+(check "procedure-name: primitive"                  (procedure-name car) 'car)
+(check "procedure-name: non-procedure raises"
+  (guard (e (#t 'raised)) (procedure-name 42)) 'raised)
+
+(check "procedure-arity: fixed 2-arg"      (procedure-arity add-two) '(2 . 2))
+(check "procedure-arity: fixed 1-arg (closure over n)" (procedure-arity add5) '(1 . 1))
+(check "procedure-arity: one required + rest" (procedure-arity varargs) '(1 . #f))
+(check "procedure-arity: all-rest (zero required)" (procedure-arity all-rest) '(0 . #f))
+(check "procedure-arity: primitive, fixed"  (procedure-arity car) '(1 . 1))
+(check "procedure-arity: primitive, variadic" (procedure-arity +) '(0 . #f))
+
+(check "procedure-arglist: proper list"     (procedure-arglist add-two) '(x y))
+(check "procedure-arglist: dotted (rest)"   (procedure-arglist varargs) '(a . rest))
+(check "procedure-arglist: primitive is #f" (procedure-arglist car) #f)
+
+(check "procedure-lambda: reconstructs the source form"
+  (procedure-lambda add-two) '(lambda (x y) (+ x y)))
+(check "procedure-lambda: primitive is #f" (procedure-lambda car) #f)
+
+(check "procedure-closure: captures the free variable"
+  (procedure-closure add5) '((n . 5)))
+(check "procedure-closure: no captures for a top-level define"
+  (procedure-closure add-two) '())
+(check "procedure-closure: primitive is '()" (procedure-closure car) '())
+
+(check "procedure-file: primitive is #f" (procedure-file car) #f)
+(check "procedure-line: primitive is #f" (procedure-line car) #f)
+
+;; A genuine tree-walker closure (T_CLOSURE, not T_BCCLOSURE) via
+;; tree-eval, curry's own primitive for forcing evaluation through the
+;; tree-walking interpreter rather than the bytecode VM -- an ordinary
+;; internal (define ...) is NOT this path (it still compiles to a
+;; BcClosure, confirmed via procedure-file returning a real filename
+;; for one rather than #f).
+(tree-eval '(define (tw-fn p q) (* p q)))
+(check "procedure-arity works for a tree-walker closure too"
+  (procedure-arity tw-fn) '(2 . 2))
+(check "procedure-arglist works for a tree-walker closure too"
+  (procedure-arglist tw-fn) '(p q))
+(check "tree-walker closures have no source-location tracking (procedure-file)"
+  (procedure-file tw-fn) #f)
+
+(let ((p (inspect-properties add-two)))
+  (has   "procedure: procedure-name"     p 'procedure-name 'add-two)
+  (has   "procedure: procedure-arity"    p 'procedure-arity '(2 . 2))
+  (has   "procedure: procedure-arglists" p 'procedure-arglists '((x y)))
+  (has   "procedure: procedure-lambda"   p 'procedure-lambda '(lambda (x y) (+ x y)))
+  (lacks "procedure: no procedure-closure for a top-level define" p 'procedure-closure))
+
+(let ((p (inspect-properties add5)))
+  (has   "procedure(closure): procedure-closure has the capture" p 'procedure-closure '((n . 5)))
+  (lacks "procedure(closure): procedure-name is absent, not #f"  p 'procedure-name))
+
+(let ((p (inspect-properties car)))
+  (has   "procedure(primitive): procedure-name" p 'procedure-name 'car)
+  (has   "procedure(primitive): procedure-arity" p 'procedure-arity '(1 . 1))
+  (lacks "procedure(primitive): no procedure-arglists" p 'procedure-arglists)
+  (lacks "procedure(primitive): no procedure-lambda"   p 'procedure-lambda)
+  (lacks "procedure(primitive): no procedure-file"     p 'procedure-file)
+  (lacks "procedure(primitive): no procedure-line"     p 'procedure-line)
+  (lacks "procedure(primitive): no procedure-closure"  p 'procedure-closure))
+
+;; Regression: procedure-closure on a closure whose env is a MODULE's own
+;; root frame (define-library's env_new_root(), not GLOBAL_ENV itself)
+;; used to leak that entire frame -- every import, every sibling private
+;; define, even command-line-args -- because the "don't dump a shared
+;; root scope" guard checked pointer-identity against GLOBAL_ENV
+;; specifically instead of "is this a root frame at all" (found by
+;; independent security review; verified to leak ~1933 bindings before
+;; the fix -- every builtin, its Akkadian/cuneiform aliases, and the
+;; real process argv, all reachable from an ordinary exported procedure
+;; of ANY shipped module). Any root frame (parent == #f at the C level)
+;; is now treated the same as GLOBAL_ENV: '(), not a real capture.
+(define-library (test s279-modscope)
+  (import (scheme base) (scheme write))
+  (export get-inner)
+  (begin
+    (define (inner) (+ 1 2))
+    (define (get-inner) inner)))
+(import (test s279-modscope))
+(check "procedure-closure on a module-scope closure does not leak the module frame"
+  (procedure-closure (get-inner)) '())
+
+;;; ════════════════════════════════════════════════════════════
 ;;; § 15  inspect-describe — human-readable output, doesn't raise
 ;;; ════════════════════════════════════════════════════════════
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -472,7 +472,28 @@ printf 'CURRYBC\x03garbage-not-a-real-v3-body' > "$CACHEVER_SCC"
 out=$("$CURRY" "$CACHEVER_SCM")
 check "cache: stale/wrong-version .scc rejected cleanly, recompiles" "$out" "42"
 ver_byte=$(od -An -tx1 -j 7 -N 1 "$CACHEVER_SCC" | tr -d ' \n')
-check "cache: stale .scc rewritten in the current format version" "$ver_byte" "05"
+check "cache: stale .scc rewritten in the current format version" "$ver_byte" "06"
+
+# Regression: Chunk.src_lambda (procedure-lambda/procedure-arglist's data
+# source) used to never be written to .scc at all, so a script's SECOND run
+# (a cache HIT, loaded from disk) silently lost it and returned #f, even
+# though the exact same script's FIRST run (a cache MISS, compiled fresh in
+# memory) had it correctly. Run the identical script twice and confirm both
+# runs -- not just the first -- report the real lambda form.
+SRCLAMBDA_SCM="$TMPDIR_CLI/srclambda_test.scm"
+cat > "$SRCLAMBDA_SCM" <<'EOF'
+(define (add x y) (+ x y))
+(display (procedure-lambda add))
+(newline)
+(display (procedure-arglist add))
+(newline)
+EOF
+rm -f "$TMPDIR_CLI/srclambda_test.scc"
+out1=$("$CURRY" "$SRCLAMBDA_SCM")
+out2=$("$CURRY" "$SRCLAMBDA_SCM")
+expected=$'(lambda (x y) (+ x y))\n(x y)'
+check "cache: procedure-lambda survives the first (cache MISS) run" "$out1" "$expected"
+check "cache: procedure-lambda survives a second (cache HIT) run" "$out2" "$expected"
 
 # -e also reports.
 out=$("$CURRY" --timings -e '(display (+ 1 2))' 2>&1 >/dev/null)


### PR DESCRIPTION
## Summary

- Adds procedure introspection: `procedure-name`, `procedure-arity`, `procedure-arglist`, `procedure-file`, `procedure-line`, `procedure-lambda`, `procedure-closure` — closing a real, previously-documented gap (`(srfi s279 inspect)`'s own header comment: "curry exposes no procedure-name/arity/arglist introspection to Scheme at all yet").
- Each primitive dispatches across curry's three procedure representations (tree-walker closures, bytecode-VM closures, C primitives) and reports `#f`/`'()` when a property genuinely doesn't exist for that representation, rather than guessing — wired into `(srfi 279)`'s `inspect-properties` as a new `%procedure-properties` case.
- Found and fixed a real pre-existing bug along the way: `Chunk.src_lambda` was never persisted to the `.scc` bytecode cache, so a script's first (cache-MISS) run reported it correctly but every subsequent (cache-HIT) run silently lost it. Fixed by serializing it through the existing constant-pool machinery and bumping the cache format version.
- Independently code-reviewed and security-reviewed (fresh subagents, no shared context). Two real, fixed findings:
  1. **DoS**: `closure_params_arity` had no cycle guard — a circular `params` list (buildable from pure Scheme via `eval`+`set-cdr!`, no sandbox needed) hung `procedure-arity` forever. Fixed with Floyd's cycle detection.
  2. **Info-disclosure (critical)**: `procedure-closure`'s "don't dump a huge shared scope" guard only special-cased `GLOBAL_ENV` by pointer identity, missing every *module's own* root frame — verified live to leak ~1933 bindings (every imported builtin plus the real process `argv`) from one ordinary two-line test module's exported procedure, reachable transitively through `inspect-properties`/`inspect-describe`. Fixed by generalizing the guard to "any root frame" (`env->parent == NULL`).

## Test plan

- [x] `./build/curry tests/srfi_s279_inspect_tests.scm` — 123/123 pass (31 new checks, including regression coverage for the module-scope leak)
- [x] `bash tests/test_cli.sh ./build/curry` — 69/69 pass (2 new checks for the `.scc` cache MISS/HIT `src_lambda` regression)
- [x] Full suite: `ctest --test-dir build -j4` — 92/92 pass
- [x] Independent code review (fresh subagent) — one real bug found and fixed (unbounded cycle hang)
- [x] Independent security review (fresh subagent) — one critical bug found and fixed (environment-scope information leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
