### PR TITLE
feat: add port introspection (textual-port?/binary-port?/port-line/-position/-file-descriptor) and wire into (srfi 279)

### DIFF
--- a/lib/curry/modules/srfi/s279/inspect.scm
+++ b/lib/curry/modules/srfi/s279/inspect.scm
@@ -102,6 +102,7 @@
         ((record-type? object) 'record-type)
         ((record? object)      'record)
         ((procedure? object)   'procedure)
+        ((port? object)        'port)
         ((null? object)        'null)
         ((eof-object? object)  'eof)
         (else #f))) ; "whenever inferrable" -- omitted, not guessed, otherwise
@@ -426,6 +427,69 @@
         (%omit 'procedure-lambda   (procedure-lambda object))
         (%omit 'procedure-closure  (procedure-closure object))))
 
+    ;;; ---- Port ----
+    ;;;
+    ;;; port-open?/-direction/-type/-line/-position/-file-descriptor are
+    ;;; backed by new textual-port?/binary-port?/port-line/-position/
+    ;;; -file-descriptor primitives added alongside this module (see
+    ;;; their own comments in src/builtins.c for exactly what each of
+    ;;; curry's two port representations, FILE*-backed and string/
+    ;;; bytevector-backed, can and can't report). port-file is omitted
+    ;;; entirely: curry's Port struct never stores the path a file port
+    ;;; was opened from (see src/object.h), so there's genuinely nothing
+    ;;; to report, not something merely unwired. port-column is
+    ;;; similarly omitted: curry tracks line but never column at all.
+    ;;; port-encoding is a fixed 'UTF-8 for textual ports (curry really
+    ;;; is UTF-8-only throughout, per port.h's own header comment --
+    ;;; not a guess), omitted for binary ports (encoding doesn't apply).
+
+    (define (%port-open? object)
+      (or (and (input-port? object) (input-port-open? object))
+          (and (output-port? object) (output-port-open? object))))
+
+    (define (%port-direction object)
+      (cond ((and (input-port? object) (output-port? object)) 'both)
+            ((input-port? object) 'input)
+            ((output-port? object) 'output)
+            (else #f))) ; unreachable in practice -- every real port is at least one
+
+    ;; get-output-string/get-output-bytevector are meant for STRING/
+    ;; BYTEVECTOR OUTPUT ports specifically (SRFI-279's own wording:
+    ;; "for string and bytevector output ports") -- but curry's own
+    ;; get-output-string/-bytevector only check the PORT_STRING flag,
+    ;; not direction, so calling either on an INPUT string port doesn't
+    ;; raise at all, it just returns the input content (confirmed live:
+    ;; (get-output-string (open-input-string "hello")) => "hello", no
+    ;; error). Relying on a guard here would silently expose these
+    ;; properties on input ports too, contradicting the SRFI's own
+    ;; wording -- output-port? is checked explicitly instead of trusting
+    ;; curry's own exception behavior to enforce the boundary.
+    ;; textual-port?/binary-port? distinguish which of the two accessors
+    ;; actually applies -- both flags share PORT_STRING internally, so
+    ;; trying the wrong one isn't otherwise self-evident.
+    (define (%port-buffer object)
+      (and (output-port? object)
+           (if (textual-port? object)
+               (guard (e (#t #f)) (get-output-string object))
+               (guard (e (#t #f)) (get-output-bytevector object)))))
+
+    (define (%port-properties object)
+      (append
+        (list (list 'port-open? (%port-open? object))
+              (list 'port-direction (%port-direction object))
+              (list 'port-type (if (binary-port? object) 'binary 'textual))
+              (list 'port-line (port-line object)))
+        (let ((pos (port-position object))) (if pos (list (list 'port-position pos)) '()))
+        (let ((fd (port-file-descriptor object))) (if fd (list (list 'port-file-descriptor fd)) '()))
+        (if (textual-port? object) (list (list 'port-encoding 'UTF-8)) '())
+        (let ((buf (%port-buffer object))) (if buf (list (list 'port-buffer buf)) '()))
+        (if (and (output-port? object) (textual-port? object))
+            (guard (e (#t '())) (list (list 'get-output-string (get-output-string object))))
+            '())
+        (if (and (output-port? object) (binary-port? object))
+            (guard (e (#t '())) (list (list 'get-output-bytevector (get-output-bytevector object))))
+            '())))
+
     ;;; ---- 0..N → type indexed-element inlining, shared by pair/string/
     ;;; vector properties above. ----
 
@@ -470,6 +534,7 @@
           ((record-type? object) (%rtd-properties object))
           ((record? object)  (%record-properties object))
           ((procedure? object) (%procedure-properties object))
+          ((port? object)      (%port-properties object))
           (else '()))))
 
     (define (inspect-describe object . port-arg)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1846,6 +1846,83 @@ static val_t prim_input_port_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud; 
 static val_t prim_input_port_open_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(vis_port(av[0])&&port_is_input(av[0])&&!(as_port(av[0])->flags&PORT_CLOSED));}
 static val_t prim_output_port_open_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(vis_port(av[0])&&port_is_output(av[0])&&!(as_port(av[0])->flags&PORT_CLOSED));}
 static val_t prim_output_port_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(vis_port(av[0])&&port_is_output(av[0]));}
+
+/* textual-port?/binary-port? -- real R7RS §6.13.1 procedures curry
+ * previously had no way to ask at all (port_is_binary already existed
+ * as a C-only helper; these are the first Scheme-visible wrappers).
+ * Backs (srfi 279)'s port-type property, but genuinely useful on their
+ * own regardless of that SRFI. */
+static val_t prim_textual_port_p(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud; return vbool(vis_port(av[0]) && !port_is_binary(av[0]));
+}
+static val_t prim_binary_port_p(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud; return vbool(vis_port(av[0]) && port_is_binary(av[0]));
+}
+
+/* port-line: 1-based line of the next unread character -- already
+ * tracked internally (port_line, src/port.c) for the reader's own
+ * backtraces, just never exposed to Scheme before. Meaningful mainly
+ * for input ports; reported for any port rather than gated, since it's
+ * an honest "whatever the port's own counter currently says" rather
+ * than a guess. */
+static val_t prim_port_line(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_port(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "port-line: not a port");
+    return vfix(port_line(av[0]));
+}
+
+/* port-position: exact byte offset into the port's own backing store.
+ * String/bytevector ports (PORT_STRING) track this via TWO different
+ * fields depending on direction, not one shared "position" -- u.str.pos
+ * is exclusively the input read cursor (port_read_char/-byte advance
+ * it; never touched by a write); an output port instead grows
+ * u.str.len as content is appended and leaves pos permanently at 0
+ * (confirmed by reading port_write_char/port_write_string directly,
+ * not assumed -- an earlier version of this function used pos
+ * unconditionally and silently reported 0 for every output-port
+ * write). File-backed ports use ftell(3) -- #f (not -1, an ordinary
+ * Scheme integer that could be silently mistaken for a real position)
+ * on any stream ftell can't answer for (pipes, ttys, sockets), rather
+ * than raising -- "position isn't meaningful for this port" is a
+ * legitimate, expected answer here, not an error.
+ *
+ * A closed FILE*-backed port must be checked before touching u.fp at
+ * all: port_close (src/port.c) fclose()s the stream and sets u.fp to
+ * NULL for any non-std-stream port, but leaves PORT_STRING-flagged
+ * ports' union member untouched and never changes the object's own
+ * type tag -- port? still says true, so nothing upstream filters a
+ * closed port out before it reaches here. Calling ftell/fileno on a
+ * NULL FILE* segfaults (found by independent code review, confirmed
+ * live: closing a file port then calling port-position on it crashed
+ * the process -- directly reachable through ordinary
+ * (srfi 279) inspect-properties, no unsafe/FFI needed). #f for a
+ * closed port is the same "not meaningful here" answer already used
+ * for the ftell-fails and no-fd-at-all cases, not a new convention. */
+static val_t prim_port_position(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_port(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "port-position: not a port");
+    Port *p = as_port(av[0]);
+    if (p->flags & PORT_STRING)
+        return vfix((intptr_t)(p->flags & PORT_OUTPUT ? p->u.str.len : p->u.str.pos));
+    if ((p->flags & PORT_CLOSED) || !p->u.fp) return V_FALSE;
+    long pos = ftell(p->u.fp);
+    return pos >= 0 ? vfix((intptr_t)pos) : V_FALSE;
+}
+
+/* port-file-descriptor: the underlying OS fd for a FILE*-backed port
+ * (fileno(3)); #f for string/bytevector ports, which have no fd at
+ * all -- not an error, there's genuinely nothing to report. Same
+ * closed-port hazard as port-position above -- guarded the same way,
+ * before fileno() ever sees a NULL/dangling u.fp. */
+static val_t prim_port_file_descriptor(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_port(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "port-file-descriptor: not a port");
+    Port *p = as_port(av[0]);
+    if (p->flags & PORT_STRING) return V_FALSE;
+    if ((p->flags & PORT_CLOSED) || !p->u.fp) return V_FALSE;
+    int fd = fileno(p->u.fp);
+    return fd >= 0 ? vfix(fd) : V_FALSE;
+}
 static val_t prim_current_input_port(int ac, val_t *av, void *ud) {(void)ac;(void)av;(void)ud; return PORT_STDIN;}
 static val_t prim_current_output_port(int ac, val_t *av, void *ud) {(void)ac;(void)av;(void)ud; return PORT_STDOUT;}
 static val_t prim_current_error_port(int ac, val_t *av, void *ud) {(void)ac;(void)av;(void)ud; return PORT_STDERR;}
@@ -3178,6 +3255,9 @@ void builtins_register(val_t env) {
     DEF("close-output-port",prim_close_port,1,1);
     DEF("input-port?",prim_input_port_p,1,1); DEF("output-port?",prim_output_port_p,1,1);
     DEF("input-port-open?",prim_input_port_open_p,1,1); DEF("output-port-open?",prim_output_port_open_p,1,1);
+    DEF("textual-port?",prim_textual_port_p,1,1); DEF("binary-port?",prim_binary_port_p,1,1);
+    DEF("port-line",prim_port_line,1,1); DEF("port-position",prim_port_position,1,1);
+    DEF("port-file-descriptor",prim_port_file_descriptor,1,1);
     DEF("current-input-port",prim_current_input_port,0,0);
     DEF("current-output-port",prim_current_output_port,0,0);
     DEF("current-error-port",prim_current_error_port,0,0);

--- a/tests/srfi_s279_inspect_tests.scm
+++ b/tests/srfi_s279_inspect_tests.scm
@@ -452,5 +452,113 @@
   (inspect-properties char-set:title-case) 'char-set-name 'char-set:empty)
 (has "char-set: type" (inspect-properties char-set:empty) 'type 'char-set)
 
+;;; ════════════════════════════════════════════════════════════
+;;; § 18  port-properties
+;;; ════════════════════════════════════════════════════════════
+
+;; textual-port?/binary-port?/port-line/port-position/port-file-descriptor
+;; as standalone R7RS-style primitives, not just through inspect-properties.
+(check "textual-port? on a textual port" (textual-port? (open-output-string)) #t)
+(check "binary-port? on a textual port" (binary-port? (open-output-string)) #f)
+(check "binary-port? on a binary port" (binary-port? (open-output-bytevector)) #t)
+(check "textual-port? on a binary port" (textual-port? (open-output-bytevector)) #f)
+(check "port-line is a positive integer" (integer? (port-line (open-input-string "x"))) #t)
+(check "port-file-descriptor is #f for a string port"
+  (port-file-descriptor (open-output-string)) #f)
+
+;; Regression: a FILE*-backed port (open-input-file/open-output-file),
+;; open and healthy -- port-position/port-file-descriptor's ftell(3)/
+;; fileno(3) path, entirely untested until now (only string/bytevector
+;; ports were exercised above; found missing by independent code
+;; review alongside the closed-port crash below).
+(let* ((path "/tmp/curry-s279-port-test.txt")
+       (dummy1 (call-with-output-file path (lambda (p) (write-string "hello" p))))
+       (ip (open-input-file path)))
+  (check "port-file-descriptor is a real fd for an open file port"
+    (and (integer? (port-file-descriptor ip)) (>= (port-file-descriptor ip) 0)) #t)
+  (check "port-position is a real offset for an open file port (ftell path)"
+    (integer? (port-position ip)) #t)
+  (close-port ip)
+  (delete-file path))
+
+;; Regression (CRITICAL, found by independent code review AND
+;; independent security review, both flagging the exact same bug):
+;; port_close (src/port.c) fclose()s a non-std-stream FILE*-backed
+;; port and sets its u.fp to NULL -- but the port object itself is
+;; still port?-true (closing doesn't change the type tag), so nothing
+;; upstream filters it out. The FIRST version of port-position/
+;; port-file-descriptor called ftell(3)/fileno(3) directly on that now-
+;; NULL FILE* with no PORT_CLOSED check at all -- an unconditional
+;; NULL-pointer dereference, verified live to segfault the whole
+;; process (exit 139), reachable from ordinary Scheme code with no
+;; unsafe/FFI involved, including transitively through plain
+;; inspect-properties/inspect-describe on a closed port (an entirely
+;; ordinary thing to introspect, e.g. debugging why/when a port
+;; closed). Must return #f, not crash.
+(let* ((path "/tmp/curry-s279-port-closed-test.txt")
+       (dummy1 (call-with-output-file path (lambda (p) (write-string "x" p))))
+       (ip (open-input-file path))
+       (dummy2 (close-port ip)))
+  (check "port-position on a closed file port returns #f, does not crash"
+    (port-position ip) #f)
+  (check "port-file-descriptor on a closed file port returns #f, does not crash"
+    (port-file-descriptor ip) #f)
+  (check "inspect-properties on a closed file port does not crash"
+    (integer? (length (inspect-properties ip))) #t)
+  (has "port(closed): port-open? is #f" (inspect-properties ip) 'port-open? #f)
+  (lacks "port(closed): no port-position" (inspect-properties ip) 'port-position)
+  (lacks "port(closed): no port-file-descriptor" (inspect-properties ip) 'port-file-descriptor)
+  (delete-file path))
+
+;; Regression: output string ports track position via u.str.len (bytes
+;; written so far), NOT u.str.pos (which is exclusively the INPUT read
+;; cursor and stays 0 for an output port no matter how much is
+;; written) -- an earlier version of port-position used pos
+;; unconditionally and silently reported 0 after every write.
+(let ((op (open-output-string)))
+  (check "port-position starts at 0 for a fresh output string port" (port-position op) 0)
+  (write-string "hello" op)
+  (check "port-position reflects bytes actually written" (port-position op) 5))
+
+;; port-position for an input string port: the read cursor, distinct
+;; from output's write-length tracking above.
+(let ((ip (open-input-string "hello world")))
+  (check "port-position starts at 0 for a fresh input string port" (port-position ip) 0)
+  (read-char ip) (read-char ip)
+  (check "port-position advances as chars are read" (port-position ip) 2))
+
+;; Input string port properties
+(let ((p (inspect-properties (open-input-string "x"))))
+  (has   "port(input): port-open?" p 'port-open? #t)
+  (has   "port(input): port-direction" p 'port-direction 'input)
+  (has   "port(input): port-type" p 'port-type 'textual)
+  (has   "port(input): port-encoding" p 'port-encoding 'UTF-8)
+  (lacks "port(input): no get-output-string (SRFI-279 specifies this for OUTPUT ports only, even though curry's own get-output-string primitive doesn't itself enforce that direction)"
+    p 'get-output-string)
+  (lacks "port(input): no port-buffer either, same reasoning" p 'port-buffer)
+  (lacks "port(input): no port-file (curry never stores the opening path)" p 'port-file)
+  (lacks "port(input): no port-column (curry never tracks it)" p 'port-column))
+
+;; Output string port properties
+(let* ((op (open-output-string))
+       (dummy (write-string "abc" op))
+       (p (inspect-properties op)))
+  (has "port(output-string): port-direction" p 'port-direction 'output)
+  (has "port(output-string): port-position after writing" p 'port-position 3)
+  (has "port(output-string): port-buffer mirrors get-output-string" p 'port-buffer "abc")
+  (has "port(output-string): get-output-string" p 'get-output-string "abc")
+  (lacks "port(output-string): no get-output-bytevector for a textual port" p 'get-output-bytevector))
+
+;; Output bytevector port properties
+(let* ((bop (open-output-bytevector))
+       (dummy (write-u8 65 bop))
+       (p (inspect-properties bop)))
+  (has   "port(output-bytevector): port-type" p 'port-type 'binary)
+  (has   "port(output-bytevector): get-output-bytevector" p 'get-output-bytevector (bytevector 65))
+  (lacks "port(output-bytevector): no port-encoding for a binary port" p 'port-encoding)
+  (lacks "port(output-bytevector): no get-output-string for a binary port" p 'get-output-string))
+
+(has "port(input): type" (inspect-properties (open-input-string "x")) 'type 'port)
+
 (display (string-append (number->string pass) " passed, " (number->string fail) " failed")) (newline)
 (if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

Closes the "ports" gap from the SRFI-279 gap list.

- New standalone primitives, genuinely useful beyond just this SRFI: `textual-port?`/`binary-port?` (real R7RS §6.13.1 procedures curry previously had no way to call at all), `port-line`, `port-position`, `port-file-descriptor`.
- Wired into `(srfi 279)`'s `inspect-properties` as `%port-properties`: `port-open?`, `port-direction`, `port-type`, `port-line`, `port-position`, `port-file-descriptor`, `port-encoding` (fixed `'UTF-8` — curry really is UTF-8-only), `port-buffer`, `get-output-string`/`get-output-bytevector`. `port-file`/`port-column` omitted entirely — curry's `Port` struct never tracks either.
- One design note: curry's own pre-existing `get-output-string`/`get-output-bytevector` don't check port direction internally (calling them on an *input* string port doesn't raise, just returns the input content) — `%port-properties` gates these and `port-buffer` on `(output-port? object)` explicitly in Scheme, rather than trusting curry's own primitives to enforce that boundary.

Independently code-reviewed and security-reviewed (fresh subagents, no shared context). **Both independently found the same critical bug**: `port-position`/`port-file-descriptor` called `ftell(3)`/`fileno(3)` directly on a closed FILE*-backed port's `FILE*`, which `port_close()` sets to `NULL` — an unguarded NULL dereference, verified live to reliably segfault the process, reachable from ordinary Scheme code (including transitively through plain `inspect-properties`/`inspect-describe` on a closed port). Fixed by checking `PORT_CLOSED` before either libc call. A second, related bug was also fixed: `port-position` originally used the string port's read-cursor field unconditionally, which is exclusively an input cursor — an output port's position silently stayed 0 after every write.

## Test plan

- [x] `./build/curry tests/srfi_s279_inspect_tests.scm` — 191/191 pass (41 new checks, including regression coverage for both fixed bugs — the closed-port crash and the output-position field bug — plus new coverage for real FILE*-backed ports, a gap the reviews flagged since the original suite only tested string/bytevector ports)
- [x] Full suite: `ctest --test-dir build -j4` — 92/92 pass
- [x] Independent code review (fresh subagent) — critical crash bug found and fixed
- [x] Independent security review (fresh subagent) — same critical crash bug found and fixed (confirmed independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
