### PR TITLE
feat(typedvec): SRFI-4 core typed vectors (u8..s64) + (srfi 4) wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ endif()
 # ---- Optional modules (shared libraries loaded at runtime) ----
 
 option(BUILD_MODULE_F64VECTOR "Build f64vector typed numeric array module" ON)
+option(BUILD_MODULE_TYPEDVEC  "Build typedvec module (SRFI-4 u8/s8/u16/s16/u32/s32/u64/s64 vectors)" ON)
 option(BUILD_MODULE_JSON      "Build JSON module"                  ON)
 option(BUILD_MODULE_SQLITE    "Build SQLite module"                ON)
 option(BUILD_MODULE_NETWORK   "Build network module"               ON)
@@ -389,6 +390,12 @@ if(BUILD_MODULE_F64VECTOR)
   curry_c_module(f64vector)
   target_link_libraries(curry_f64vector PRIVATE m)
   message(STATUS "Building f64vector module (typed double[] arrays)")
+endif()
+
+if(BUILD_MODULE_TYPEDVEC)
+  curry_c_module(typedvec)
+  target_link_libraries(curry_typedvec PRIVATE ${GMP_LIB})
+  message(STATUS "Building typedvec module (SRFI-4 u8/s8/u16/s16/u32/s32/u64/s64 vectors)")
 endif()
 
 if(BUILD_MODULE_JSON)

--- a/docs/reference/module-typedvec.md
+++ b/docs/reference/module-typedvec.md
@@ -1,0 +1,70 @@
+# Module: (curry typedvec)
+
+SRFI-4 core homogeneous numeric vectors for 8 integer kinds: `u8`, `s8`, `u16`, `s16`, `u32`, `s32`, `u64`, `s64`. One C module, one GC heap type (`T_TYPEDVEC`), one generic set of C functions parameterized over element kind — not 8 hand-duplicated implementations.
+
+`f64vector` is deliberately **not** part of this module — curry already ships a separate, more capable `(curry f64vector)` module with its own numeric-computation surface (`f64vector-dot`, `-map`, element-wise trig/exp/log, etc). [`(srfi s4 uniform-vectors)`](srfi/s4.md) (and its `(srfi 4)`/`(srfi srfi-4)` shims) combine both modules' basic SRFI-4 operations into one import; use `(curry f64vector)` directly for its extended numeric surface. There is no `f32vector`: curry's numeric tower has no native single-precision float representation to back it with.
+
+Build flag: `-DBUILD_MODULE_TYPEDVEC=ON` (default `ON`).
+
+## Import
+
+```scheme
+(import (curry typedvec))
+```
+
+Or, for the combined SRFI-4 surface including `f64vector`:
+
+```scheme
+(import (srfi 4))
+```
+
+## Per-kind operations
+
+Every kind `TAG` in `{u8, s8, u16, s16, u32, s32, u64, s64}` gets the same 12 procedures:
+
+| Procedure | Arity | Description |
+|---|---|---|
+| `(make-TAGvector n [fill])` | 1–2 | New vector of `n` elements, `fill` (default 0) |
+| `(TAGvector x ...)` | 0+ | New vector from the given elements |
+| `(TAGvector? obj)` | 1 | `#t` iff `obj` is a `TAGvector` (kind-specific — a `u8vector` is not `s8vector?`) |
+| `(TAGvector-length v)` | 1 | Element count |
+| `(TAGvector-ref v i)` | 2 | Element at index `i`; raises on out-of-bounds |
+| `(TAGvector-set! v i x)` | 3 | Set element `i` to `x`; raises if `x` is out of the kind's representable range or not an exact integer |
+| `(TAGvector->list v [start [end]])` | 1–3 | Elements as a list |
+| `(list->TAGvector lst)` | 1 | New vector from a list |
+| `(TAGvector-copy v [start [end]])` | 1–3 | Copy of a sub-range (default: the whole vector) |
+| `(TAGvector-copy! to at from [start [end]])` | 3–5 | Copy a sub-range of `from` into `to` starting at index `at` |
+| `(TAGvector-append v ...)` | 0+ | Concatenation of all given vectors of the same kind |
+| `(TAGvector-fill! v x [start [end]])` | 2–4 | Fill a sub-range with `x` |
+
+## Range checking and the numeric tower
+
+`TAGvector-set!` validates both type (must be an exact integer) and range against the kind's representable bounds — e.g. `(u8vector-set! v 0 300)` and `(u8vector-set! v 0 -1)` both raise, since `u8` is `[0, 255]`.
+
+`u64`/`s64` elements are read back through curry's numeric tower, not truncated to fixnum/`long`: values exceeding `FIXNUM_MAX`/`long` range (including all of `u64`'s upper half, past `INT64_MAX`) come back as exact bignums.
+
+```scheme
+(define v (u64vector 18446744073709551615))  ; UINT64_MAX
+(u64vector-ref v 0)   ; => 18446744073709551615, an exact bignum
+(integer? (u64vector-ref v 0))  ; => #t
+```
+
+## External representation
+
+`write`/`display` produce a `#TAG(...)` form, one per kind, mirroring `(curry f64vector)`'s existing `#f64(...)`:
+
+```scheme
+(display (u8vector 1 2 3))                          ; #u8(1 2 3)
+(display (s64vector -9223372036854775808 5))         ; #s64(-9223372036854775808 5)
+```
+
+This is a printed *representation*, not a reader syntax — there is no `#u8(...)` literal in the reader (R7RS's `#u8(...)` bytevector literal is unrelated and produces a `bytevector`, a different type, not a `u8vector`).
+
+## GC
+
+Typed vectors are allocated atomically (`gc_alloc_atomic`) — the element bytes are never scanned for pointers, matching every other flat numeric buffer type in curry (`F64Vec`, `Bytevector`, `String`). Supported under both the default Boehm backend and the experimental `--gc generational` backend (`src/gc_gen.c` has explicit `T_TYPEDVEC` cases for size computation and marking it pointer-free).
+
+## See also
+
+- [`srfi/s4.md`](srfi/s4.md) — the combined SRFI-4 library (this module + `(curry f64vector)`)
+- [`srfi/index.md`](srfi/index.md) — full SRFI availability table

--- a/docs/reference/module-typedvec.md
+++ b/docs/reference/module-typedvec.md
@@ -51,14 +51,14 @@ Every kind `TAG` in `{u8, s8, u16, s16, u32, s32, u64, s64}` gets the same 12 pr
 
 ## External representation
 
-`write`/`display` produce a `#TAG(...)` form, one per kind, mirroring `(curry f64vector)`'s existing `#f64(...)`:
+`write`/`display` produce a `#TAGvec(...)` form, one per kind:
 
 ```scheme
-(display (u8vector 1 2 3))                          ; #u8(1 2 3)
-(display (s64vector -9223372036854775808 5))         ; #s64(-9223372036854775808 5)
+(display (u8vector 1 2 3))                          ; #u8vec(1 2 3)
+(display (s64vector -9223372036854775808 5))         ; #s64vec(-9223372036854775808 5)
 ```
 
-This is a printed *representation*, not a reader syntax — there is no `#u8(...)` literal in the reader (R7RS's `#u8(...)` bytevector literal is unrelated and produces a `bytevector`, a different type, not a `u8vector`).
+This is a printed *representation*, not reader syntax — reading `#u8vec(...)`/`#s8vec(...)`/etc back raises a clean read-error rather than reconstructing a typed vector (matching `(curry f64vector)`'s own `#f64(...)`, which has the same limitation). The suffix is deliberate, not cosmetic: the bare prefix `#u8(...)` is already R7RS bytevector reader syntax (a *different* type), and bare `#s...` is already curry's sexagesimal-number reader syntax — reusing either would make `write` followed by `read` either silently produce the wrong type or silently corrupt the rest of the read stream, instead of failing loudly.
 
 ## GC
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -59,6 +59,7 @@ The full list of `(curry ...)` modules. Optional modules that need an external l
 | [mariadb](module-mariadb.md) | `(curry mariadb)` | MariaDB/MySQL client *(pure Scheme + FFI, no build step)* | `libmariadb`/`libmysqlclient` installed at runtime (`-DBUILD_FFI=ON`) |
 | [postgres](module-postgres.md) | `(curry postgres)` | PostgreSQL client *(pure Scheme + FFI, no build step)* | `libpq` installed at runtime (`-DBUILD_FFI=ON`) |
 | [tts](module-tts.md) | `(curry tts)` | Cross-backend text-to-speech — macOS (`say`) and Linux (`espeak-ng`/`espeak`) *(pure Scheme, no build step)* | `(curry posix)`, `(curry conditions)`; `say` or `espeak-ng`/`espeak` installed at runtime |
+| [typedvec](module-typedvec.md) | `(curry typedvec)` | SRFI-4 core typed numeric vectors: u8/s8/u16/s16/u32/s32/u64/s64vector | — |
 
 ## See also
 

--- a/docs/reference/srfi/index.md
+++ b/docs/reference/srfi/index.md
@@ -30,6 +30,7 @@ The same import-collision caveat as `(srfi N)` above applies identically here (i
 | Library | SRFI | Description |
 |---------|------|-------------|
 | [`(srfi s1 lists)`](s1.md) | [SRFI-1](https://srfi.schemers.org/srfi-1/) | List library |
+| [`(srfi s4 uniform-vectors)`](s4.md) | [SRFI-4](https://srfi.schemers.org/srfi-4/) | Homogeneous numeric vectors — u8/s8/u16/s16/u32/s32/u64/s64vector from `(curry typedvec)` plus f64vector from `(curry f64vector)`; no f32vector (curry's numeric tower has no native single-precision type) |
 | [`(srfi s8 receive)`](s8.md) | [SRFI-8](https://srfi.schemers.org/srfi-8/) | `receive` multiple-values binding macro — shadows curry's own actor `receive` special form when imported |
 | [`(srfi s14 char-sets)`](s14.md) | [SRFI-14](https://srfi.schemers.org/srfi-14/) | Character sets — construction, iteration, set algebra, and the standard predefined sets (`char-set:letter`, `char-set:whitespace`, etc), backed by a sorted-range representation over curry's full Unicode codepoint space |
 | [`(srfi s18 multithreading)`](s18.md) | [SRFI-18](https://srfi.schemers.org/srfi-18/) | Thread/mutex/condition-variable naming over curry's actor `spawn` and `(curry sync)` |

--- a/docs/reference/srfi/s4.md
+++ b/docs/reference/srfi/s4.md
@@ -1,0 +1,21 @@
+# `(srfi s4 uniform-vectors)` — SRFI-4 homogeneous numeric vectors
+
+```scheme
+(import (srfi s4 uniform-vectors))
+```
+
+Thin re-export combining two C modules into one [SRFI-4](https://srfi.schemers.org/srfi-4/) surface: the 8 integer kinds (`u8`/`s8`/`u16`/`s16`/`u32`/`s32`/`u64`/`s64`vector) from `(curry typedvec)`, and `f64vector` from the separate, pre-existing `(curry f64vector)` module — see [`../module-typedvec.md`](../module-typedvec.md) for the full per-kind API. `(curry f64vector)` predates this library and has no doc page of its own yet; its source (with its larger numeric-computation surface) is `modules/f64vector/f64vector.c`.
+
+Only `make-TAGvector`, `TAGvector`, `TAGvector?`, `TAGvector-length`, `TAGvector-ref`, `TAGvector-set!`, `TAGvector->list`, `list->TAGvector`, `TAGvector-copy`, `TAGvector-copy!`, `TAGvector-append`, and `TAGvector-fill!` are re-exported for each kind — the classic SRFI-4 operation set, not `(curry f64vector)`'s much larger numeric-computation surface (`f64vector-dot`, `-map`, `-sum`, trig/exp/log element-wise ops, etc), which stays available only via a direct `(import (curry f64vector))`.
+
+`f64vector-copy!` and `f64vector-append` are **not** re-exported: `(curry f64vector)` has no such procedures (only `f64vector-copy`), so this library re-exports what actually exists rather than adding new C-level operations just for SRFI-4 symmetry.
+
+No `f32vector`: curry's numeric tower has no native single-precision float representation to back it with.
+
+`u8vector`/`s8vector`/.../`s64vector` require `-DBUILD_MODULE_TYPEDVEC=ON` (the default); `f64vector` requires `-DBUILD_MODULE_F64VECTOR=ON` (also the default).
+
+## See also
+
+- [`index.md`](index.md) — full SRFI availability table
+- [`../module-typedvec.md`](../module-typedvec.md) — the underlying `(curry typedvec)` module (u8..s64)
+- Bare `(srfi 4)` and `(srfi srfi-4)` shims re-export the same bindings

--- a/lib/curry/modules/srfi/4.scm
+++ b/lib/curry/modules/srfi/4.scm
@@ -1,0 +1,38 @@
+(define-library (srfi 4)
+  (import (srfi s4 uniform-vectors))
+  (export
+    make-u8vector u8vector u8vector? u8vector-length u8vector-ref
+    u8vector-set! u8vector->list list->u8vector u8vector-copy
+    u8vector-copy! u8vector-append u8vector-fill!
+
+    make-s8vector s8vector s8vector? s8vector-length s8vector-ref
+    s8vector-set! s8vector->list list->s8vector s8vector-copy
+    s8vector-copy! s8vector-append s8vector-fill!
+
+    make-u16vector u16vector u16vector? u16vector-length u16vector-ref
+    u16vector-set! u16vector->list list->u16vector u16vector-copy
+    u16vector-copy! u16vector-append u16vector-fill!
+
+    make-s16vector s16vector s16vector? s16vector-length s16vector-ref
+    s16vector-set! s16vector->list list->s16vector s16vector-copy
+    s16vector-copy! s16vector-append s16vector-fill!
+
+    make-u32vector u32vector u32vector? u32vector-length u32vector-ref
+    u32vector-set! u32vector->list list->u32vector u32vector-copy
+    u32vector-copy! u32vector-append u32vector-fill!
+
+    make-s32vector s32vector s32vector? s32vector-length s32vector-ref
+    s32vector-set! s32vector->list list->s32vector s32vector-copy
+    s32vector-copy! s32vector-append s32vector-fill!
+
+    make-u64vector u64vector u64vector? u64vector-length u64vector-ref
+    u64vector-set! u64vector->list list->u64vector u64vector-copy
+    u64vector-copy! u64vector-append u64vector-fill!
+
+    make-s64vector s64vector s64vector? s64vector-length s64vector-ref
+    s64vector-set! s64vector->list list->s64vector s64vector-copy
+    s64vector-copy! s64vector-append s64vector-fill!
+
+    make-f64vector f64vector f64vector? f64vector-length f64vector-ref
+    f64vector-set! f64vector->list list->f64vector f64vector-copy
+    f64vector-fill!))

--- a/lib/curry/modules/srfi/s4/uniform-vectors.scm
+++ b/lib/curry/modules/srfi/s4/uniform-vectors.scm
@@ -1,0 +1,51 @@
+(define-library (srfi s4 uniform-vectors)
+  (import (curry typedvec) (curry f64vector) (scheme base))
+  (export
+    make-u8vector u8vector u8vector? u8vector-length u8vector-ref
+    u8vector-set! u8vector->list list->u8vector u8vector-copy
+    u8vector-copy! u8vector-append u8vector-fill!
+
+    make-s8vector s8vector s8vector? s8vector-length s8vector-ref
+    s8vector-set! s8vector->list list->s8vector s8vector-copy
+    s8vector-copy! s8vector-append s8vector-fill!
+
+    make-u16vector u16vector u16vector? u16vector-length u16vector-ref
+    u16vector-set! u16vector->list list->u16vector u16vector-copy
+    u16vector-copy! u16vector-append u16vector-fill!
+
+    make-s16vector s16vector s16vector? s16vector-length s16vector-ref
+    s16vector-set! s16vector->list list->s16vector s16vector-copy
+    s16vector-copy! s16vector-append s16vector-fill!
+
+    make-u32vector u32vector u32vector? u32vector-length u32vector-ref
+    u32vector-set! u32vector->list list->u32vector u32vector-copy
+    u32vector-copy! u32vector-append u32vector-fill!
+
+    make-s32vector s32vector s32vector? s32vector-length s32vector-ref
+    s32vector-set! s32vector->list list->s32vector s32vector-copy
+    s32vector-copy! s32vector-append s32vector-fill!
+
+    make-u64vector u64vector u64vector? u64vector-length u64vector-ref
+    u64vector-set! u64vector->list list->u64vector u64vector-copy
+    u64vector-copy! u64vector-append u64vector-fill!
+
+    make-s64vector s64vector s64vector? s64vector-length s64vector-ref
+    s64vector-set! s64vector->list list->s64vector s64vector-copy
+    s64vector-copy! s64vector-append s64vector-fill!
+
+    make-f64vector f64vector f64vector? f64vector-length f64vector-ref
+    f64vector-set! f64vector->list list->f64vector f64vector-copy
+    f64vector-fill!)
+  (begin
+    ; u8/s8/.../s64 come from (curry typedvec) (modules/typedvec/typedvec.c,
+    ; one generic C implementation parameterized over 8 element kinds);
+    ; f64vector comes from the separate, pre-existing (curry f64vector)
+    ; module (which also has a much larger numeric-computation surface --
+    ; f64vector-dot, -map, -sum, etc -- not part of SRFI-4 and deliberately
+    ; not re-exported here). f64vector has no -copy!/-append counterpart
+    ; in that module, so SRFI-4's f64vector-copy!/f64vector-append are not
+    ; available through this library -- only what's actually implemented
+    ; is re-exported, per the s170/posix.scm precedent in this codebase.
+    ; f32vector is not part of this library: curry's numeric tower has no
+    ; native single-precision float representation to back it with.
+    ))

--- a/lib/curry/modules/srfi/srfi-4.scm
+++ b/lib/curry/modules/srfi/srfi-4.scm
@@ -1,0 +1,38 @@
+(define-library (srfi srfi-4)
+  (import (srfi s4 uniform-vectors))
+  (export
+    make-u8vector u8vector u8vector? u8vector-length u8vector-ref
+    u8vector-set! u8vector->list list->u8vector u8vector-copy
+    u8vector-copy! u8vector-append u8vector-fill!
+
+    make-s8vector s8vector s8vector? s8vector-length s8vector-ref
+    s8vector-set! s8vector->list list->s8vector s8vector-copy
+    s8vector-copy! s8vector-append s8vector-fill!
+
+    make-u16vector u16vector u16vector? u16vector-length u16vector-ref
+    u16vector-set! u16vector->list list->u16vector u16vector-copy
+    u16vector-copy! u16vector-append u16vector-fill!
+
+    make-s16vector s16vector s16vector? s16vector-length s16vector-ref
+    s16vector-set! s16vector->list list->s16vector s16vector-copy
+    s16vector-copy! s16vector-append s16vector-fill!
+
+    make-u32vector u32vector u32vector? u32vector-length u32vector-ref
+    u32vector-set! u32vector->list list->u32vector u32vector-copy
+    u32vector-copy! u32vector-append u32vector-fill!
+
+    make-s32vector s32vector s32vector? s32vector-length s32vector-ref
+    s32vector-set! s32vector->list list->s32vector s32vector-copy
+    s32vector-copy! s32vector-append s32vector-fill!
+
+    make-u64vector u64vector u64vector? u64vector-length u64vector-ref
+    u64vector-set! u64vector->list list->u64vector u64vector-copy
+    u64vector-copy! u64vector-append u64vector-fill!
+
+    make-s64vector s64vector s64vector? s64vector-length s64vector-ref
+    s64vector-set! s64vector->list list->s64vector s64vector-copy
+    s64vector-copy! s64vector-append s64vector-fill!
+
+    make-f64vector f64vector f64vector? f64vector-length f64vector-ref
+    f64vector-set! f64vector->list list->f64vector f64vector-copy
+    f64vector-fill!))

--- a/modules/typedvec/typedvec.c
+++ b/modules/typedvec/typedvec.c
@@ -80,8 +80,11 @@ static void tv_range(int ac, val_t *av, int start_idx, uint32_t len,
      * (one past the last element, the valid "whole rest" case) pass;
      * a true out-of-range end is caught by the *end > len check below. */
     if (*start > len) curry_error("%s: start out of range", ctx);
-    *end = ac > start_idx + 1 ? (uint32_t)vunfix(av[start_idx + 1]) : len;
-    if (!(ac > start_idx + 1) ) *end = len;
+    if (ac > start_idx + 1) {
+        *end = tv_idx(av[start_idx + 1], len + 1, ctx);
+    } else {
+        *end = len;
+    }
     if (*end > len || *end < *start)
         curry_error("%s: end out of range", ctx);
 }
@@ -198,7 +201,8 @@ static val_t fn_make_typedvector(int ac, val_t *av, void *ud) {
     TVKind kind = ud_kind(ud);
     if (!vis_fixnum(av[0])) curry_error("make-%svector: length must be fixnum", TV_INFO[kind].prefix);
     intptr_t n = vunfix(av[0]);
-    if (n < 0) curry_error("make-%svector: negative length", TV_INFO[kind].prefix);
+    if (n < 0 || n > (intptr_t)UINT32_MAX)
+        curry_error("make-%svector: length out of range", TV_INFO[kind].prefix);
     val_t r = alloc_typedvec(kind, (uint32_t)n);
     if (ac > 1) {
         TypedVec *tv = as_typedvec(r);
@@ -296,11 +300,11 @@ static val_t fn_typedvector_copy_bang(int ac, val_t *av, void *ud) {
     /* tv_range's start_idx counts from av[0]; here the optional
      * start/end refer to `from` and begin at av[3]/av[4]. */
     uint32_t fstart = ac > 3 ? tv_idx(av[3], from->len + 1, ctx) : 0;
-    uint32_t fend   = ac > 4 ? (uint32_t)vunfix(av[4]) : from->len;
+    uint32_t fend   = ac > 4 ? tv_idx(av[4], from->len + 1, ctx) : from->len;
     if (fend > from->len || fend < fstart) curry_error("%s: end out of range", ctx);
     start = fstart; end = fend;
     uint32_t n = end - start;
-    if (at + n > to->len) curry_error("%s: destination too short", ctx);
+    if ((size_t)at + (size_t)n > (size_t)to->len) curry_error("%s: destination too short", ctx);
     memmove(to->data + (size_t)at * tv_elem_size(kind),
             from->data + (size_t)start * tv_elem_size(kind),
             (size_t)n * tv_elem_size(kind));
@@ -310,9 +314,10 @@ static val_t fn_typedvector_copy_bang(int ac, val_t *av, void *ud) {
 static val_t fn_typedvector_append(int ac, val_t *av, void *ud) {
     TVKind kind = ud_kind(ud);
     char ctx[24]; snprintf(ctx, sizeof(ctx), "%svector-append", TV_INFO[kind].prefix);
-    uint32_t total = 0;
-    for (int i = 0; i < ac; i++) total += get_tv(av[i], kind, ctx)->len;
-    val_t r = alloc_typedvec(kind, total);
+    uint64_t total = 0;
+    for (int i = 0; i < ac; i++) total += (uint64_t)get_tv(av[i], kind, ctx)->len;
+    if (total > UINT32_MAX) curry_error("%s: combined length too large", ctx);
+    val_t r = alloc_typedvec(kind, (uint32_t)total);
     uint8_t *out = as_typedvec(r)->data;
     for (int i = 0; i < ac; i++) {
         TypedVec *tv = as_typedvec(av[i]);

--- a/modules/typedvec/typedvec.c
+++ b/modules/typedvec/typedvec.c
@@ -1,0 +1,358 @@
+/* typedvec.c — SRFI-4 homogeneous numeric vector datatypes: u8vector,
+ * s8vector, u16vector, s16vector, u32vector, s32vector, u64vector,
+ * s64vector. (curry f64vector, a separate pre-existing module with a
+ * much larger BLAS-flavored operation set, already covers f64vector --
+ * see object.h's TVKind comment for why that ninth SRFI-4 type is
+ * deliberately not duplicated here.)
+ *
+ * One shared TypedVec struct backs all 8 kinds (object.h) rather than
+ * 8 separate structs/ObjTypes; the operations below are similarly
+ * generic, parameterized by TVKind passed through curry_define_fn's
+ * `ud` argument rather than hand-duplicated 8 times each.
+ *
+ * (import (srfi 4))
+ */
+
+#include <curry.h>
+#include "object.h"
+#include "gc.h"
+#include "numeric.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <gmp.h>
+
+/* ---- kind metadata ---- */
+
+typedef struct {
+    const char *prefix;   /* "u8", "s8", ... */
+    bool        is_signed;
+    int64_t     min;      /* only meaningful when is_signed */
+    uint64_t    max;      /* signed: max positive value; unsigned: max value */
+} TVKindInfo;
+
+static const TVKindInfo TV_INFO[8] = {
+    [TV_U8]  = { "u8",  false, 0,               UINT8_MAX  },
+    [TV_S8]  = { "s8",  true,  INT8_MIN,        INT8_MAX   },
+    [TV_U16] = { "u16", false, 0,               UINT16_MAX },
+    [TV_S16] = { "s16", true,  INT16_MIN,       INT16_MAX  },
+    [TV_U32] = { "u32", false, 0,               UINT32_MAX },
+    [TV_S32] = { "s32", true,  INT32_MIN,       INT32_MAX  },
+    [TV_U64] = { "u64", false, 0,               UINT64_MAX },
+    [TV_S64] = { "s64", true,  INT64_MIN,       INT64_MAX  },
+};
+
+static TVKind ud_kind(void *ud) { return (TVKind)(intptr_t)ud; }
+
+/* ---- allocation ---- */
+
+static val_t alloc_typedvec(TVKind kind, uint32_t n) {
+    uint32_t esz = tv_elem_size(kind);
+    TypedVec *tv = (TypedVec *)gc_alloc_atomic(sizeof(TypedVec) + (size_t)n * esz);
+    tv->hdr.type  = T_TYPEDVEC;
+    tv->hdr.flags = (uint32_t)kind;
+    tv->len = n;
+    memset(tv->data, 0, (size_t)n * esz);
+    return vptr(tv);
+}
+
+static TypedVec *get_tv(val_t v, TVKind kind, const char *ctx) {
+    if (!vis_typedvec(v) || (TVKind)as_typedvec(v)->hdr.flags != kind)
+        curry_error("%s: expected %svector", ctx, TV_INFO[kind].prefix);
+    return as_typedvec(v);
+}
+
+static uint32_t tv_idx(val_t v, uint32_t len, const char *ctx) {
+    if (!vis_fixnum(v)) curry_error("%s: expected fixnum index", ctx);
+    intptr_t i = vunfix(v);
+    if (i < 0 || (uint32_t)i >= len)
+        curry_error("%s: index %ld out of range [0, %u)", ctx, (long)i, (unsigned)len);
+    return (uint32_t)i;
+}
+
+/* start/end pair shared by ->list, copy, copy!, fill! -- defaults to
+ * the whole vector when the optional argument(s) are absent. */
+static void tv_range(int ac, val_t *av, int start_idx, uint32_t len,
+                      const char *ctx, uint32_t *start, uint32_t *end) {
+    *start = ac > start_idx ? tv_idx(av[start_idx], len + 1, ctx) : 0;
+    /* tv_idx's own upper bound is exclusive and len+1 lets `end == len`
+     * (one past the last element, the valid "whole rest" case) pass;
+     * a true out-of-range end is caught by the *end > len check below. */
+    if (*start > len) curry_error("%s: start out of range", ctx);
+    *end = ac > start_idx + 1 ? (uint32_t)vunfix(av[start_idx + 1]) : len;
+    if (!(ac > start_idx + 1) ) *end = len;
+    if (*end > len || *end < *start)
+        curry_error("%s: end out of range", ctx);
+}
+
+/* ---- element get/set: the numeric-tower <-> raw-bytes boundary ---- */
+
+static val_t tv_get(TypedVec *tv, uint32_t i) {
+    TVKind k = (TVKind)tv->hdr.flags;
+    const uint8_t *p = tv->data + (size_t)i * tv_elem_size(k);
+    switch (k) {
+        case TV_U8:  return vfix(*(const uint8_t  *)p);
+        case TV_S8:  return vfix(*(const int8_t   *)p);
+        case TV_U16: { uint16_t x; memcpy(&x,p,2); return vfix(x); }
+        case TV_S16: { int16_t  x; memcpy(&x,p,2); return vfix(x); }
+        case TV_U32: { uint32_t x; memcpy(&x,p,4); return vfix((intptr_t)x); }
+        case TV_S32: { int32_t  x; memcpy(&x,p,4); return vfix(x); }
+        case TV_S64: {
+            int64_t x; memcpy(&x,p,8);
+            if (in_fixnum_range(x)) return vfix((intptr_t)x);
+            return num_make_bignum_i((long)x); /* long == int64_t on curry's supported platforms */
+        }
+        case TV_U64: {
+            uint64_t x; memcpy(&x,p,8);
+            if (x <= (uint64_t)FIXNUM_MAX) return vfix((intptr_t)x);
+            if (x <= (uint64_t)INT64_MAX) return num_make_bignum_i((long)x);
+            /* Top bit set: exceeds signed long's range entirely --
+             * num_make_bignum_i has no unsigned counterpart, so build
+             * the bignum via GMP directly rather than round-tripping
+             * through a decimal string (correct either way; this just
+             * avoids the snprintf+reparse for what's still a plausible,
+             * not exotic, value for a real u64vector). */
+            { mpz_t z; mpz_init(z); mpz_set_ui(z, (unsigned long)(x >> 32));
+              mpz_mul_2exp(z, z, 32); mpz_add_ui(z, z, (unsigned long)(x & 0xFFFFFFFFu));
+              char *s = mpz_get_str(NULL, 10, z); mpz_clear(z);
+              val_t r = num_make_bignum_str(s, 10); free(s); return r; }
+        }
+    }
+    return V_FALSE; /* unreachable */
+}
+
+/* Reads an exact-integer val_t into a signed int64_t range check
+ * against [lo, hi], raising a clear error on the wrong type or an
+ * out-of-range value rather than silently truncating. */
+static int64_t tv_check_signed(val_t v, int64_t lo, int64_t hi, const char *ctx) {
+    if (vis_fixnum(v)) {
+        intptr_t x = vunfix(v);
+        if (x < lo || x > hi) curry_error("%s: value %ld out of range", ctx, (long)x);
+        return x;
+    }
+    if (vis_bignum(v)) {
+        if (!mpz_fits_slong_p(as_big(v)->z))
+            curry_error("%s: value out of range", ctx);
+        long x = mpz_get_si(as_big(v)->z);
+        if (x < lo || x > hi) curry_error("%s: value %ld out of range", ctx, x);
+        return x;
+    }
+    curry_error("%s: expected an exact integer", ctx);
+    return 0; /* unreachable */
+}
+
+/* Same, but for the unsigned kinds (u8/u16/u32/u64) -- checked
+ * against [0, hi] as a uint64_t, since u64's own range exceeds what a
+ * signed int64_t comparison could represent without ambiguity. */
+static uint64_t tv_check_unsigned(val_t v, uint64_t hi, const char *ctx) {
+    if (vis_fixnum(v)) {
+        intptr_t x = vunfix(v);
+        if (x < 0 || (uint64_t)x > hi) curry_error("%s: value %ld out of range", ctx, (long)x);
+        return (uint64_t)x;
+    }
+    if (vis_bignum(v)) {
+        if (mpz_sgn(as_big(v)->z) < 0) curry_error("%s: value out of range (negative)", ctx);
+        if (mpz_fits_ulong_p(as_big(v)->z)) {
+            unsigned long x = mpz_get_ui(as_big(v)->z);
+            if ((uint64_t)x > hi) curry_error("%s: value out of range", ctx);
+            return (uint64_t)x;
+        }
+        /* Doesn't fit unsigned long (only possible on a platform where
+         * long is narrower than 64 bits -- not one of curry's actual
+         * supported platforms, but handled rather than assumed). */
+        curry_error("%s: value out of range", ctx);
+    }
+    curry_error("%s: expected an exact integer", ctx);
+    return 0; /* unreachable */
+}
+
+static void tv_set(TypedVec *tv, uint32_t i, val_t v, const char *ctx) {
+    TVKind k = (TVKind)tv->hdr.flags;
+    uint8_t *p = tv->data + (size_t)i * tv_elem_size(k);
+    const TVKindInfo *info = &TV_INFO[k];
+    if (info->is_signed) {
+        int64_t x = tv_check_signed(v, info->min, (int64_t)info->max, ctx);
+        switch (k) {
+            case TV_S8:  *(int8_t  *)p = (int8_t)x;  break;
+            case TV_S16: { int16_t xx = (int16_t)x; memcpy(p,&xx,2); break; }
+            case TV_S32: { int32_t xx = (int32_t)x; memcpy(p,&xx,4); break; }
+            case TV_S64: { int64_t xx = x;          memcpy(p,&xx,8); break; }
+            default: break;
+        }
+    } else {
+        uint64_t x = tv_check_unsigned(v, info->max, ctx);
+        switch (k) {
+            case TV_U8:  *(uint8_t  *)p = (uint8_t)x;  break;
+            case TV_U16: { uint16_t xx = (uint16_t)x; memcpy(p,&xx,2); break; }
+            case TV_U32: { uint32_t xx = (uint32_t)x; memcpy(p,&xx,4); break; }
+            case TV_U64: { uint64_t xx = x;           memcpy(p,&xx,8); break; }
+            default: break;
+        }
+    }
+}
+
+/* ==== Constructors / predicates / access ==== */
+
+static val_t fn_make_typedvector(int ac, val_t *av, void *ud) {
+    TVKind kind = ud_kind(ud);
+    if (!vis_fixnum(av[0])) curry_error("make-%svector: length must be fixnum", TV_INFO[kind].prefix);
+    intptr_t n = vunfix(av[0]);
+    if (n < 0) curry_error("make-%svector: negative length", TV_INFO[kind].prefix);
+    val_t r = alloc_typedvec(kind, (uint32_t)n);
+    if (ac > 1) {
+        TypedVec *tv = as_typedvec(r);
+        char ctx[32]; snprintf(ctx, sizeof(ctx), "make-%svector", TV_INFO[kind].prefix);
+        /* Validate once, then fill -- tv_set re-validates per element,
+         * which is fine (n is typically small; correctness over a
+         * micro-optimization here). */
+        for (uint32_t i = 0; i < (uint32_t)n; i++) tv_set(tv, i, av[1], ctx);
+    }
+    return r;
+}
+
+static val_t fn_typedvector(int ac, val_t *av, void *ud) {
+    TVKind kind = ud_kind(ud);
+    val_t r = alloc_typedvec(kind, (uint32_t)ac);
+    TypedVec *tv = as_typedvec(r);
+    char ctx[16]; snprintf(ctx, sizeof(ctx), "%svector", TV_INFO[kind].prefix);
+    for (int i = 0; i < ac; i++) tv_set(tv, (uint32_t)i, av[i], ctx);
+    return r;
+}
+
+static val_t fn_typedvector_p(int ac, val_t *av, void *ud) {
+    (void)ac; TVKind kind = ud_kind(ud);
+    return curry_make_bool(vis_typedvec(av[0]) && (TVKind)as_typedvec(av[0])->hdr.flags == kind);
+}
+
+static val_t fn_typedvector_length(int ac, val_t *av, void *ud) {
+    (void)ac; TVKind kind = ud_kind(ud);
+    char ctx[24]; snprintf(ctx, sizeof(ctx), "%svector-length", TV_INFO[kind].prefix);
+    return curry_make_fixnum((intptr_t)get_tv(av[0], kind, ctx)->len);
+}
+
+static val_t fn_typedvector_ref(int ac, val_t *av, void *ud) {
+    (void)ac; TVKind kind = ud_kind(ud);
+    char ctx[24]; snprintf(ctx, sizeof(ctx), "%svector-ref", TV_INFO[kind].prefix);
+    TypedVec *tv = get_tv(av[0], kind, ctx);
+    return tv_get(tv, tv_idx(av[1], tv->len, ctx));
+}
+
+static val_t fn_typedvector_set(int ac, val_t *av, void *ud) {
+    (void)ac; TVKind kind = ud_kind(ud);
+    char ctx[24]; snprintf(ctx, sizeof(ctx), "%svector-set!", TV_INFO[kind].prefix);
+    TypedVec *tv = get_tv(av[0], kind, ctx);
+    uint32_t i = tv_idx(av[1], tv->len, ctx);
+    tv_set(tv, i, av[2], ctx);
+    return V_VOID;
+}
+
+/* ==== Conversion ==== */
+
+static val_t fn_typedvector_to_list(int ac, val_t *av, void *ud) {
+    TVKind kind = ud_kind(ud);
+    char ctx[28]; snprintf(ctx, sizeof(ctx), "%svector->list", TV_INFO[kind].prefix);
+    TypedVec *tv = get_tv(av[0], kind, ctx);
+    uint32_t start, end; tv_range(ac, av, 1, tv->len, ctx, &start, &end);
+    val_t out = V_NIL;
+    for (uint32_t i = end; i > start; i--) out = curry_make_pair(tv_get(tv, i - 1), out);
+    return out;
+}
+
+static val_t fn_list_to_typedvector(int ac, val_t *av, void *ud) {
+    (void)ac; TVKind kind = ud_kind(ud);
+    char ctx[28]; snprintf(ctx, sizeof(ctx), "list->%svector", TV_INFO[kind].prefix);
+    int n = 0;
+    for (val_t p = av[0]; curry_is_pair(p); p = curry_cdr(p)) n++;
+    val_t r = alloc_typedvec(kind, (uint32_t)n);
+    TypedVec *tv = as_typedvec(r);
+    uint32_t i = 0;
+    for (val_t p = av[0]; curry_is_pair(p); p = curry_cdr(p), i++)
+        tv_set(tv, i, curry_car(p), ctx);
+    return r;
+}
+
+/* ==== Copy / append / fill ==== */
+
+static val_t fn_typedvector_copy(int ac, val_t *av, void *ud) {
+    TVKind kind = ud_kind(ud);
+    char ctx[24]; snprintf(ctx, sizeof(ctx), "%svector-copy", TV_INFO[kind].prefix);
+    TypedVec *src = get_tv(av[0], kind, ctx);
+    uint32_t start, end; tv_range(ac, av, 1, src->len, ctx, &start, &end);
+    uint32_t n = end - start;
+    val_t r = alloc_typedvec(kind, n);
+    memcpy(as_typedvec(r)->data, src->data + (size_t)start * tv_elem_size(kind),
+           (size_t)n * tv_elem_size(kind));
+    return r;
+}
+
+static val_t fn_typedvector_copy_bang(int ac, val_t *av, void *ud) {
+    TVKind kind = ud_kind(ud);
+    char ctx[26]; snprintf(ctx, sizeof(ctx), "%svector-copy!", TV_INFO[kind].prefix);
+    TypedVec *to = get_tv(av[0], kind, ctx);
+    uint32_t at = tv_idx(av[1], to->len + 1, ctx);
+    TypedVec *from = get_tv(av[2], kind, ctx);
+    uint32_t start, end;
+    /* tv_range's start_idx counts from av[0]; here the optional
+     * start/end refer to `from` and begin at av[3]/av[4]. */
+    uint32_t fstart = ac > 3 ? tv_idx(av[3], from->len + 1, ctx) : 0;
+    uint32_t fend   = ac > 4 ? (uint32_t)vunfix(av[4]) : from->len;
+    if (fend > from->len || fend < fstart) curry_error("%s: end out of range", ctx);
+    start = fstart; end = fend;
+    uint32_t n = end - start;
+    if (at + n > to->len) curry_error("%s: destination too short", ctx);
+    memmove(to->data + (size_t)at * tv_elem_size(kind),
+            from->data + (size_t)start * tv_elem_size(kind),
+            (size_t)n * tv_elem_size(kind));
+    return V_VOID;
+}
+
+static val_t fn_typedvector_append(int ac, val_t *av, void *ud) {
+    TVKind kind = ud_kind(ud);
+    char ctx[24]; snprintf(ctx, sizeof(ctx), "%svector-append", TV_INFO[kind].prefix);
+    uint32_t total = 0;
+    for (int i = 0; i < ac; i++) total += get_tv(av[i], kind, ctx)->len;
+    val_t r = alloc_typedvec(kind, total);
+    uint8_t *out = as_typedvec(r)->data;
+    for (int i = 0; i < ac; i++) {
+        TypedVec *tv = as_typedvec(av[i]);
+        size_t bytes = (size_t)tv->len * tv_elem_size(kind);
+        memcpy(out, tv->data, bytes);
+        out += bytes;
+    }
+    return r;
+}
+
+static val_t fn_typedvector_fill_bang(int ac, val_t *av, void *ud) {
+    TVKind kind = ud_kind(ud);
+    char ctx[24]; snprintf(ctx, sizeof(ctx), "%svector-fill!", TV_INFO[kind].prefix);
+    TypedVec *tv = get_tv(av[0], kind, ctx);
+    uint32_t start, end; tv_range(ac, av, 2, tv->len, ctx, &start, &end);
+    for (uint32_t i = start; i < end; i++) tv_set(tv, i, av[1], ctx);
+    return V_VOID;
+}
+
+/* ==== Registration ==== */
+
+void curry_module_init(CurryVM *vm) {
+    for (int k = 0; k < 8; k++) {
+        const char *pfx = TV_INFO[k].prefix;
+        void *ud = (void *)(intptr_t)k;
+        char name[32];
+#define REG(fmt, fn, lo, hi) \
+        (snprintf(name, sizeof(name), fmt, pfx), curry_define_fn(vm, name, fn, lo, hi, ud))
+        REG("make-%svector",   fn_make_typedvector,      1, 2);
+        REG("%svector",        fn_typedvector,           0, -1);
+        REG("%svector?",       fn_typedvector_p,         1, 1);
+        REG("%svector-length", fn_typedvector_length,    1, 1);
+        REG("%svector-ref",    fn_typedvector_ref,       2, 2);
+        REG("%svector-set!",   fn_typedvector_set,       3, 3);
+        REG("%svector->list",  fn_typedvector_to_list,   1, 3);
+        REG("list->%svector",  fn_list_to_typedvector,   1, 1);
+        REG("%svector-copy",   fn_typedvector_copy,      1, 3);
+        REG("%svector-copy!",  fn_typedvector_copy_bang, 3, 5);
+        REG("%svector-append", fn_typedvector_append,    0, -1);
+        REG("%svector-fill!",  fn_typedvector_fill_bang, 2, 4);
+#undef REG
+    }
+}

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -247,6 +247,10 @@ static size_t obj_size(const Hdr *h) {
         const F64Vec *f = (const F64Vec *)h;
         return ((sizeof(F64Vec) + f->len * sizeof(double)) + 7u) & ~7u;
     }
+    case T_TYPEDVEC: {
+        const TypedVec *t = (const TypedVec *)h;
+        return ((sizeof(TypedVec) + (size_t)t->len * tv_elem_size((TVKind)h->flags)) + 7u) & ~7u;
+    }
     case T_VALUES: {
         const Values *v = (const Values *)h;
         return ((sizeof(Values) + v->count * sizeof(val_t)) + 7u) & ~7u;
@@ -311,7 +315,7 @@ static bool type_has_ptrs(uint32_t t) {
     case T_FLONUM: case T_QUATERNION: case T_OCTONION:
     case T_F64VEC: case T_BYTEVECTOR: case T_SPINOR:
     case T_MULTIVECTOR: case T_MATRIX: case T_TENSOR:
-    case T_STRING: case T_CPTR:
+    case T_STRING: case T_CPTR: case T_TYPEDVEC:
         return false;
     default:
         return true;
@@ -356,7 +360,7 @@ static void scan_object(void *obj) {
     case T_FLONUM: case T_QUATERNION: case T_OCTONION:
     case T_F64VEC: case T_BYTEVECTOR: case T_SPINOR:
     case T_MULTIVECTOR: case T_MATRIX: case T_TENSOR:
-    case T_STRING: case T_CPTR:
+    case T_STRING: case T_CPTR: case T_TYPEDVEC:
         break;
 
     case T_PAIR: {

--- a/src/object.h
+++ b/src/object.h
@@ -98,6 +98,12 @@ typedef enum {
     T_INTERVAL      = 52,  /* GC:MOVE — lo/hi are val_t (the MPFR values they point to are pinned) */
     T_CHUNK         = 53,  /* GC:PIN val_t: constants[], src_lambda — BcClosure.chunk is raw ptr */
     T_UPVALUE       = 54,  /* GC:PIN  — vm->open_upvalues raw linked list; location is interior ptr */
+    T_TYPEDVEC      = 55,  /* GC:MOVE — SRFI-4 typed vector (u8/s8/u16/s16/u32/s32/u64/s64/f32/f64);
+                               one shared struct for all 9 kinds, not 9 separate types -- see
+                               TV_KIND_* in object.h and modules/typedvec/typedvec.c. Distinct
+                               from the existing T_F64VEC (a separate, math/BLAS-flavored
+                               module with its own different operation set) -- deliberately not
+                               unified with it, to avoid destabilizing that already-shipped API. */
 } ObjType;
 
 /*
@@ -171,6 +177,7 @@ static inline uint32_t vtype(val_t v) {
 #define vis_matrix(v)   vis_type(v, T_MATRIX)
 #define vis_tensor(v)   vis_type(v, T_TENSOR)
 #define vis_f64vec(v)   vis_type(v, T_F64VEC)
+#define vis_typedvec(v) vis_type(v, T_TYPEDVEC)
 #define vis_up(v)       vis_type(v, T_UP)
 #define vis_down(v)     vis_type(v, T_DOWN)
 #define vis_tuple(v)    (vis_up(v) || vis_down(v))
@@ -319,6 +326,41 @@ typedef struct {
     uint32_t len;
     double   data[];
 } F64Vec;
+
+/* SRFI-4 element kind, stored in hdr.flags -- one shared struct for all
+ * 8 integer typed-vector kinds rather than 8 separate ObjTypes/structs
+ * (f64 is deliberately NOT included here: curry already has a full,
+ * separately-shipped (curry f64vector) module with its own F64Vec type
+ * and a much larger BLAS-flavored operation set; (srfi 4) re-exports
+ * that module's f64vector rather than introducing a second, competing
+ * f64 vector type that would collide on every name if both modules
+ * were ever imported together). See modules/typedvec/typedvec.c. */
+typedef enum {
+    TV_U8, TV_S8, TV_U16, TV_S16, TV_U32, TV_S32, TV_U64, TV_S64
+} TVKind;
+
+/* Element byte width per kind -- shared by the typedvec module and the
+ * GC (gc_gen.c needs it to size/copy a TypedVec without linking against
+ * the module). Inline rather than a lookup table: TVKind is a small,
+ * fixed, ordered enum, so a switch compiles to a jump table anyway. */
+static inline uint32_t tv_elem_size(TVKind k) {
+    switch (k) {
+        case TV_U8: case TV_S8:   return 1;
+        case TV_U16: case TV_S16: return 2;
+        case TV_U32: case TV_S32: return 4;
+        case TV_U64: case TV_S64: return 8;
+    }
+    return 1; /* unreachable */
+}
+
+/* TypedVec: flat array of raw bytes, element width determined by the
+ * TVKind in hdr.flags -- no GC pointers, use CURRY_NEW_FLEX_ATOM
+ * (data[] sized in BYTES, not elements: allocate len * tv_elem_size(kind)). */
+typedef struct {
+    Hdr      hdr;      /* hdr.flags = TVKind */
+    uint32_t len;      /* element count, not byte count */
+    uint8_t  data[];
+} TypedVec;
 
 typedef struct {
     Hdr      hdr;
@@ -739,6 +781,7 @@ typedef struct {
 #define as_quat(v)    vunptr(Quaternion, v)
 #define as_oct(v)     vunptr(Octonion,   v)
 #define as_f64v(v)    vunptr(F64Vec,     v)
+#define as_typedvec(v) vunptr(TypedVec,  v)
 #define as_bytes(v)   vunptr(Bytevector, v)
 #define as_port(v)    vunptr(Port,       v)
 #define as_clos(v)    vunptr(Closure,    v)

--- a/src/port.c
+++ b/src/port.c
@@ -527,6 +527,45 @@ void scm_write(val_t v, val_t port) {
         port_write_char(port, ')');
         return;
     }
+    if (vis_typedvec(v)) {
+        /* SRFI-4 typed vectors (modules/typedvec/typedvec.c) -- printed
+         * directly from the raw bytes here in core rather than calling
+         * back into the module (a loadable .so, not linked against by
+         * port.c), matching #f64(...) above's own established pattern
+         * for a typed numeric vector's external representation. Values
+         * are formatted straight as long/unsigned long (both exactly
+         * 64 bits on every platform curry supports), not routed through
+         * the numeric tower/bignum promotion the module's own
+         * tv_get does for Scheme-visible access -- printing never
+         * needs a val_t, just correct signed/unsigned text. */
+        TypedVec *tv = as_typedvec(v);
+        static const char *tv_prefix[8] = {
+            "u8","s8","u16","s16","u32","s32","u64","s64"
+        };
+        TVKind k = (TVKind)tv->hdr.flags;
+        port_write_char(port, '#');
+        port_write_string(port, tv_prefix[k], (uint32_t)strlen(tv_prefix[k]));
+        port_write_char(port, '(');
+        for (uint32_t i = 0; i < tv->len; i++) {
+            if (i) port_write_char(port, ' ');
+            const uint8_t *p = tv->data + (size_t)i * tv_elem_size(k);
+            int n;
+            switch (k) {
+                case TV_U8:  n = snprintf(buf, sizeof(buf), "%u",  *(const uint8_t  *)p); break;
+                case TV_S8:  n = snprintf(buf, sizeof(buf), "%d",  *(const int8_t   *)p); break;
+                case TV_U16: { uint16_t x; memcpy(&x,p,2); n = snprintf(buf, sizeof(buf), "%u",  x); break; }
+                case TV_S16: { int16_t  x; memcpy(&x,p,2); n = snprintf(buf, sizeof(buf), "%d",  x); break; }
+                case TV_U32: { uint32_t x; memcpy(&x,p,4); n = snprintf(buf, sizeof(buf), "%u",  x); break; }
+                case TV_S32: { int32_t  x; memcpy(&x,p,4); n = snprintf(buf, sizeof(buf), "%d",  x); break; }
+                case TV_U64: { uint64_t x; memcpy(&x,p,8); n = snprintf(buf, sizeof(buf), "%llu", (unsigned long long)x); break; }
+                case TV_S64: { int64_t  x; memcpy(&x,p,8); n = snprintf(buf, sizeof(buf), "%lld", (long long)x); break; }
+                default: n = 0; break;
+            }
+            port_write_string(port, buf, (uint32_t)n);
+        }
+        port_write_char(port, ')');
+        return;
+    }
     if (vis_traced(v)) {
         Traced *t = as_traced(v);
         if (vis_symbol(t->name)) {

--- a/src/port.c
+++ b/src/port.c
@@ -531,16 +531,30 @@ void scm_write(val_t v, val_t port) {
         /* SRFI-4 typed vectors (modules/typedvec/typedvec.c) -- printed
          * directly from the raw bytes here in core rather than calling
          * back into the module (a loadable .so, not linked against by
-         * port.c), matching #f64(...) above's own established pattern
-         * for a typed numeric vector's external representation. Values
-         * are formatted straight as long/unsigned long (both exactly
-         * 64 bits on every platform curry supports), not routed through
-         * the numeric tower/bignum promotion the module's own
-         * tv_get does for Scheme-visible access -- printing never
-         * needs a val_t, just correct signed/unsigned text. */
+         * port.c). Values are formatted straight as long/unsigned long
+         * (both exactly 64 bits on every platform curry supports), not
+         * routed through the numeric tower/bignum promotion the module's
+         * own tv_get does for Scheme-visible access -- printing never
+         * needs a val_t, just correct signed/unsigned text.
+         *
+         * Deliberately NOT "#u8(...)"/"#s8(...)"/etc (i.e. NOT the bare
+         * TAG_INFO prefix used everywhere else, e.g. procedure names):
+         * the reader already treats "#u8(" as R7RS bytevector syntax
+         * (read_bytevector in reader.c) and "#s" followed by digits as
+         * a sexagesimal number literal (sex_parse_neugebauer) -- reusing
+         * either prefix bare would make write/read silently round-trip
+         * to the WRONG TYPE (a u8vector reading back as a bytevector) or
+         * corrupt the read stream (an s8vector's "(1 2 3)" silently
+         * swallowed as unconsumed sexagesimal-literal trailing text).
+         * The "vec" suffix guarantees neither reader path's literal
+         * character match succeeds, so an attempt to read one of these
+         * back raises a clean read-error instead -- not yet a true
+         * reader literal (matching the pre-existing #f64(...) above,
+         * which has the same limitation), but no longer type-confusing
+         * or silently corrupting on read. */
         TypedVec *tv = as_typedvec(v);
         static const char *tv_prefix[8] = {
-            "u8","s8","u16","s16","u32","s32","u64","s64"
+            "u8vec","s8vec","u16vec","s16vec","u32vec","s32vec","u64vec","s64vec"
         };
         TVKind k = (TVKind)tv->hdr.flags;
         port_write_char(port, '#');

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,6 +234,13 @@ if(BUILD_MODULE_RPI AND TARGET curry_rpi)
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
+if(BUILD_MODULE_TYPEDVEC AND TARGET curry_typedvec AND BUILD_MODULE_F64VECTOR AND TARGET curry_f64vector)
+    # (srfi 4) imports both (curry typedvec) and (curry f64vector).
+    add_test(NAME typedvec COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/typedvec_tests.scm)
+    set_tests_properties(typedvec PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
 if(BUILD_MODULE_QT6 AND TARGET curry_qt6)
     # Phase 1 (widget creation) runs immediately; Phase 2 (painter / text
     # metrics) triggers an offscreen render via canvas-save-png!.

--- a/tests/typedvec_tests.scm
+++ b/tests/typedvec_tests.scm
@@ -92,23 +92,57 @@
   (u8vector-fill! v 5)
   (check "u8vector-fill!" (u8vector->list v) '(5 5 5)))
 
-;;; ---- external representation (#u8(...), #s64(...), etc.) ----
+;;; ---- external representation (#u8vec(...), #s64vec(...), etc.) ----
+;;; Deliberately NOT "#u8(...)"/"#s8(...)": those exact prefixes are
+;;; already claimed by the reader (R7RS bytevector syntax and the
+;;; sexagesimal-literal reader, respectively) -- reusing them would make
+;;; write/read round-trip to the wrong type or silently corrupt. The
+;;; "vec" suffix avoids both collisions; see src/port.c's comment.
 
 (check "u8vector write representation"
        (let ((p (open-output-string)))
          (write (u8vector 1 2 3) p)
          (get-output-string p))
-       "#u8(1 2 3)")
+       "#u8vec(1 2 3)")
 (check "s64vector write representation round-trips boundary values"
        (let ((p (open-output-string)))
          (write (s64vector -9223372036854775808 9223372036854775807) p)
          (get-output-string p))
-       "#s64(-9223372036854775808 9223372036854775807)")
+       "#s64vec(-9223372036854775808 9223372036854775807)")
 (check "u64vector write representation for UINT64_MAX"
        (let ((p (open-output-string)))
          (write (u64vector 18446744073709551615) p)
          (get-output-string p))
-       "#u64(18446744073709551615)")
+       "#u64vec(18446744073709551615)")
+
+;;; ---- printed representation no longer collides with reader syntax ----
+;;; (regression: found by code review -- the original "#u8(...)"/
+;;; "#s8(...)" forms collided with R7RS bytevector syntax and the
+;;; sexagesimal-literal reader, so writing a u8vector and reading it
+;;; back silently produced a *bytevector*, and writing an s8vector..
+;;; s64vector and reading it back silently corrupted the read stream
+;;; instead of raising.)
+
+(check "#u8(...) still reads as a bytevector, not confused with u8vector"
+       (bytevector? (read (open-input-string "#u8(1 2 3)")))
+       #t)
+(check "#u8vec(...) is not (yet) reader syntax -- raises cleanly instead of misparsing"
+       (guard (e (#t 'raised)) (read (open-input-string "#u8vec(1 2 3)")))
+       'raised)
+(check "#s8vec(...) is not (yet) reader syntax -- raises cleanly instead of silently corrupting"
+       (guard (e (#t 'raised)) (read (open-input-string "#s8vec(1 2 3)")))
+       'raised)
+
+;;; ---- input validation regressions found by independent review ----
+
+(check "TAGvector-copy! end argument must be a fixnum, not silently reinterpreted"
+       (guard (e (#t 'raised))
+         (let ((to (make-u8vector 5 0)) (from (u8vector 9 9 9)))
+           (u8vector-copy! to 0 from 0 #t)))
+       'raised)
+(check "make-TAGvector rejects a length exceeding uint32_t range instead of silently truncating"
+       (guard (e (#t 'raised)) (make-u8vector 4294967297 7))
+       'raised)
 
 ;;; ---- (srfi 4) re-exports both the 8 integer kinds and f64vector ----
 

--- a/tests/typedvec_tests.scm
+++ b/tests/typedvec_tests.scm
@@ -1,0 +1,128 @@
+;;; typedvec_tests.scm — SRFI-4 core typed vectors: (curry typedvec) directly,
+;;; plus the combined (srfi 4) / (srfi srfi-4) / (srfi s4 uniform-vectors)
+;;; wrapper libraries (which also re-export the pre-existing f64vector kind).
+
+(import (curry typedvec))
+(import (srfi 4))
+
+(define pass 0)
+(define fail 0)
+
+(define-syntax check
+  (syntax-rules ()
+    ((_ label expr expected)
+     (let ((got expr))
+       (if (equal? got expected)
+           (begin (set! pass (+ pass 1)))
+           (begin
+             (set! fail (+ fail 1))
+             (display "FAIL: ") (display label) (newline)
+             (display "  expected: ") (write expected) (newline)
+             (display "  got:      ") (write got) (newline)))))))
+
+;;; ---- u8vector: construction, ref/set!, bounds ----
+
+(define v8 (u8vector 1 2 3))
+(check "u8vector?" (u8vector? v8) #t)
+(check "u8vector? on wrong kind" (u8vector? (s8vector 1)) #f)
+(check "u8vector-length" (u8vector-length v8) 3)
+(check "u8vector-ref" (u8vector-ref v8 1) 2)
+(u8vector-set! v8 1 99)
+(check "u8vector-set!" (u8vector-ref v8 1) 99)
+(check "u8vector->list" (u8vector->list (u8vector 5 6 7)) '(5 6 7))
+(check "list->u8vector" (u8vector->list (list->u8vector '(9 8 7))) '(9 8 7))
+(check "make-u8vector default fill" (u8vector->list (make-u8vector 3)) '(0 0 0))
+(check "make-u8vector with fill" (u8vector->list (make-u8vector 3 7)) '(7 7 7))
+
+(check "u8vector-set! out of range high raises"
+       (guard (e (#t 'raised)) (u8vector-set! v8 0 300))
+       'raised)
+(check "u8vector-set! out of range low raises"
+       (guard (e (#t 'raised)) (u8vector-set! v8 0 -1))
+       'raised)
+(check "u8vector-ref out of bounds raises"
+       (guard (e (#t 'raised)) (u8vector-ref v8 99))
+       'raised)
+
+;;; ---- s8vector: signed boundary values ----
+
+(define v8s (s8vector -128 0 127))
+(check "s8vector min boundary" (s8vector-ref v8s 0) -128)
+(check "s8vector max boundary" (s8vector-ref v8s 2) 127)
+(check "s8vector-set! overflow raises"
+       (guard (e (#t 'raised)) (s8vector-set! v8s 0 128))
+       'raised)
+(check "s8vector-set! underflow raises"
+       (guard (e (#t 'raised)) (s8vector-set! v8s 0 -129))
+       'raised)
+
+;;; ---- u16/s16 ----
+
+(check "u16vector max" (u16vector-ref (u16vector 65535) 0) 65535)
+(check "s16vector min/max" (s16vector->list (s16vector -32768 32767)) '(-32768 32767))
+
+;;; ---- u32/s32 ----
+
+(check "u32vector max" (u32vector-ref (u32vector 4294967295) 0) 4294967295)
+(check "s32vector min/max"
+       (s32vector->list (s32vector -2147483648 2147483647))
+       '(-2147483648 2147483647))
+
+;;; ---- u64/s64: exact-bignum round-tripping past signed-long range ----
+
+(define big-u64 18446744073709551615) ; UINT64_MAX
+(define v64u (u64vector big-u64 0))
+(check "u64vector round-trips UINT64_MAX exactly" (u64vector-ref v64u 0) big-u64)
+(check "u64vector element is exact integer" (integer? (u64vector-ref v64u 0)) #t)
+
+(define v64s (s64vector -9223372036854775808 9223372036854775807))
+(check "s64vector round-trips INT64_MIN" (s64vector-ref v64s 0) -9223372036854775808)
+(check "s64vector round-trips INT64_MAX" (s64vector-ref v64s 1) 9223372036854775807)
+
+;;; ---- copy / copy! / append / fill! ----
+
+(check "u8vector-copy" (u8vector->list (u8vector-copy (u8vector 1 2 3 4) 1 3)) '(2 3))
+(let ((dst (make-u8vector 4 0)))
+  (u8vector-copy! dst 1 (u8vector 10 20 30))
+  (check "u8vector-copy!" (u8vector->list dst) '(0 10 20 30)))
+(check "u8vector-append"
+       (u8vector->list (u8vector-append (u8vector 1 2) (u8vector 3 4)))
+       '(1 2 3 4))
+(let ((v (make-u8vector 3 0)))
+  (u8vector-fill! v 5)
+  (check "u8vector-fill!" (u8vector->list v) '(5 5 5)))
+
+;;; ---- external representation (#u8(...), #s64(...), etc.) ----
+
+(check "u8vector write representation"
+       (let ((p (open-output-string)))
+         (write (u8vector 1 2 3) p)
+         (get-output-string p))
+       "#u8(1 2 3)")
+(check "s64vector write representation round-trips boundary values"
+       (let ((p (open-output-string)))
+         (write (s64vector -9223372036854775808 9223372036854775807) p)
+         (get-output-string p))
+       "#s64(-9223372036854775808 9223372036854775807)")
+(check "u64vector write representation for UINT64_MAX"
+       (let ((p (open-output-string)))
+         (write (u64vector 18446744073709551615) p)
+         (get-output-string p))
+       "#u64(18446744073709551615)")
+
+;;; ---- (srfi 4) re-exports both the 8 integer kinds and f64vector ----
+
+(check "(srfi 4) exports u8vector" (u8vector? (u8vector 1)) #t)
+(check "(srfi 4) exports f64vector" (f64vector? (f64vector 1.5 2.5)) #t)
+(check "(srfi 4) f64vector-ref" (f64vector-ref (f64vector 1.5 2.5) 1) 2.5)
+
+;;; ---- Summary ----
+
+(newline)
+(display "typedvec/srfi-4 tests: ")
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0)
+    (begin (display "SOME TESTS FAILED") (newline) (exit 1))
+    (begin (display "all OK") (newline)))


### PR DESCRIPTION
## Summary

- Adds `(curry typedvec)`: SRFI-4 core homogeneous numeric vectors for the 8 integer kinds (u8/s8/u16/s16/u32/s32/u64/s64vector), as one new GC heap type (`T_TYPEDVEC`) and one generic C implementation parameterized by kind, rather than 8 duplicated implementations. `f64vector` is deliberately excluded — `(curry f64vector)` already ships it with a much larger numeric-computation surface.
- Adds `(srfi 4)` / `(srfi srfi-4)` / `(srfi s4 uniform-vectors)`, combining the new module with the pre-existing `(curry f64vector)` module into one SRFI-4 surface, following this codebase's established SRFI-shim convention.
- Adds a `#TAGvec(...)` printed representation for each kind (e.g. `#u8vec(1 2 3)`, `#s64vec(-9223372036854775808 5)`) in `src/port.c`.
- 39 regression tests in `tests/typedvec_tests.scm`, docs at `docs/reference/module-typedvec.md` and `docs/reference/srfi/s4.md`, registered in the module and SRFI indexes.

## Independent review

Per this repo's CLAUDE.md, a fresh code-review subagent and a fresh security-review subagent (no shared context with the writing session) each independently reviewed the code. Both found real bugs, since fixed:

- **Critical**: the original `#u8(...)`/`#s8(...)` printed forms collided with existing reader syntax — `#u8(` is already R7RS bytevector literal syntax, and `#s...` is already curry's sexagesimal-number literal syntax. Writing a `u8vector` and reading it back silently produced a *bytevector* (type confusion); writing an `s8`..`s64vector` and reading it back silently corrupted the rest of the read stream instead of raising. Fixed by suffixing every prefix with `vec` (`#u8vec(...)`, `#s64vec(...)`), which now raises a clean read error on read-back instead of misparsing.
- Missing `vis_fixnum` check before `vunfix` on `TAGvector-copy!`'s `end`/`fend` arguments — a non-fixnum value (e.g. `#t`) was silently reinterpreted as a small integer instead of raising a type error.
- `make-TAGvector` validated only `n < 0`, then silently truncated the length to `uint32_t` — `(make-u8vector 4294967297 7)` produced a 1-element vector instead of raising.
- `%svector-append`'s length accumulator was `uint32_t` with no overflow check — a combined length exceeding `UINT32_MAX` (several GB of vectors) wraps, under-allocates, and the copy loop then writes past the allocation (real heap buffer overflow, not reproducible in a normal sandbox but a real bug). Fixed by accumulating in `uint64_t` and rejecting before truncation; the related `at + n > to->len` bounds check in `TAGvector-copy!` had the same overflow shape and is now computed in `size_t`.

## Test plan

- [x] `cmake --build build` succeeds cleanly
- [x] `ctest --test-dir build -R typedvec` — 39/39 checks pass
- [x] Full `ctest` suite: 93/93 pass (one intermittent `lsp` failure under `-j` parallel contention, confirmed to pass standalone — this repo's established environmental-noise pattern, not a regression)
- [x] Live-verified all four review findings are fixed (non-fixnum `end` raises, oversized length raises, bytevector read-back still works, `#u8vec(...)`/`#s8vec(...)` raise cleanly instead of misparsing)
