### PR TITLE
feat(srfi160): extended uniform-vector ops (map/fold/filter/comparator/generator) for all 9 kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,135 @@
 # Changelog
 
-### 1.17.12 - 2026-08-10
+### 1.20.0 - 2026-08-14
+
+**New — `(curry tts)`: cross-backend text-to-speech**
+
+`tts-speak`/`tts-save`/`tts-speak-async` over two backends: `'macos-say`
+(the system `say` command) and `'espeak-ng` (Linux, `espeak-ng` or
+`espeak`) — both plain command-line tools run through `(curry
+posix)`'s `posix_spawn`-backed `process-run`/`process-start`, so text,
+voice names, and paths pass through as literal argv data with no
+shell-injection surface. `current-tts-backend`/`-voice`/`-rate`/
+`-language` are real parameter objects (the same idiom as
+`current-number-notation`); `current-tts-language` resolves to a
+concrete voice by locale prefix against the active backend's own
+`tts-voices` listing, since neither backend takes a locale directly.
+`tts-backend-available?` fixed to return `#f` for an unrecognized
+backend symbol instead of raising. See docs/reference/module-tts.md.
+
+**New — R7RS `cond-expand` and `(features)`**
+
+`cond-expand` was a pre-interned symbol that was never actually
+dispatched — a real R7RS 4.2.9 gap. Now a genuine special form
+(feature identifiers, `and`/`or`/`not`, `(library <name>)`, `else`),
+resolved at three call sites: the tree-walker, the VM compiler
+(resolved once at compile time), and `define-library` declaration
+position — the motivating case, since SRFI-279's own reference
+implementation dispatches chibi/kawa/guile/else exactly this way.
+`(features)` is the new matching R7RS 6.13.3 builtin.
+
+**New — SRFI-279 (In(tro)spection Protocol)**
+
+`inspect-properties`/`inspect-describe`, written directly against
+curry's own primitives rather than porting the SRFI's reference
+implementation (which depends on SRFI 14/26/160/253, none of which
+curry had at the time). Covers objects, numbers, booleans, pairs,
+symbols, characters, strings, vectors, bytevectors, error-objects,
+hash-tables, boxes, sets/bags, and records — plus four new primitives
+(`record?`/`record-type?`/`record-rtd`/`record-type-name`/
+`record-type-field-names`) giving curry generic record introspection
+for the first time, not just the type-specific accessors
+`define-record-type` hands out. Two independent review rounds found
+and fixed a real type-dispatch ordering bug (SRFI-113 bags are hash
+tables under the hood, so `bag?` must be checked before the generic
+`hash-table?` branch) and a doc/code mismatch (`utf8->string` was
+documented as validating its input; it doesn't). See
+docs/reference/srfi/s279.md.
+
+**New — `(load ...)`/`(include ...)` resolve relative paths against the loading file's own directory, not the process's cwd**
+
+Found while porting SRFI-279 upstream: a library whose own directory
+wasn't the process's cwd could never portably `(include "sibling.scm")`.
+A new directory-context stack is pushed/released around every path
+that reads Scheme source from a file. Three rounds of review found and
+fixed real bugs along the way: an exception mid-load left stale stack
+state that corrupted a later, unrelated load (fixed via a mark/release
+scheme instead of push/pop pairing); the stack being a plain static
+was a genuine cross-thread data race confirmed via ThreadSanitizer (a
+real use-after-free, not just a lost update) — fixed by making it
+`_Thread_local`, which then meant a freshly-spawned actor started with
+an empty stack instead of inheriting its spawning thread's directory
+context (fixed with an explicit snapshot/adopt handoff in `actor_spawn`/
+`actor_thread`).
+
+**New — Partial hygiene for `syntax-rules`; `(srfi 26)` (`cut`/`cute`)**
+
+curry's `syntax-rules` was fully unhygienic — a template-introduced
+identifier was always emitted unchanged, resolved at the macro's use
+site. This broke porting SRFI-26's reference `cut`/`cute` (a recursive
+macro that accumulates a fresh identifier across expansions): every
+recursive step's introduced identifier collapsed into the same literal
+symbol. Now, after a pattern match, every template-introduced symbol
+that isn't already a real reference gets one fresh gensym for that
+expansion. Two independent review rounds found real concurrency bugs
+along the way: `let`/`letrec-syntax` self-recursion broke in compiled
+code (those macro names live only in the compiler's own per-call
+table, a second thread-local was needed), and the gensym counter
+itself was an unsynchronized plain `static long`, a genuine cross-thread
+race under curry's real-OS-thread actors (fixed with `_Atomic long`).
+`lib/curry/modules/srfi/s26/cut.scm` is the reference implementation
+verbatim.
+
+**New — SRFI-14 (Character-Set Library)** — construction, iteration, set
+algebra, comparisons, and the standard predefined sets, backed by a
+sorted-range representation over curry's full Unicode codepoint space.
+
+**New — Symbolic inequalities** (`<`, `<=`, `>`, `>=`) in the CAS.
+
+**Fix — NaN formatting normalized to a literal `"nan"` everywhere.**
+`%g`-based formatting faithfully printed a NaN's own sign bit, but
+IEEE 754 doesn't specify what sign a computation like `0.0/0.0`
+produces, so the same source expression could print `"nan"` on one
+platform and `"-nan"` on another — confirmed via a CI-only failure on
+Linux for a value neither platform's C code actually chooses the sign
+of. curry's display convention doesn't distinguish signed NaNs (unlike
+`+inf`/`-inf`, where the sign is IEEE-754-unambiguous and meaningful).
+
+**Fix — `src/features.h` renamed to `src/curry_features.h`.** It
+shadowed glibc's own `<features.h>` (transitively included by nearly
+everything, including Boehm GC's headers), breaking the Ubuntu build
+via a header-search-order collision never surfaced on macOS/BSD libc,
+which has no header by this name.
+
+**Docs** — CONTRIBUTING.md and issue templates added; an unresolved
+git-merge conflict marker left in LICENSE fixed.
+
+### 1.19.0 - 2026-08-11
+
+**New — `(curry mariadb)`/`(curry postgres)`: type coercion, structured errors, streaming, TLS, LISTEN/NOTIFY, COPY**
+
+Column values now coerce to native Scheme types automatically (mariadb:
+fixed a real BLOB-corruption bug found while doing this; postgres:
+coerced by OID) instead of every column coming back as a string. Both
+backends now raise structured `mariadb-error`/`postgres-error`
+conditions carrying SQLSTATE/errno instead of a bare error string.
+`sql-query-stream`/`sql-with-stream` (plus each backend's own native
+streaming mechanism — postgres also gets a native async
+single-row-mode variant) let a caller process large result sets
+without materializing them all in memory first. `(curry mariadb)`
+gains TLS config keys, now defaulting to verifying the server
+certificate (fixed after initially defaulting to skip verification);
+`(curry postgres)` gains LISTEN/NOTIFY pub-sub and COPY bulk
+load/unload, and `pg-cursor-close` is now guarded against being called
+twice.
+
+Docs (module-mariadb.md/module-postgres.md/module-sql.md) and tests
+extended to match; `sql_tests.scm` adds sqlite-backed
+`sql-query-stream`/`sql-with-stream` coverage (sqlite streams natively
+via true prepared statements, needing no live server). Full ctest
+suite passes.
+
+### 1.18.0 - 2026-08-10
 
 **New — `(curry sql)`: a Scheme-native cross-database layer, with sqlite/mariadb/postgres backends**
 

--- a/docs/reference/module-typedvec.md
+++ b/docs/reference/module-typedvec.md
@@ -67,4 +67,5 @@ Typed vectors are allocated atomically (`gc_alloc_atomic`) — the element bytes
 ## See also
 
 - [`srfi/s4.md`](srfi/s4.md) — the combined SRFI-4 library (this module + `(curry f64vector)`)
+- [`srfi/s160.md`](srfi/s160.md) — extended map/fold/filter/comparator/generator ops layered on top of SRFI-4
 - [`srfi/index.md`](srfi/index.md) — full SRFI availability table

--- a/docs/reference/srfi/index.md
+++ b/docs/reference/srfi/index.md
@@ -53,6 +53,7 @@ The same import-collision caveat as `(srfi N)` above applies identically here (i
 | [`(srfi s133 vectors)`](s132-s133.md) | [SRFI-133](https://srfi.schemers.org/srfi-133/) | Vector extras layered on curry's native vector ops: fold, index/count/any/every, binary-search, concatenate, unfold |
 | [`(srfi s145 assume)`](s145.md) | [SRFI-145](https://srfi.schemers.org/srfi-145/) | `assume` runtime invariant declaration (always checked, never elided) |
 | [`(srfi s158 generators-and-accumulators)`](s158.md) | [SRFI-158](https://srfi.schemers.org/srfi-158/) | Generator/accumulator combinators; `make-coroutine-generator` via a real thread |
+| [`(srfi s160 uniform-vectors)`](s160.md) | [SRFI-160](https://srfi.schemers.org/srfi-160/) | Extended homogeneous numeric vector ops (map/fold/filter/comparator/generator) for all 9 kinds, layered on `(srfi s4 uniform-vectors)` |
 | [`(srfi s170 posix)`](s170.md) | [SRFI-170](https://srfi.schemers.org/srfi-170/) | POSIX API (subset) — thin re-export of `(curry posix)`, requires `-DBUILD_MODULE_POSIX=ON` (default) |
 | [`(srfi s174 posix-timespecs)`](s174.md) | [SRFI-174](https://srfi.schemers.org/srfi-174/) | Immutable `(seconds nanoseconds)` time-instant type |
 | [`(srfi s194 random-data-samples)`](s194.md) | [SRFI-194](https://srfi.schemers.org/srfi-194/) | Random integer/real/boolean/char generators plus distribution samplers |

--- a/docs/reference/srfi/s160.md
+++ b/docs/reference/srfi/s160.md
@@ -1,0 +1,47 @@
+# `(srfi s160 uniform-vectors)` — SRFI-160 homogeneous numeric vectors, extended
+
+```scheme
+(import (srfi s160 uniform-vectors))
+```
+
+Layers the extended [SRFI-160](https://srfi.schemers.org/srfi-160/) operation set — higher-order iteration, searching, folding, comparators, and generators — on top of [`(srfi s4 uniform-vectors)`](s4.md), for all 9 kinds: `u8`, `s8`, `u16`, `s16`, `u32`, `s32`, `u64`, `s64`, `f64`. This library re-exports the SRFI-4 base ops too (`make-TAGvector`, `TAGvector-ref`, etc — see [`../module-typedvec.md`](../module-typedvec.md)), so importing just this one library is self-sufficient; a separate `(srfi 4)` import isn't needed.
+
+Every kind `TAG` gets the same extended set:
+
+| Procedure | Description |
+|---|---|
+| `(TAGvector-empty? v)` | `#t` iff length 0 |
+| `(TAGvector= v ...)` | Elementwise equality across 2+ vectors |
+| `(TAGvector-swap! v i j)` | Swap two elements in place |
+| `(TAGvector-reverse! v [start [end]])` | Reverse a sub-range in place |
+| `(TAGvector-reverse-copy v [start [end]])` | Reversed copy of a sub-range |
+| `(TAGvector-map f v1 v2 ...)` | New vector from `f` applied elementwise |
+| `(TAGvector-map! f v1 v2 ...)` | Like `-map`, but overwrites `v1` in place |
+| `(TAGvector-for-each f v1 v2 ...)` | Elementwise side effects, no return value |
+| `(TAGvector-count pred v1 v2 ...)` | Count of elements satisfying `pred` |
+| `(TAGvector-index pred v1 v2 ...)` / `-index-right` | Leftmost/rightmost index where `pred` holds, or `#f` |
+| `(TAGvector-skip pred v1 v2 ...)` / `-skip-right` | Leftmost/rightmost index where `pred` does *not* hold, or `#f` |
+| `(TAGvector-any pred v1 v2 ...)` / `-every` | Short-circuiting existential/universal test |
+| `(TAGvector-filter pred v)` / `-remove` | New vector of elements that do/don't satisfy `pred` |
+| `(TAGvector-partition pred v)` | Two values: elements that do and don't satisfy `pred` |
+| `(TAGvector-fold kons knil v1 v2 ...)` | Left fold; `kons` called as `(kons acc e1 e2 ...)` |
+| `(TAGvector-fold-right kons knil v1 v2 ...)` | Right fold; `kons` called as `(kons e1 e2 ... acc)` — note the accumulator position is the *opposite* of `-fold` |
+| `(TAGvector-concatenate list-of-vectors)` | Concatenation of a list of same-kind vectors |
+| `(TAGvector-unfold f length seed ...)` / `-unfold-right` | Build a vector of `length` elements from a generator function `f` (called as `(f i seed ...)`, returning `(values elt next-seed ...)`) |
+| `TAGvector-comparator` | A [`(srfi s128 comparators)`](s128.md) comparator instance: type test, elementwise `=?`, lexicographic `<?` |
+| `(TAGvector->generator v [start [end]])` / `make-TAGvector-generator` | A [`(srfi s158 generators-and-accumulators)`](s158.md)-style generator thunk over the elements |
+
+`comparator?`, `=?`, `<?`, `>?`, `<=?`, `>=?` (SRFI-128's comparator-usage predicates) are re-exported too, so a `TAGvector-comparator` is usable without a separate `(srfi 128)` import.
+
+## Notes
+
+- `f64vector-concatenate` folds pairwise over `(curry f64vector)`'s `f64vector-append` (a fixed 2-argument procedure, unlike the other 8 kinds' N-ary `append`) rather than `apply`-ing it — same observable result, different implementation, because of that underlying arity difference. See [`s4.md`](s4.md).
+- `TAGvector-fold` and `TAGvector-fold-right` deliberately differ in where the accumulator appears in the `kons` call — this matches the SRFI-133/SRFI-160 convention and matters for non-commutative `kons` (e.g. `cons`): `(TAGvector-fold cons '() (u8vector 1 2 3))` nests as `(((() . 1) . 2) . 3)`, while `(TAGvector-fold-right cons '() (u8vector 1 2 3))` produces the plain list `(1 2 3)`.
+- No `f32vector`, matching `(srfi s4 uniform-vectors)`: curry's numeric tower has no native single-precision float representation.
+
+## See also
+
+- [`index.md`](index.md) — full SRFI availability table
+- [`s4.md`](s4.md) — the SRFI-4 core library this extends
+- [`../module-typedvec.md`](../module-typedvec.md) — the underlying `(curry typedvec)` module (u8..s64)
+- Bare `(srfi 160)` and `(srfi srfi-160)` shims re-export the same bindings

--- a/docs/reference/srfi/s4.md
+++ b/docs/reference/srfi/s4.md
@@ -8,7 +8,7 @@ Thin re-export combining two C modules into one [SRFI-4](https://srfi.schemers.o
 
 Only `make-TAGvector`, `TAGvector`, `TAGvector?`, `TAGvector-length`, `TAGvector-ref`, `TAGvector-set!`, `TAGvector->list`, `list->TAGvector`, `TAGvector-copy`, `TAGvector-copy!`, `TAGvector-append`, and `TAGvector-fill!` are re-exported for each kind — the classic SRFI-4 operation set, not `(curry f64vector)`'s much larger numeric-computation surface (`f64vector-dot`, `-map`, `-sum`, trig/exp/log element-wise ops, etc), which stays available only via a direct `(import (curry f64vector))`.
 
-`f64vector-copy!` and `f64vector-append` are **not** re-exported: `(curry f64vector)` has no such procedures (only `f64vector-copy`), so this library re-exports what actually exists rather than adding new C-level operations just for SRFI-4 symmetry.
+`f64vector-copy!` is **not** re-exported: `(curry f64vector)` has no such procedure, so this library re-exports what actually exists rather than adding new C-level operations just for SRFI-4 symmetry. `f64vector-append` *is* re-exported, but note it's a fixed 2-argument procedure in `(curry f64vector)`, not the N-ary form the other 8 kinds have.
 
 No `f32vector`: curry's numeric tower has no native single-precision float representation to back it with.
 
@@ -18,4 +18,5 @@ No `f32vector`: curry's numeric tower has no native single-precision float repre
 
 - [`index.md`](index.md) — full SRFI availability table
 - [`../module-typedvec.md`](../module-typedvec.md) — the underlying `(curry typedvec)` module (u8..s64)
+- [`s160.md`](s160.md) — [SRFI-160](https://srfi.schemers.org/srfi-160/), the extended map/fold/filter/comparator/generator surface layered on top of this library
 - Bare `(srfi 4)` and `(srfi srfi-4)` shims re-export the same bindings

--- a/lib/curry/modules/srfi/160.scm
+++ b/lib/curry/modules/srfi/160.scm
@@ -1,0 +1,94 @@
+(define-library (srfi 160)
+  (import (srfi s160 uniform-vectors))
+  (export
+    make-u8vector u8vector u8vector? u8vector-length u8vector-ref
+    u8vector-set! u8vector->list list->u8vector u8vector-copy
+    u8vector-append u8vector-copy! u8vector-fill! u8vector-empty? u8vector=
+    u8vector-swap! u8vector-reverse! u8vector-reverse-copy u8vector-map
+    u8vector-map! u8vector-for-each u8vector-count u8vector-index
+    u8vector-index-right u8vector-skip u8vector-skip-right u8vector-any
+    u8vector-every u8vector-filter u8vector-remove u8vector-partition
+    u8vector-fold u8vector-fold-right u8vector-concatenate u8vector-unfold
+    u8vector-unfold-right u8vector-comparator u8vector->generator
+    make-u8vector-generator make-s8vector s8vector s8vector?
+    s8vector-length s8vector-ref s8vector-set! s8vector->list
+    list->s8vector s8vector-copy s8vector-append s8vector-copy!
+    s8vector-fill! s8vector-empty? s8vector= s8vector-swap!
+    s8vector-reverse! s8vector-reverse-copy s8vector-map s8vector-map!
+    s8vector-for-each s8vector-count s8vector-index s8vector-index-right
+    s8vector-skip s8vector-skip-right s8vector-any s8vector-every
+    s8vector-filter s8vector-remove s8vector-partition s8vector-fold
+    s8vector-fold-right s8vector-concatenate s8vector-unfold
+    s8vector-unfold-right s8vector-comparator s8vector->generator
+    make-s8vector-generator make-u16vector u16vector u16vector?
+    u16vector-length u16vector-ref u16vector-set! u16vector->list
+    list->u16vector u16vector-copy u16vector-append u16vector-copy!
+    u16vector-fill! u16vector-empty? u16vector= u16vector-swap!
+    u16vector-reverse! u16vector-reverse-copy u16vector-map u16vector-map!
+    u16vector-for-each u16vector-count u16vector-index
+    u16vector-index-right u16vector-skip u16vector-skip-right u16vector-any
+    u16vector-every u16vector-filter u16vector-remove u16vector-partition
+    u16vector-fold u16vector-fold-right u16vector-concatenate
+    u16vector-unfold u16vector-unfold-right u16vector-comparator
+    u16vector->generator make-u16vector-generator make-s16vector s16vector
+    s16vector? s16vector-length s16vector-ref s16vector-set!
+    s16vector->list list->s16vector s16vector-copy s16vector-append
+    s16vector-copy! s16vector-fill! s16vector-empty? s16vector=
+    s16vector-swap! s16vector-reverse! s16vector-reverse-copy s16vector-map
+    s16vector-map! s16vector-for-each s16vector-count s16vector-index
+    s16vector-index-right s16vector-skip s16vector-skip-right s16vector-any
+    s16vector-every s16vector-filter s16vector-remove s16vector-partition
+    s16vector-fold s16vector-fold-right s16vector-concatenate
+    s16vector-unfold s16vector-unfold-right s16vector-comparator
+    s16vector->generator make-s16vector-generator make-u32vector u32vector
+    u32vector? u32vector-length u32vector-ref u32vector-set!
+    u32vector->list list->u32vector u32vector-copy u32vector-append
+    u32vector-copy! u32vector-fill! u32vector-empty? u32vector=
+    u32vector-swap! u32vector-reverse! u32vector-reverse-copy u32vector-map
+    u32vector-map! u32vector-for-each u32vector-count u32vector-index
+    u32vector-index-right u32vector-skip u32vector-skip-right u32vector-any
+    u32vector-every u32vector-filter u32vector-remove u32vector-partition
+    u32vector-fold u32vector-fold-right u32vector-concatenate
+    u32vector-unfold u32vector-unfold-right u32vector-comparator
+    u32vector->generator make-u32vector-generator make-s32vector s32vector
+    s32vector? s32vector-length s32vector-ref s32vector-set!
+    s32vector->list list->s32vector s32vector-copy s32vector-append
+    s32vector-copy! s32vector-fill! s32vector-empty? s32vector=
+    s32vector-swap! s32vector-reverse! s32vector-reverse-copy s32vector-map
+    s32vector-map! s32vector-for-each s32vector-count s32vector-index
+    s32vector-index-right s32vector-skip s32vector-skip-right s32vector-any
+    s32vector-every s32vector-filter s32vector-remove s32vector-partition
+    s32vector-fold s32vector-fold-right s32vector-concatenate
+    s32vector-unfold s32vector-unfold-right s32vector-comparator
+    s32vector->generator make-s32vector-generator make-u64vector u64vector
+    u64vector? u64vector-length u64vector-ref u64vector-set!
+    u64vector->list list->u64vector u64vector-copy u64vector-append
+    u64vector-copy! u64vector-fill! u64vector-empty? u64vector=
+    u64vector-swap! u64vector-reverse! u64vector-reverse-copy u64vector-map
+    u64vector-map! u64vector-for-each u64vector-count u64vector-index
+    u64vector-index-right u64vector-skip u64vector-skip-right u64vector-any
+    u64vector-every u64vector-filter u64vector-remove u64vector-partition
+    u64vector-fold u64vector-fold-right u64vector-concatenate
+    u64vector-unfold u64vector-unfold-right u64vector-comparator
+    u64vector->generator make-u64vector-generator make-s64vector s64vector
+    s64vector? s64vector-length s64vector-ref s64vector-set!
+    s64vector->list list->s64vector s64vector-copy s64vector-append
+    s64vector-copy! s64vector-fill! s64vector-empty? s64vector=
+    s64vector-swap! s64vector-reverse! s64vector-reverse-copy s64vector-map
+    s64vector-map! s64vector-for-each s64vector-count s64vector-index
+    s64vector-index-right s64vector-skip s64vector-skip-right s64vector-any
+    s64vector-every s64vector-filter s64vector-remove s64vector-partition
+    s64vector-fold s64vector-fold-right s64vector-concatenate
+    s64vector-unfold s64vector-unfold-right s64vector-comparator
+    s64vector->generator make-s64vector-generator make-f64vector f64vector
+    f64vector? f64vector-length f64vector-ref f64vector-set!
+    f64vector->list list->f64vector f64vector-copy f64vector-append
+    f64vector-fill! f64vector-empty? f64vector= f64vector-swap!
+    f64vector-reverse! f64vector-reverse-copy f64vector-map f64vector-map!
+    f64vector-for-each f64vector-count f64vector-index
+    f64vector-index-right f64vector-skip f64vector-skip-right f64vector-any
+    f64vector-every f64vector-filter f64vector-remove f64vector-partition
+    f64vector-fold f64vector-fold-right f64vector-concatenate
+    f64vector-unfold f64vector-unfold-right f64vector-comparator
+    f64vector->generator make-f64vector-generator comparator? =? <? >? <=?
+    >=?))

--- a/lib/curry/modules/srfi/4.scm
+++ b/lib/curry/modules/srfi/4.scm
@@ -35,4 +35,4 @@
 
     make-f64vector f64vector f64vector? f64vector-length f64vector-ref
     f64vector-set! f64vector->list list->f64vector f64vector-copy
-    f64vector-fill!))
+    f64vector-append f64vector-fill!))

--- a/lib/curry/modules/srfi/s160/uniform-vectors.scm
+++ b/lib/curry/modules/srfi/s160/uniform-vectors.scm
@@ -1,0 +1,1740 @@
+(define-library (srfi s160 uniform-vectors)
+  (import (scheme base) (srfi s4 uniform-vectors) (srfi s128 comparators)
+          (srfi s1 lists))
+  (export
+    make-u8vector u8vector u8vector? u8vector-length u8vector-ref
+    u8vector-set! u8vector->list list->u8vector u8vector-copy
+    u8vector-append u8vector-copy! u8vector-fill! u8vector-empty? u8vector=
+    u8vector-swap! u8vector-reverse! u8vector-reverse-copy u8vector-map
+    u8vector-map! u8vector-for-each u8vector-count u8vector-index
+    u8vector-index-right u8vector-skip u8vector-skip-right u8vector-any
+    u8vector-every u8vector-filter u8vector-remove u8vector-partition
+    u8vector-fold u8vector-fold-right u8vector-concatenate u8vector-unfold
+    u8vector-unfold-right u8vector-comparator u8vector->generator
+    make-u8vector-generator make-s8vector s8vector s8vector?
+    s8vector-length s8vector-ref s8vector-set! s8vector->list
+    list->s8vector s8vector-copy s8vector-append s8vector-copy!
+    s8vector-fill! s8vector-empty? s8vector= s8vector-swap!
+    s8vector-reverse! s8vector-reverse-copy s8vector-map s8vector-map!
+    s8vector-for-each s8vector-count s8vector-index s8vector-index-right
+    s8vector-skip s8vector-skip-right s8vector-any s8vector-every
+    s8vector-filter s8vector-remove s8vector-partition s8vector-fold
+    s8vector-fold-right s8vector-concatenate s8vector-unfold
+    s8vector-unfold-right s8vector-comparator s8vector->generator
+    make-s8vector-generator make-u16vector u16vector u16vector?
+    u16vector-length u16vector-ref u16vector-set! u16vector->list
+    list->u16vector u16vector-copy u16vector-append u16vector-copy!
+    u16vector-fill! u16vector-empty? u16vector= u16vector-swap!
+    u16vector-reverse! u16vector-reverse-copy u16vector-map u16vector-map!
+    u16vector-for-each u16vector-count u16vector-index
+    u16vector-index-right u16vector-skip u16vector-skip-right u16vector-any
+    u16vector-every u16vector-filter u16vector-remove u16vector-partition
+    u16vector-fold u16vector-fold-right u16vector-concatenate
+    u16vector-unfold u16vector-unfold-right u16vector-comparator
+    u16vector->generator make-u16vector-generator make-s16vector s16vector
+    s16vector? s16vector-length s16vector-ref s16vector-set!
+    s16vector->list list->s16vector s16vector-copy s16vector-append
+    s16vector-copy! s16vector-fill! s16vector-empty? s16vector=
+    s16vector-swap! s16vector-reverse! s16vector-reverse-copy s16vector-map
+    s16vector-map! s16vector-for-each s16vector-count s16vector-index
+    s16vector-index-right s16vector-skip s16vector-skip-right s16vector-any
+    s16vector-every s16vector-filter s16vector-remove s16vector-partition
+    s16vector-fold s16vector-fold-right s16vector-concatenate
+    s16vector-unfold s16vector-unfold-right s16vector-comparator
+    s16vector->generator make-s16vector-generator make-u32vector u32vector
+    u32vector? u32vector-length u32vector-ref u32vector-set!
+    u32vector->list list->u32vector u32vector-copy u32vector-append
+    u32vector-copy! u32vector-fill! u32vector-empty? u32vector=
+    u32vector-swap! u32vector-reverse! u32vector-reverse-copy u32vector-map
+    u32vector-map! u32vector-for-each u32vector-count u32vector-index
+    u32vector-index-right u32vector-skip u32vector-skip-right u32vector-any
+    u32vector-every u32vector-filter u32vector-remove u32vector-partition
+    u32vector-fold u32vector-fold-right u32vector-concatenate
+    u32vector-unfold u32vector-unfold-right u32vector-comparator
+    u32vector->generator make-u32vector-generator make-s32vector s32vector
+    s32vector? s32vector-length s32vector-ref s32vector-set!
+    s32vector->list list->s32vector s32vector-copy s32vector-append
+    s32vector-copy! s32vector-fill! s32vector-empty? s32vector=
+    s32vector-swap! s32vector-reverse! s32vector-reverse-copy s32vector-map
+    s32vector-map! s32vector-for-each s32vector-count s32vector-index
+    s32vector-index-right s32vector-skip s32vector-skip-right s32vector-any
+    s32vector-every s32vector-filter s32vector-remove s32vector-partition
+    s32vector-fold s32vector-fold-right s32vector-concatenate
+    s32vector-unfold s32vector-unfold-right s32vector-comparator
+    s32vector->generator make-s32vector-generator make-u64vector u64vector
+    u64vector? u64vector-length u64vector-ref u64vector-set!
+    u64vector->list list->u64vector u64vector-copy u64vector-append
+    u64vector-copy! u64vector-fill! u64vector-empty? u64vector=
+    u64vector-swap! u64vector-reverse! u64vector-reverse-copy u64vector-map
+    u64vector-map! u64vector-for-each u64vector-count u64vector-index
+    u64vector-index-right u64vector-skip u64vector-skip-right u64vector-any
+    u64vector-every u64vector-filter u64vector-remove u64vector-partition
+    u64vector-fold u64vector-fold-right u64vector-concatenate
+    u64vector-unfold u64vector-unfold-right u64vector-comparator
+    u64vector->generator make-u64vector-generator make-s64vector s64vector
+    s64vector? s64vector-length s64vector-ref s64vector-set!
+    s64vector->list list->s64vector s64vector-copy s64vector-append
+    s64vector-copy! s64vector-fill! s64vector-empty? s64vector=
+    s64vector-swap! s64vector-reverse! s64vector-reverse-copy s64vector-map
+    s64vector-map! s64vector-for-each s64vector-count s64vector-index
+    s64vector-index-right s64vector-skip s64vector-skip-right s64vector-any
+    s64vector-every s64vector-filter s64vector-remove s64vector-partition
+    s64vector-fold s64vector-fold-right s64vector-concatenate
+    s64vector-unfold s64vector-unfold-right s64vector-comparator
+    s64vector->generator make-s64vector-generator make-f64vector f64vector
+    f64vector? f64vector-length f64vector-ref f64vector-set!
+    f64vector->list list->f64vector f64vector-copy f64vector-append
+    f64vector-fill! f64vector-empty? f64vector= f64vector-swap!
+    f64vector-reverse! f64vector-reverse-copy f64vector-map f64vector-map!
+    f64vector-for-each f64vector-count f64vector-index
+    f64vector-index-right f64vector-skip f64vector-skip-right f64vector-any
+    f64vector-every f64vector-filter f64vector-remove f64vector-partition
+    f64vector-fold f64vector-fold-right f64vector-concatenate
+    f64vector-unfold f64vector-unfold-right f64vector-comparator
+    f64vector->generator make-f64vector-generator comparator? =? <? >? <=?
+    >=?)
+  (begin
+
+    ;; ---- u8vector: extended ops (SRFI-160-style) ----
+
+    (define (u8vector-empty? v) (= (u8vector-length v) 0))
+
+    (define (u8vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (u8vector-length a) (u8vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (u8vector-length a))
+                               (and (= (u8vector-ref a i) (u8vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (u8vector-swap! v i j)
+      (let ((tmp (u8vector-ref v i)))
+        (u8vector-set! v i (u8vector-ref v j))
+        (u8vector-set! v j tmp)))
+
+    (define (u8vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u8vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (u8vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (u8vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u8vector-length v)))
+             (n (- end start))
+             (out (make-u8vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (u8vector-set! out i (u8vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (u8vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs)))
+             (out (make-u8vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (u8vector-set! out i (apply f (map (lambda (vv) (u8vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (u8vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (u8vector-set! v1 i (apply f (map (lambda (vv) (u8vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (u8vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (u8vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (u8vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (u8vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (u8vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (u8vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (u8vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (u8vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (u8vector-skip pred v1 . vs) (apply u8vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (u8vector-skip-right pred v1 . vs) (apply u8vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (u8vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (u8vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (u8vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (u8vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (u8vector-filter pred v)
+      (list->u8vector (filter pred (u8vector->list v))))
+
+    (define (u8vector-remove pred v)
+      (list->u8vector (remove pred (u8vector->list v))))
+
+    (define (u8vector-partition pred v)
+      (let-values (((yes no) (partition pred (u8vector->list v))))
+        (values (list->u8vector yes) (list->u8vector no))))
+
+    (define (u8vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (u8vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from u8vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (u8vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u8vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (u8vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (u8vector-concatenate vs) (apply u8vector-append vs))
+
+    (define (u8vector-unfold f length . seeds)
+      (let ((out (make-u8vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (u8vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (u8vector-unfold-right f length . seeds)
+      (let ((out (make-u8vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (u8vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define u8vector-comparator
+      (make-comparator
+        u8vector?
+        u8vector=
+        (lambda (a b)
+          (let ((la (u8vector-length a)) (lb (u8vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (u8vector-ref a i) (u8vector-ref b i)) (loop (+ i 1)))
+                        (else (< (u8vector-ref a i) (u8vector-ref b i))))))))
+        #f))
+
+    (define (u8vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u8vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (u8vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-u8vector-generator v . range) (apply u8vector->generator v range))
+
+    ;; ---- s8vector: extended ops (SRFI-160-style) ----
+
+    (define (s8vector-empty? v) (= (s8vector-length v) 0))
+
+    (define (s8vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (s8vector-length a) (s8vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (s8vector-length a))
+                               (and (= (s8vector-ref a i) (s8vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (s8vector-swap! v i j)
+      (let ((tmp (s8vector-ref v i)))
+        (s8vector-set! v i (s8vector-ref v j))
+        (s8vector-set! v j tmp)))
+
+    (define (s8vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s8vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (s8vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (s8vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s8vector-length v)))
+             (n (- end start))
+             (out (make-s8vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (s8vector-set! out i (s8vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (s8vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs)))
+             (out (make-s8vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (s8vector-set! out i (apply f (map (lambda (vv) (s8vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (s8vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (s8vector-set! v1 i (apply f (map (lambda (vv) (s8vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (s8vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (s8vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (s8vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (s8vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (s8vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (s8vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (s8vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (s8vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (s8vector-skip pred v1 . vs) (apply s8vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (s8vector-skip-right pred v1 . vs) (apply s8vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (s8vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (s8vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (s8vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (s8vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (s8vector-filter pred v)
+      (list->s8vector (filter pred (s8vector->list v))))
+
+    (define (s8vector-remove pred v)
+      (list->s8vector (remove pred (s8vector->list v))))
+
+    (define (s8vector-partition pred v)
+      (let-values (((yes no) (partition pred (s8vector->list v))))
+        (values (list->s8vector yes) (list->s8vector no))))
+
+    (define (s8vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (s8vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from s8vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (s8vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s8vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (s8vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (s8vector-concatenate vs) (apply s8vector-append vs))
+
+    (define (s8vector-unfold f length . seeds)
+      (let ((out (make-s8vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (s8vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (s8vector-unfold-right f length . seeds)
+      (let ((out (make-s8vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (s8vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define s8vector-comparator
+      (make-comparator
+        s8vector?
+        s8vector=
+        (lambda (a b)
+          (let ((la (s8vector-length a)) (lb (s8vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (s8vector-ref a i) (s8vector-ref b i)) (loop (+ i 1)))
+                        (else (< (s8vector-ref a i) (s8vector-ref b i))))))))
+        #f))
+
+    (define (s8vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s8vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (s8vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-s8vector-generator v . range) (apply s8vector->generator v range))
+
+    ;; ---- u16vector: extended ops (SRFI-160-style) ----
+
+    (define (u16vector-empty? v) (= (u16vector-length v) 0))
+
+    (define (u16vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (u16vector-length a) (u16vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (u16vector-length a))
+                               (and (= (u16vector-ref a i) (u16vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (u16vector-swap! v i j)
+      (let ((tmp (u16vector-ref v i)))
+        (u16vector-set! v i (u16vector-ref v j))
+        (u16vector-set! v j tmp)))
+
+    (define (u16vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u16vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (u16vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (u16vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u16vector-length v)))
+             (n (- end start))
+             (out (make-u16vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (u16vector-set! out i (u16vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (u16vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs)))
+             (out (make-u16vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (u16vector-set! out i (apply f (map (lambda (vv) (u16vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (u16vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (u16vector-set! v1 i (apply f (map (lambda (vv) (u16vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (u16vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (u16vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (u16vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (u16vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (u16vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (u16vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (u16vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (u16vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (u16vector-skip pred v1 . vs) (apply u16vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (u16vector-skip-right pred v1 . vs) (apply u16vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (u16vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (u16vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (u16vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (u16vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (u16vector-filter pred v)
+      (list->u16vector (filter pred (u16vector->list v))))
+
+    (define (u16vector-remove pred v)
+      (list->u16vector (remove pred (u16vector->list v))))
+
+    (define (u16vector-partition pred v)
+      (let-values (((yes no) (partition pred (u16vector->list v))))
+        (values (list->u16vector yes) (list->u16vector no))))
+
+    (define (u16vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (u16vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from u16vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (u16vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u16vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (u16vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (u16vector-concatenate vs) (apply u16vector-append vs))
+
+    (define (u16vector-unfold f length . seeds)
+      (let ((out (make-u16vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (u16vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (u16vector-unfold-right f length . seeds)
+      (let ((out (make-u16vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (u16vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define u16vector-comparator
+      (make-comparator
+        u16vector?
+        u16vector=
+        (lambda (a b)
+          (let ((la (u16vector-length a)) (lb (u16vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (u16vector-ref a i) (u16vector-ref b i)) (loop (+ i 1)))
+                        (else (< (u16vector-ref a i) (u16vector-ref b i))))))))
+        #f))
+
+    (define (u16vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u16vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (u16vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-u16vector-generator v . range) (apply u16vector->generator v range))
+
+    ;; ---- s16vector: extended ops (SRFI-160-style) ----
+
+    (define (s16vector-empty? v) (= (s16vector-length v) 0))
+
+    (define (s16vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (s16vector-length a) (s16vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (s16vector-length a))
+                               (and (= (s16vector-ref a i) (s16vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (s16vector-swap! v i j)
+      (let ((tmp (s16vector-ref v i)))
+        (s16vector-set! v i (s16vector-ref v j))
+        (s16vector-set! v j tmp)))
+
+    (define (s16vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s16vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (s16vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (s16vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s16vector-length v)))
+             (n (- end start))
+             (out (make-s16vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (s16vector-set! out i (s16vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (s16vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs)))
+             (out (make-s16vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (s16vector-set! out i (apply f (map (lambda (vv) (s16vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (s16vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (s16vector-set! v1 i (apply f (map (lambda (vv) (s16vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (s16vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (s16vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (s16vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (s16vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (s16vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (s16vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (s16vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (s16vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (s16vector-skip pred v1 . vs) (apply s16vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (s16vector-skip-right pred v1 . vs) (apply s16vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (s16vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (s16vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (s16vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (s16vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (s16vector-filter pred v)
+      (list->s16vector (filter pred (s16vector->list v))))
+
+    (define (s16vector-remove pred v)
+      (list->s16vector (remove pred (s16vector->list v))))
+
+    (define (s16vector-partition pred v)
+      (let-values (((yes no) (partition pred (s16vector->list v))))
+        (values (list->s16vector yes) (list->s16vector no))))
+
+    (define (s16vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (s16vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from s16vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (s16vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s16vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (s16vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (s16vector-concatenate vs) (apply s16vector-append vs))
+
+    (define (s16vector-unfold f length . seeds)
+      (let ((out (make-s16vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (s16vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (s16vector-unfold-right f length . seeds)
+      (let ((out (make-s16vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (s16vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define s16vector-comparator
+      (make-comparator
+        s16vector?
+        s16vector=
+        (lambda (a b)
+          (let ((la (s16vector-length a)) (lb (s16vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (s16vector-ref a i) (s16vector-ref b i)) (loop (+ i 1)))
+                        (else (< (s16vector-ref a i) (s16vector-ref b i))))))))
+        #f))
+
+    (define (s16vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s16vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (s16vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-s16vector-generator v . range) (apply s16vector->generator v range))
+
+    ;; ---- u32vector: extended ops (SRFI-160-style) ----
+
+    (define (u32vector-empty? v) (= (u32vector-length v) 0))
+
+    (define (u32vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (u32vector-length a) (u32vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (u32vector-length a))
+                               (and (= (u32vector-ref a i) (u32vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (u32vector-swap! v i j)
+      (let ((tmp (u32vector-ref v i)))
+        (u32vector-set! v i (u32vector-ref v j))
+        (u32vector-set! v j tmp)))
+
+    (define (u32vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u32vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (u32vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (u32vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u32vector-length v)))
+             (n (- end start))
+             (out (make-u32vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (u32vector-set! out i (u32vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (u32vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs)))
+             (out (make-u32vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (u32vector-set! out i (apply f (map (lambda (vv) (u32vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (u32vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (u32vector-set! v1 i (apply f (map (lambda (vv) (u32vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (u32vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (u32vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (u32vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (u32vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (u32vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (u32vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (u32vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (u32vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (u32vector-skip pred v1 . vs) (apply u32vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (u32vector-skip-right pred v1 . vs) (apply u32vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (u32vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (u32vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (u32vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (u32vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (u32vector-filter pred v)
+      (list->u32vector (filter pred (u32vector->list v))))
+
+    (define (u32vector-remove pred v)
+      (list->u32vector (remove pred (u32vector->list v))))
+
+    (define (u32vector-partition pred v)
+      (let-values (((yes no) (partition pred (u32vector->list v))))
+        (values (list->u32vector yes) (list->u32vector no))))
+
+    (define (u32vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (u32vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from u32vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (u32vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u32vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (u32vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (u32vector-concatenate vs) (apply u32vector-append vs))
+
+    (define (u32vector-unfold f length . seeds)
+      (let ((out (make-u32vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (u32vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (u32vector-unfold-right f length . seeds)
+      (let ((out (make-u32vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (u32vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define u32vector-comparator
+      (make-comparator
+        u32vector?
+        u32vector=
+        (lambda (a b)
+          (let ((la (u32vector-length a)) (lb (u32vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (u32vector-ref a i) (u32vector-ref b i)) (loop (+ i 1)))
+                        (else (< (u32vector-ref a i) (u32vector-ref b i))))))))
+        #f))
+
+    (define (u32vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u32vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (u32vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-u32vector-generator v . range) (apply u32vector->generator v range))
+
+    ;; ---- s32vector: extended ops (SRFI-160-style) ----
+
+    (define (s32vector-empty? v) (= (s32vector-length v) 0))
+
+    (define (s32vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (s32vector-length a) (s32vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (s32vector-length a))
+                               (and (= (s32vector-ref a i) (s32vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (s32vector-swap! v i j)
+      (let ((tmp (s32vector-ref v i)))
+        (s32vector-set! v i (s32vector-ref v j))
+        (s32vector-set! v j tmp)))
+
+    (define (s32vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s32vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (s32vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (s32vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s32vector-length v)))
+             (n (- end start))
+             (out (make-s32vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (s32vector-set! out i (s32vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (s32vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs)))
+             (out (make-s32vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (s32vector-set! out i (apply f (map (lambda (vv) (s32vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (s32vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (s32vector-set! v1 i (apply f (map (lambda (vv) (s32vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (s32vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (s32vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (s32vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (s32vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (s32vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (s32vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (s32vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (s32vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (s32vector-skip pred v1 . vs) (apply s32vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (s32vector-skip-right pred v1 . vs) (apply s32vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (s32vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (s32vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (s32vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (s32vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (s32vector-filter pred v)
+      (list->s32vector (filter pred (s32vector->list v))))
+
+    (define (s32vector-remove pred v)
+      (list->s32vector (remove pred (s32vector->list v))))
+
+    (define (s32vector-partition pred v)
+      (let-values (((yes no) (partition pred (s32vector->list v))))
+        (values (list->s32vector yes) (list->s32vector no))))
+
+    (define (s32vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (s32vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from s32vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (s32vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s32vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (s32vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (s32vector-concatenate vs) (apply s32vector-append vs))
+
+    (define (s32vector-unfold f length . seeds)
+      (let ((out (make-s32vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (s32vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (s32vector-unfold-right f length . seeds)
+      (let ((out (make-s32vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (s32vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define s32vector-comparator
+      (make-comparator
+        s32vector?
+        s32vector=
+        (lambda (a b)
+          (let ((la (s32vector-length a)) (lb (s32vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (s32vector-ref a i) (s32vector-ref b i)) (loop (+ i 1)))
+                        (else (< (s32vector-ref a i) (s32vector-ref b i))))))))
+        #f))
+
+    (define (s32vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s32vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (s32vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-s32vector-generator v . range) (apply s32vector->generator v range))
+
+    ;; ---- u64vector: extended ops (SRFI-160-style) ----
+
+    (define (u64vector-empty? v) (= (u64vector-length v) 0))
+
+    (define (u64vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (u64vector-length a) (u64vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (u64vector-length a))
+                               (and (= (u64vector-ref a i) (u64vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (u64vector-swap! v i j)
+      (let ((tmp (u64vector-ref v i)))
+        (u64vector-set! v i (u64vector-ref v j))
+        (u64vector-set! v j tmp)))
+
+    (define (u64vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u64vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (u64vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (u64vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u64vector-length v)))
+             (n (- end start))
+             (out (make-u64vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (u64vector-set! out i (u64vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (u64vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs)))
+             (out (make-u64vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (u64vector-set! out i (apply f (map (lambda (vv) (u64vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (u64vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (u64vector-set! v1 i (apply f (map (lambda (vv) (u64vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (u64vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (u64vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (u64vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (u64vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (u64vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (u64vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (u64vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (u64vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (u64vector-skip pred v1 . vs) (apply u64vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (u64vector-skip-right pred v1 . vs) (apply u64vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (u64vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (u64vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (u64vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (u64vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (u64vector-filter pred v)
+      (list->u64vector (filter pred (u64vector->list v))))
+
+    (define (u64vector-remove pred v)
+      (list->u64vector (remove pred (u64vector->list v))))
+
+    (define (u64vector-partition pred v)
+      (let-values (((yes no) (partition pred (u64vector->list v))))
+        (values (list->u64vector yes) (list->u64vector no))))
+
+    (define (u64vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (u64vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from u64vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (u64vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map u64vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (u64vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (u64vector-concatenate vs) (apply u64vector-append vs))
+
+    (define (u64vector-unfold f length . seeds)
+      (let ((out (make-u64vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (u64vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (u64vector-unfold-right f length . seeds)
+      (let ((out (make-u64vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (u64vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define u64vector-comparator
+      (make-comparator
+        u64vector?
+        u64vector=
+        (lambda (a b)
+          (let ((la (u64vector-length a)) (lb (u64vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (u64vector-ref a i) (u64vector-ref b i)) (loop (+ i 1)))
+                        (else (< (u64vector-ref a i) (u64vector-ref b i))))))))
+        #f))
+
+    (define (u64vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (u64vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (u64vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-u64vector-generator v . range) (apply u64vector->generator v range))
+
+    ;; ---- s64vector: extended ops (SRFI-160-style) ----
+
+    (define (s64vector-empty? v) (= (s64vector-length v) 0))
+
+    (define (s64vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (s64vector-length a) (s64vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (s64vector-length a))
+                               (and (= (s64vector-ref a i) (s64vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (s64vector-swap! v i j)
+      (let ((tmp (s64vector-ref v i)))
+        (s64vector-set! v i (s64vector-ref v j))
+        (s64vector-set! v j tmp)))
+
+    (define (s64vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s64vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (s64vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (s64vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s64vector-length v)))
+             (n (- end start))
+             (out (make-s64vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (s64vector-set! out i (s64vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (s64vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs)))
+             (out (make-s64vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (s64vector-set! out i (apply f (map (lambda (vv) (s64vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (s64vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (s64vector-set! v1 i (apply f (map (lambda (vv) (s64vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (s64vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (s64vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (s64vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (s64vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (s64vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (s64vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (s64vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (s64vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (s64vector-skip pred v1 . vs) (apply s64vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (s64vector-skip-right pred v1 . vs) (apply s64vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (s64vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (s64vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (s64vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (s64vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (s64vector-filter pred v)
+      (list->s64vector (filter pred (s64vector->list v))))
+
+    (define (s64vector-remove pred v)
+      (list->s64vector (remove pred (s64vector->list v))))
+
+    (define (s64vector-partition pred v)
+      (let-values (((yes no) (partition pred (s64vector->list v))))
+        (values (list->s64vector yes) (list->s64vector no))))
+
+    (define (s64vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (s64vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from s64vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (s64vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map s64vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (s64vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (s64vector-concatenate vs) (apply s64vector-append vs))
+
+    (define (s64vector-unfold f length . seeds)
+      (let ((out (make-s64vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (s64vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (s64vector-unfold-right f length . seeds)
+      (let ((out (make-s64vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (s64vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define s64vector-comparator
+      (make-comparator
+        s64vector?
+        s64vector=
+        (lambda (a b)
+          (let ((la (s64vector-length a)) (lb (s64vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (s64vector-ref a i) (s64vector-ref b i)) (loop (+ i 1)))
+                        (else (< (s64vector-ref a i) (s64vector-ref b i))))))))
+        #f))
+
+    (define (s64vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (s64vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (s64vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-s64vector-generator v . range) (apply s64vector->generator v range))
+
+    ;; ---- f64vector: extended ops (SRFI-160-style) ----
+
+    (define (f64vector-empty? v) (= (f64vector-length v) 0))
+
+    (define (f64vector= . vs)
+      (or (null? vs) (null? (cdr vs))
+          (let ((a (car vs)))
+            (let loop ((rest (cdr vs)))
+              (or (null? rest)
+                  (let ((b (car rest)))
+                    (and (= (f64vector-length a) (f64vector-length b))
+                         (let eq-loop ((i 0))
+                           (or (= i (f64vector-length a))
+                               (and (= (f64vector-ref a i) (f64vector-ref b i))
+                                    (eq-loop (+ i 1)))))
+                         (loop (cdr rest)))))))))
+
+    (define (f64vector-swap! v i j)
+      (let ((tmp (f64vector-ref v i)))
+        (f64vector-set! v i (f64vector-ref v j))
+        (f64vector-set! v j tmp)))
+
+    (define (f64vector-reverse! v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (f64vector-length v))))
+        (let loop ((i start) (j (- end 1)))
+          (when (< i j) (f64vector-swap! v i j) (loop (+ i 1) (- j 1))))))
+
+    (define (f64vector-reverse-copy v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (f64vector-length v)))
+             (n (- end start))
+             (out (make-f64vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (f64vector-set! out i (f64vector-ref v (- end 1 i)))
+            (loop (+ i 1))))
+        out))
+
+    (define (f64vector-map f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs)))
+             (out (make-f64vector n)))
+        (let loop ((i 0))
+          (when (< i n)
+            (f64vector-set! out i (apply f (map (lambda (vv) (f64vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        out))
+
+    (define (f64vector-map! f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (f64vector-set! v1 i (apply f (map (lambda (vv) (f64vector-ref vv i)) vecs)))
+            (loop (+ i 1))))
+        v1))
+
+    (define (f64vector-for-each f v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i 0))
+          (when (< i n)
+            (apply f (map (lambda (vv) (f64vector-ref vv i)) vecs))
+            (loop (+ i 1))))))
+
+    (define (f64vector-count pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i 0) (acc 0))
+          (if (= i n) acc
+              (loop (+ i 1) (if (apply pred (map (lambda (vv) (f64vector-ref vv i)) vecs)) (+ acc 1) acc))))))
+
+    (define (f64vector-index pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i 0))
+          (cond ((= i n) #f)
+                ((apply pred (map (lambda (vv) (f64vector-ref vv i)) vecs)) i)
+                (else (loop (+ i 1)))))))
+
+    (define (f64vector-index-right pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i (- n 1)))
+          (cond ((< i 0) #f)
+                ((apply pred (map (lambda (vv) (f64vector-ref vv i)) vecs)) i)
+                (else (loop (- i 1)))))))
+
+    (define (f64vector-skip pred v1 . vs) (apply f64vector-index (lambda args (not (apply pred args))) v1 vs))
+    (define (f64vector-skip-right pred v1 . vs) (apply f64vector-index-right (lambda args (not (apply pred args))) v1 vs))
+
+    (define (f64vector-any pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i 0))
+          (and (< i n)
+               (or (apply pred (map (lambda (vv) (f64vector-ref vv i)) vecs))
+                   (loop (+ i 1)))))))
+
+    (define (f64vector-every pred v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i 0) (last #t))
+          (if (= i n) last
+              (let ((r (apply pred (map (lambda (vv) (f64vector-ref vv i)) vecs))))
+                (and r (loop (+ i 1) r)))))))
+
+    (define (f64vector-filter pred v)
+      (list->f64vector (filter pred (f64vector->list v))))
+
+    (define (f64vector-remove pred v)
+      (list->f64vector (remove pred (f64vector->list v))))
+
+    (define (f64vector-partition pred v)
+      (let-values (((yes no) (partition pred (f64vector->list v))))
+        (values (list->f64vector yes) (list->f64vector no))))
+
+    (define (f64vector-fold kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i 0) (acc knil))
+          (if (= i n) acc
+              (loop (+ i 1) (apply kons acc (map (lambda (vv) (f64vector-ref vv i)) vecs)))))))
+
+    ;; Note the argument order differs from f64vector-fold above: kons
+    ;; here receives the current elements FIRST and the accumulator LAST
+    ;; (e.g. (kons e1 e2 ... acc)), matching SRFI-133/SRFI-160's own
+    ;; fold-right convention -- not the same order as fold's (kons acc
+    ;; e1 e2 ...), which matters for a non-commutative kons like cons.
+    (define (f64vector-fold-right kons knil v1 . vs)
+      (let* ((vecs (cons v1 vs))
+             (n (apply min (map f64vector-length vecs))))
+        (let loop ((i (- n 1)) (acc knil))
+          (if (< i 0) acc
+              (loop (- i 1) (apply kons (append (map (lambda (vv) (f64vector-ref vv i)) vecs) (list acc))))))))
+
+    (define (f64vector-concatenate vs)
+      ;; (curry f64vector)'s f64vector-append is a fixed 2-arg procedure
+      ;; (unlike the other 8 kinds' N-ary append), so concatenating N
+      ;; vectors folds pairwise instead of apply-ing.
+      (if (null? vs) (f64vector)
+          (fold-left f64vector-append (car vs) (cdr vs))))
+
+    (define (f64vector-unfold f length . seeds)
+      (let ((out (make-f64vector length)))
+        (let loop ((i 0) (ss seeds))
+          (when (< i length)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (f64vector-set! out i val)
+                (loop (+ i 1) next-ss)))))
+        out))
+
+    (define (f64vector-unfold-right f length . seeds)
+      (let ((out (make-f64vector length)))
+        (let loop ((i (- length 1)) (ss seeds))
+          (when (>= i 0)
+            (call-with-values (lambda () (apply f i ss))
+              (lambda (val . next-ss)
+                (f64vector-set! out i val)
+                (loop (- i 1) next-ss)))))
+        out))
+
+    (define f64vector-comparator
+      (make-comparator
+        f64vector?
+        f64vector=
+        (lambda (a b)
+          (let ((la (f64vector-length a)) (lb (f64vector-length b)))
+            (if (not (= la lb)) (< la lb)
+                (let loop ((i 0))
+                  (cond ((= i la) #f)
+                        ((= (f64vector-ref a i) (f64vector-ref b i)) (loop (+ i 1)))
+                        (else (< (f64vector-ref a i) (f64vector-ref b i))))))))
+        #f))
+
+    (define (f64vector->generator v . range)
+      (let* ((start (if (pair? range) (car range) 0))
+             (end (if (and (pair? range) (pair? (cdr range))) (cadr range) (f64vector-length v)))
+             (i start))
+        (lambda ()
+          (if (>= i end) (eof-object)
+              (let ((x (f64vector-ref v i))) (set! i (+ i 1)) x)))))
+
+    (define (make-f64vector-generator v . range) (apply f64vector->generator v range))
+))

--- a/lib/curry/modules/srfi/s160/uniform-vectors.scm
+++ b/lib/curry/modules/srfi/s160/uniform-vectors.scm
@@ -234,24 +234,34 @@
 
     (define (u8vector-concatenate vs) (apply u8vector-append vs))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (u8vector-unfold f length . seeds)
-      (let ((out (make-u8vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-u8vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (u8vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (u8vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (u8vector-unfold-right f length . seeds)
-      (let ((out (make-u8vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-u8vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (u8vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (u8vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define u8vector-comparator
@@ -416,24 +426,34 @@
 
     (define (s8vector-concatenate vs) (apply s8vector-append vs))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (s8vector-unfold f length . seeds)
-      (let ((out (make-s8vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-s8vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (s8vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (s8vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (s8vector-unfold-right f length . seeds)
-      (let ((out (make-s8vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-s8vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (s8vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (s8vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define s8vector-comparator
@@ -598,24 +618,34 @@
 
     (define (u16vector-concatenate vs) (apply u16vector-append vs))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (u16vector-unfold f length . seeds)
-      (let ((out (make-u16vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-u16vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (u16vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (u16vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (u16vector-unfold-right f length . seeds)
-      (let ((out (make-u16vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-u16vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (u16vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (u16vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define u16vector-comparator
@@ -780,24 +810,34 @@
 
     (define (s16vector-concatenate vs) (apply s16vector-append vs))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (s16vector-unfold f length . seeds)
-      (let ((out (make-s16vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-s16vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (s16vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (s16vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (s16vector-unfold-right f length . seeds)
-      (let ((out (make-s16vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-s16vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (s16vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (s16vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define s16vector-comparator
@@ -962,24 +1002,34 @@
 
     (define (u32vector-concatenate vs) (apply u32vector-append vs))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (u32vector-unfold f length . seeds)
-      (let ((out (make-u32vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-u32vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (u32vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (u32vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (u32vector-unfold-right f length . seeds)
-      (let ((out (make-u32vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-u32vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (u32vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (u32vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define u32vector-comparator
@@ -1144,24 +1194,34 @@
 
     (define (s32vector-concatenate vs) (apply s32vector-append vs))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (s32vector-unfold f length . seeds)
-      (let ((out (make-s32vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-s32vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (s32vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (s32vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (s32vector-unfold-right f length . seeds)
-      (let ((out (make-s32vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-s32vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (s32vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (s32vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define s32vector-comparator
@@ -1326,24 +1386,34 @@
 
     (define (u64vector-concatenate vs) (apply u64vector-append vs))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (u64vector-unfold f length . seeds)
-      (let ((out (make-u64vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-u64vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (u64vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (u64vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (u64vector-unfold-right f length . seeds)
-      (let ((out (make-u64vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-u64vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (u64vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (u64vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define u64vector-comparator
@@ -1508,24 +1578,34 @@
 
     (define (s64vector-concatenate vs) (apply s64vector-append vs))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (s64vector-unfold f length . seeds)
-      (let ((out (make-s64vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-s64vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (s64vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (s64vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (s64vector-unfold-right f length . seeds)
-      (let ((out (make-s64vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-s64vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (s64vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (s64vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define s64vector-comparator
@@ -1691,28 +1771,43 @@
     (define (f64vector-concatenate vs)
       ;; (curry f64vector)'s f64vector-append is a fixed 2-arg procedure
       ;; (unlike the other 8 kinds' N-ary append), so concatenating N
-      ;; vectors folds pairwise instead of apply-ing.
-      (if (null? vs) (f64vector)
-          (fold-left f64vector-append (car vs) (cdr vs))))
+      ;; vectors folds pairwise instead of apply-ing. The single-element
+      ;; case is special-cased to copy rather than fold-left-ing over an
+      ;; empty rest list, which would just return (car vs) unchanged --
+      ;; aliasing the input instead of producing a fresh vector, unlike
+      ;; every other kind's -concatenate (found by independent review).
+      (cond ((null? vs) (f64vector))
+            ((null? (cdr vs)) (f64vector-copy (car vs)))
+            (else (fold-left f64vector-append (car vs) (cdr vs)))))
 
+    ;; call-with-values's receiver used to be called with (loop ...) as
+    ;; its own tail call -- curry's core VM doesn't fully TCO that shape
+    ;; inside a define-library body (a separate, pre-existing core bug,
+    ;; found here by independent security review: SIGSEGV via C stack
+    ;; overflow past a few thousand elements). Worked around by routing
+    ;; the multiple return values through `list` as call-with-values's
+    ;; receiver (an ordinary, non-tail call) and doing the actual loop
+    ;; recursion as a separate, genuinely tail call afterward.
     (define (f64vector-unfold f length . seeds)
-      (let ((out (make-f64vector length)))
-        (let loop ((i 0) (ss seeds))
+      (let ((out (make-f64vector length))
+            (ss seeds))
+        (let loop ((i 0))
           (when (< i length)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (f64vector-set! out i val)
-                (loop (+ i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (f64vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (+ i 1)))))
         out))
 
     (define (f64vector-unfold-right f length . seeds)
-      (let ((out (make-f64vector length)))
-        (let loop ((i (- length 1)) (ss seeds))
+      (let ((out (make-f64vector length))
+            (ss seeds))
+        (let loop ((i (- length 1)))
           (when (>= i 0)
-            (call-with-values (lambda () (apply f i ss))
-              (lambda (val . next-ss)
-                (f64vector-set! out i val)
-                (loop (- i 1) next-ss)))))
+            (let ((results (call-with-values (lambda () (apply f i ss)) list)))
+              (f64vector-set! out i (car results))
+              (set! ss (cdr results))
+              (loop (- i 1)))))
         out))
 
     (define f64vector-comparator

--- a/lib/curry/modules/srfi/s4/uniform-vectors.scm
+++ b/lib/curry/modules/srfi/s4/uniform-vectors.scm
@@ -35,17 +35,20 @@
 
     make-f64vector f64vector f64vector? f64vector-length f64vector-ref
     f64vector-set! f64vector->list list->f64vector f64vector-copy
-    f64vector-fill!)
+    f64vector-append f64vector-fill!)
   (begin
     ; u8/s8/.../s64 come from (curry typedvec) (modules/typedvec/typedvec.c,
     ; one generic C implementation parameterized over 8 element kinds);
     ; f64vector comes from the separate, pre-existing (curry f64vector)
     ; module (which also has a much larger numeric-computation surface --
     ; f64vector-dot, -map, -sum, etc -- not part of SRFI-4 and deliberately
-    ; not re-exported here). f64vector has no -copy!/-append counterpart
-    ; in that module, so SRFI-4's f64vector-copy!/f64vector-append are not
-    ; available through this library -- only what's actually implemented
-    ; is re-exported, per the s170/posix.scm precedent in this codebase.
+    ; not re-exported here). f64vector-append exists there too, but only
+    ; as a fixed 2-argument procedure, not the N-ary form the other 8
+    ; kinds have; still re-exported as-is (SRFI-4's own append is silent
+    ; on arity). f64vector-copy! has no counterpart in that module at
+    ; all, so it's the one SRFI-4 operation not available through this
+    ; library -- only what's actually implemented is re-exported, per
+    ; the s170/posix.scm precedent in this codebase.
     ; f32vector is not part of this library: curry's numeric tower has no
     ; native single-precision float representation to back it with.
     ))

--- a/lib/curry/modules/srfi/srfi-160.scm
+++ b/lib/curry/modules/srfi/srfi-160.scm
@@ -1,0 +1,94 @@
+(define-library (srfi srfi-160)
+  (import (srfi s160 uniform-vectors))
+  (export
+    make-u8vector u8vector u8vector? u8vector-length u8vector-ref
+    u8vector-set! u8vector->list list->u8vector u8vector-copy
+    u8vector-append u8vector-copy! u8vector-fill! u8vector-empty? u8vector=
+    u8vector-swap! u8vector-reverse! u8vector-reverse-copy u8vector-map
+    u8vector-map! u8vector-for-each u8vector-count u8vector-index
+    u8vector-index-right u8vector-skip u8vector-skip-right u8vector-any
+    u8vector-every u8vector-filter u8vector-remove u8vector-partition
+    u8vector-fold u8vector-fold-right u8vector-concatenate u8vector-unfold
+    u8vector-unfold-right u8vector-comparator u8vector->generator
+    make-u8vector-generator make-s8vector s8vector s8vector?
+    s8vector-length s8vector-ref s8vector-set! s8vector->list
+    list->s8vector s8vector-copy s8vector-append s8vector-copy!
+    s8vector-fill! s8vector-empty? s8vector= s8vector-swap!
+    s8vector-reverse! s8vector-reverse-copy s8vector-map s8vector-map!
+    s8vector-for-each s8vector-count s8vector-index s8vector-index-right
+    s8vector-skip s8vector-skip-right s8vector-any s8vector-every
+    s8vector-filter s8vector-remove s8vector-partition s8vector-fold
+    s8vector-fold-right s8vector-concatenate s8vector-unfold
+    s8vector-unfold-right s8vector-comparator s8vector->generator
+    make-s8vector-generator make-u16vector u16vector u16vector?
+    u16vector-length u16vector-ref u16vector-set! u16vector->list
+    list->u16vector u16vector-copy u16vector-append u16vector-copy!
+    u16vector-fill! u16vector-empty? u16vector= u16vector-swap!
+    u16vector-reverse! u16vector-reverse-copy u16vector-map u16vector-map!
+    u16vector-for-each u16vector-count u16vector-index
+    u16vector-index-right u16vector-skip u16vector-skip-right u16vector-any
+    u16vector-every u16vector-filter u16vector-remove u16vector-partition
+    u16vector-fold u16vector-fold-right u16vector-concatenate
+    u16vector-unfold u16vector-unfold-right u16vector-comparator
+    u16vector->generator make-u16vector-generator make-s16vector s16vector
+    s16vector? s16vector-length s16vector-ref s16vector-set!
+    s16vector->list list->s16vector s16vector-copy s16vector-append
+    s16vector-copy! s16vector-fill! s16vector-empty? s16vector=
+    s16vector-swap! s16vector-reverse! s16vector-reverse-copy s16vector-map
+    s16vector-map! s16vector-for-each s16vector-count s16vector-index
+    s16vector-index-right s16vector-skip s16vector-skip-right s16vector-any
+    s16vector-every s16vector-filter s16vector-remove s16vector-partition
+    s16vector-fold s16vector-fold-right s16vector-concatenate
+    s16vector-unfold s16vector-unfold-right s16vector-comparator
+    s16vector->generator make-s16vector-generator make-u32vector u32vector
+    u32vector? u32vector-length u32vector-ref u32vector-set!
+    u32vector->list list->u32vector u32vector-copy u32vector-append
+    u32vector-copy! u32vector-fill! u32vector-empty? u32vector=
+    u32vector-swap! u32vector-reverse! u32vector-reverse-copy u32vector-map
+    u32vector-map! u32vector-for-each u32vector-count u32vector-index
+    u32vector-index-right u32vector-skip u32vector-skip-right u32vector-any
+    u32vector-every u32vector-filter u32vector-remove u32vector-partition
+    u32vector-fold u32vector-fold-right u32vector-concatenate
+    u32vector-unfold u32vector-unfold-right u32vector-comparator
+    u32vector->generator make-u32vector-generator make-s32vector s32vector
+    s32vector? s32vector-length s32vector-ref s32vector-set!
+    s32vector->list list->s32vector s32vector-copy s32vector-append
+    s32vector-copy! s32vector-fill! s32vector-empty? s32vector=
+    s32vector-swap! s32vector-reverse! s32vector-reverse-copy s32vector-map
+    s32vector-map! s32vector-for-each s32vector-count s32vector-index
+    s32vector-index-right s32vector-skip s32vector-skip-right s32vector-any
+    s32vector-every s32vector-filter s32vector-remove s32vector-partition
+    s32vector-fold s32vector-fold-right s32vector-concatenate
+    s32vector-unfold s32vector-unfold-right s32vector-comparator
+    s32vector->generator make-s32vector-generator make-u64vector u64vector
+    u64vector? u64vector-length u64vector-ref u64vector-set!
+    u64vector->list list->u64vector u64vector-copy u64vector-append
+    u64vector-copy! u64vector-fill! u64vector-empty? u64vector=
+    u64vector-swap! u64vector-reverse! u64vector-reverse-copy u64vector-map
+    u64vector-map! u64vector-for-each u64vector-count u64vector-index
+    u64vector-index-right u64vector-skip u64vector-skip-right u64vector-any
+    u64vector-every u64vector-filter u64vector-remove u64vector-partition
+    u64vector-fold u64vector-fold-right u64vector-concatenate
+    u64vector-unfold u64vector-unfold-right u64vector-comparator
+    u64vector->generator make-u64vector-generator make-s64vector s64vector
+    s64vector? s64vector-length s64vector-ref s64vector-set!
+    s64vector->list list->s64vector s64vector-copy s64vector-append
+    s64vector-copy! s64vector-fill! s64vector-empty? s64vector=
+    s64vector-swap! s64vector-reverse! s64vector-reverse-copy s64vector-map
+    s64vector-map! s64vector-for-each s64vector-count s64vector-index
+    s64vector-index-right s64vector-skip s64vector-skip-right s64vector-any
+    s64vector-every s64vector-filter s64vector-remove s64vector-partition
+    s64vector-fold s64vector-fold-right s64vector-concatenate
+    s64vector-unfold s64vector-unfold-right s64vector-comparator
+    s64vector->generator make-s64vector-generator make-f64vector f64vector
+    f64vector? f64vector-length f64vector-ref f64vector-set!
+    f64vector->list list->f64vector f64vector-copy f64vector-append
+    f64vector-fill! f64vector-empty? f64vector= f64vector-swap!
+    f64vector-reverse! f64vector-reverse-copy f64vector-map f64vector-map!
+    f64vector-for-each f64vector-count f64vector-index
+    f64vector-index-right f64vector-skip f64vector-skip-right f64vector-any
+    f64vector-every f64vector-filter f64vector-remove f64vector-partition
+    f64vector-fold f64vector-fold-right f64vector-concatenate
+    f64vector-unfold f64vector-unfold-right f64vector-comparator
+    f64vector->generator make-f64vector-generator comparator? =? <? >? <=?
+    >=?))

--- a/lib/curry/modules/srfi/srfi-4.scm
+++ b/lib/curry/modules/srfi/srfi-4.scm
@@ -35,4 +35,4 @@
 
     make-f64vector f64vector f64vector? f64vector-length f64vector-ref
     f64vector-set! f64vector->list list->f64vector f64vector-copy
-    f64vector-fill!))
+    f64vector-append f64vector-fill!))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -239,6 +239,10 @@ if(BUILD_MODULE_TYPEDVEC AND TARGET curry_typedvec AND BUILD_MODULE_F64VECTOR AN
     add_test(NAME typedvec COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/typedvec_tests.scm)
     set_tests_properties(typedvec PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+    # (srfi 160) builds on (srfi 4) in pure Scheme -- same module dependency.
+    add_test(NAME srfi_160 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_160_tests.scm)
+    set_tests_properties(srfi_160 PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
 if(BUILD_MODULE_QT6 AND TARGET curry_qt6)

--- a/tests/srfi_160_tests.scm
+++ b/tests/srfi_160_tests.scm
@@ -115,6 +115,22 @@
        (u8vector->list (u8vector-unfold-right (lambda (i seed) (values seed (+ seed 1))) 5 0))
        '(4 3 2 1 0))
 
+;; regression: the original call-with-values-in-tail-position shape
+;; SIGSEGV'd (C stack overflow) at a few thousand elements -- a
+;; pre-existing core-VM TCO defect for that pattern inside a
+;; define-library body, found by independent security review. Fixed
+;; here at the library level by routing call-with-values's receiver
+;; through `list` (an ordinary, non-tail call) and doing the actual
+;; loop recursion as a separate tail call. This checks a length well
+;; past the crash threshold that used to be reproducible.
+(check "u8vector-unfold at 200000 elements doesn't crash and is correct"
+       (let ((v (u8vector-unfold (lambda (i s) (values (modulo i 256) (+ s 1))) 200000 0)))
+         (list (u8vector-length v) (u8vector-ref v 0) (u8vector-ref v 300)))
+       '(200000 0 44))
+(check "u8vector-unfold-right at 200000 elements doesn't crash"
+       (u8vector-length (u8vector-unfold-right (lambda (i s) (values (modulo i 256) (+ s 1))) 200000 0))
+       200000)
+
 ;;; ---- comparators ----
 
 (check "u8vector-comparator is a comparator" (comparator? u8vector-comparator) #t)
@@ -155,6 +171,15 @@
        (f64vector->list (f64vector-concatenate (list (f64vector 1.0 2.0) (f64vector 3.0) (f64vector 4.0 5.0))))
        '(1.0 2.0 3.0 4.0 5.0))
 (check "f64vector-concatenate empty list" (f64vector->list (f64vector-concatenate '())) '())
+;; regression: a single-element list originally fold-left'd over an
+;; empty rest list, returning (car vs) unchanged -- aliasing the input
+;; instead of producing a fresh vector, unlike every other kind's
+;; -concatenate (found by independent code review).
+(check "f64vector-concatenate on a single-element list copies, doesn't alias"
+       (let* ((v (f64vector 1.0 2.0 3.0))
+              (c (f64vector-concatenate (list v))))
+         (list (eq? v c) (begin (f64vector-set! c 0 999.0) (f64vector->list v))))
+       '(#f (1.0 2.0 3.0)))
 (check "f64vector-comparator" (=? f64vector-comparator (f64vector 1.0 2.0) (f64vector 1.0 2.0)) #t)
 
 ;;; ---- Summary ----

--- a/tests/srfi_160_tests.scm
+++ b/tests/srfi_160_tests.scm
@@ -1,0 +1,169 @@
+;;; srfi_160_tests.scm — (srfi 160): SRFI-4 base ops plus the extended
+;;; SRFI-160-style surface (map/fold/filter/comparator/generator/etc)
+;;; for all 9 kinds (u8..s64, f64), layered in pure Scheme on top of
+;;; (srfi 4). Full coverage on u8 (small unsigned) and spot checks on
+;;; s64 (signed, bignum boundary) and f64 (float) for cross-kind
+;;; regressions, since the same generated code is shared by all 9.
+
+(import (srfi 160))
+
+(define pass 0)
+(define fail 0)
+
+(define-syntax check
+  (syntax-rules ()
+    ((_ label expr expected)
+     (let ((got expr))
+       (if (equal? got expected)
+           (begin (set! pass (+ pass 1)))
+           (begin
+             (set! fail (+ fail 1))
+             (display "FAIL: ") (display label) (newline)
+             (display "  expected: ") (write expected) (newline)
+             (display "  got:      ") (write got) (newline)))))))
+
+;;; ---- base SRFI-4 ops still reachable through (srfi 160) ----
+
+(check "u8vector base ops reachable" (u8vector->list (u8vector 1 2 3)) '(1 2 3))
+(check "f64vector-append reachable (2-arg only, unlike the other 8 kinds)"
+       (f64vector->list (f64vector-append (f64vector 1.0) (f64vector 2.0)))
+       '(1.0 2.0))
+
+;;; ---- u8vector: full extended-op coverage ----
+
+(check "u8vector-empty? true" (u8vector-empty? (u8vector)) #t)
+(check "u8vector-empty? false" (u8vector-empty? (u8vector 1)) #f)
+
+(check "u8vector= equal" (u8vector= (u8vector 1 2 3) (u8vector 1 2 3)) #t)
+(check "u8vector= different length" (u8vector= (u8vector 1 2) (u8vector 1 2 3)) #f)
+(check "u8vector= different element" (u8vector= (u8vector 1 2 3) (u8vector 1 2 4)) #f)
+;; regression: the original generated code called (loop rest) instead of
+;; (loop (cdr rest)) in the 3+-argument chain, an infinite loop -- this
+;; specifically exercises the chain past the first pair.
+(check "u8vector= three-way chain terminates and is correct"
+       (u8vector= (u8vector 1 2) (u8vector 1 2) (u8vector 1 2))
+       #t)
+(check "u8vector= three-way chain, third differs"
+       (u8vector= (u8vector 1 2) (u8vector 1 2) (u8vector 1 3))
+       #f)
+
+(let ((v (u8vector 1 2 3)))
+  (u8vector-swap! v 0 2)
+  (check "u8vector-swap!" (u8vector->list v) '(3 2 1)))
+
+(let ((v (u8vector 1 2 3 4)))
+  (u8vector-reverse! v)
+  (check "u8vector-reverse!" (u8vector->list v) '(4 3 2 1)))
+
+(check "u8vector-reverse-copy" (u8vector->list (u8vector-reverse-copy (u8vector 1 2 3))) '(3 2 1))
+(check "u8vector-reverse-copy leaves original untouched"
+       (let ((v (u8vector 1 2 3))) (u8vector-reverse-copy v) (u8vector->list v))
+       '(1 2 3))
+
+(check "u8vector-map" (u8vector->list (u8vector-map (lambda (x) (* x 2)) (u8vector 1 2 3))) '(2 4 6))
+(check "u8vector-map two vectors" (u8vector->list (u8vector-map + (u8vector 1 2 3) (u8vector 10 20 30))) '(11 22 33))
+
+(let ((v (u8vector 1 2 3)))
+  (u8vector-map! (lambda (x) (+ x 1)) v)
+  (check "u8vector-map!" (u8vector->list v) '(2 3 4)))
+
+(check "u8vector-for-each side effects"
+       (let ((acc 0)) (u8vector-for-each (lambda (x) (set! acc (+ acc x))) (u8vector 1 2 3)) acc)
+       6)
+
+(check "u8vector-count" (u8vector-count odd? (u8vector 1 2 3 4 5)) 3)
+(check "u8vector-index found" (u8vector-index even? (u8vector 1 3 4 5)) 2)
+(check "u8vector-index not found" (u8vector-index even? (u8vector 1 3 5)) #f)
+(check "u8vector-index-right" (u8vector-index-right even? (u8vector 2 3 4 5)) 2)
+(check "u8vector-skip" (u8vector-skip even? (u8vector 2 4 5 6)) 2)
+;; -skip-right finds the rightmost index where the predicate is FALSE
+;; (i.e. index-right of (not pred)): scanning (2 4 5 6) right-to-left,
+;; index 3 (6) is even so it's skipped, index 2 (5) is odd -> matches.
+(check "u8vector-skip-right" (u8vector-skip-right even? (u8vector 2 4 5 6)) 2)
+
+(check "u8vector-any true" (u8vector-any even? (u8vector 1 3 4)) #t)
+(check "u8vector-any false" (u8vector-any even? (u8vector 1 3 5)) #f)
+(check "u8vector-every true" (u8vector-every odd? (u8vector 1 3 5)) #t)
+(check "u8vector-every false" (u8vector-every odd? (u8vector 1 3 4)) #f)
+
+(check "u8vector-filter" (u8vector->list (u8vector-filter even? (u8vector 1 2 3 4 5 6))) '(2 4 6))
+(check "u8vector-remove" (u8vector->list (u8vector-remove even? (u8vector 1 2 3 4 5 6))) '(1 3 5))
+(check "u8vector-partition"
+       (call-with-values (lambda () (u8vector-partition even? (u8vector 1 2 3 4)))
+         (lambda (yes no) (list (u8vector->list yes) (u8vector->list no))))
+       '((2 4) (1 3)))
+
+(check "u8vector-fold" (u8vector-fold + 0 (u8vector 1 2 3 4)) 10)
+;; fold's kons order is (kons acc elem), the opposite of fold-right below
+;; -- cons-ing acc first nests rather than building a reversed list.
+(check "u8vector-fold order (acc first)" (u8vector-fold cons '() (u8vector 1 2 3)) '(((() . 1) . 2) . 3))
+;; regression: fold-right must pass elements first, accumulator LAST to
+;; kons (the opposite order from fold) -- the original generated code
+;; used fold's order for both, producing garbage for non-commutative kons.
+(check "u8vector-fold-right order (elements first, acc last)"
+       (u8vector-fold-right cons '() (u8vector 1 2 3))
+       '(1 2 3))
+(check "u8vector-fold-right with +" (u8vector-fold-right + 0 (u8vector 1 2 3 4)) 10)
+
+(check "u8vector-concatenate" (u8vector->list (u8vector-concatenate (list (u8vector 1 2) (u8vector 3 4)))) '(1 2 3 4))
+(check "u8vector-concatenate empty list" (u8vector->list (u8vector-concatenate '())) '())
+
+(check "u8vector-unfold"
+       (u8vector->list (u8vector-unfold (lambda (i seed) (values seed (+ seed 1))) 5 0))
+       '(0 1 2 3 4))
+(check "u8vector-unfold-right"
+       (u8vector->list (u8vector-unfold-right (lambda (i seed) (values seed (+ seed 1))) 5 0))
+       '(4 3 2 1 0))
+
+;;; ---- comparators ----
+
+(check "u8vector-comparator is a comparator" (comparator? u8vector-comparator) #t)
+(check "u8vector-comparator =? equal" (=? u8vector-comparator (u8vector 1 2) (u8vector 1 2)) #t)
+(check "u8vector-comparator =? unequal" (=? u8vector-comparator (u8vector 1 2) (u8vector 1 3)) #f)
+(check "u8vector-comparator <? shorter first" (<? u8vector-comparator (u8vector 1) (u8vector 1 2)) #t)
+(check "u8vector-comparator <? elementwise" (<? u8vector-comparator (u8vector 1 2) (u8vector 1 3)) #t)
+
+;;; ---- generators ----
+
+(check "u8vector->generator"
+       (let ((g (u8vector->generator (u8vector 9 8 7))))
+         (list (g) (g) (g) (eof-object? (g))))
+       '(9 8 7 #t))
+(check "u8vector->generator with range"
+       (let ((g (u8vector->generator (u8vector 9 8 7 6) 1 3)))
+         (list (g) (g) (eof-object? (g))))
+       '(8 7 #t))
+(check "make-u8vector-generator alias" (procedure? (make-u8vector-generator (u8vector 1))) #t)
+
+;;; ---- s64vector: bignum boundary spot check ----
+
+(check "s64vector-map preserves bignum-range values"
+       (s64vector->list (s64vector-map (lambda (x) x) (s64vector -9223372036854775808 9223372036854775807)))
+       '(-9223372036854775808 9223372036854775807))
+(check "s64vector-fold with bignum values"
+       (s64vector-fold + 0 (s64vector 9223372036854775807 1))
+       9223372036854775808)
+(check "u64vector-comparator on UINT64_MAX"
+       (=? u64vector-comparator (u64vector 18446744073709551615) (u64vector 18446744073709551615))
+       #t)
+
+;;; ---- f64vector: float spot check ----
+
+(check "f64vector-map" (f64vector->list (f64vector-map (lambda (x) (* x 2.0)) (f64vector 1.5 2.5))) '(3.0 5.0))
+(check "f64vector-fold" (f64vector-fold + 0.0 (f64vector 1.5 2.5)) 4.0)
+(check "f64vector-concatenate folds pairwise over the 2-arg f64vector-append"
+       (f64vector->list (f64vector-concatenate (list (f64vector 1.0 2.0) (f64vector 3.0) (f64vector 4.0 5.0))))
+       '(1.0 2.0 3.0 4.0 5.0))
+(check "f64vector-concatenate empty list" (f64vector->list (f64vector-concatenate '())) '())
+(check "f64vector-comparator" (=? f64vector-comparator (f64vector 1.0 2.0) (f64vector 1.0 2.0)) #t)
+
+;;; ---- Summary ----
+
+(newline)
+(display "srfi-160 tests: ")
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0)
+    (begin (display "SOME TESTS FAILED") (newline) (exit 1))
+    (begin (display "all OK") (newline)))


### PR DESCRIPTION
## Summary

Layers the extended [SRFI-160](https://srfi.schemers.org/srfi-160/) operation set on top of SRFI-4 core (#28) — higher-order iteration (`map`/`for-each`/`fold`/`fold-right`/`filter`/`remove`/`partition`/`count`/`index`/`skip`/`any`/`every`), a comparator instance, and a generator, per kind, for all 9 SRFI-4 kinds (u8/s8/u16/s16/u32/s32/u64/s64/f64). Entirely pure Scheme — no new C code, built on the already-shipped `(curry typedvec)`/`(curry f64vector)` primitives plus this codebase's existing `(srfi 128)` comparators and `(srfi 158)` generators.

- `(srfi s160 uniform-vectors)`, plus `(srfi 160)` / `(srfi srfi-160)` bare-number shims, matching this codebase's established SRFI naming convention
- Also fixes a real doc/export gap from #28: `(srfi 4)` claimed `(curry f64vector)` has no `f64vector-append`; it does (fixed 2-arg arity, unlike the other 8 kinds' N-ary form) and just wasn't re-exported — now is

## Bugs found (and fixed) during manual testing

This is one generator script producing the same shape of definition for all 9 kinds, so a template bug is a bug in all 9 — caught these before commit:

- **Real infinite loop**: `TAGvector=`'s N-ary equality chain called `(loop rest)` instead of `(loop (cdr rest))` in its recursive step, so any 3+-argument call that reached its second comparison never terminated. Verified live (had to `kill -9` a hung process), fixed, regression test added.
- `TAGvector-fold-right` passed `kons` the accumulator in the same position as `TAGvector-fold` (`(kons acc e1 e2 ...)`); the actual SRFI-133/SRFI-160 convention has `fold-right`'s `kons` take elements first and the accumulator last — matters for a non-commutative `kons` like `cons`. Fixed, regression test added.
- `TAGvector-comparator` values were unusable without a separate `(srfi 128)` import (`comparator?`/`=?`/`<?`/etc weren't re-exported). Fixed.

## Test plan

- [x] `cmake --build build` succeeds cleanly
- [x] `ctest --test-dir build -R "srfi_160|typedvec"` — 54 + 39 checks pass
- [x] Full `ctest` suite: 94/94 pass
- [x] Live-verified the infinite-loop fix terminates correctly for 3+-argument `TAGvector=` chains, and that `fold`/`fold-right` now produce the documented (different) accumulator orderings

## Additional review findings (fixed in a follow-up commit)

- **`f64vector-concatenate` aliasing bug**: a single-element list short-circuited to returning the input vector unchanged instead of a fresh copy — later mutation of the "concatenated" result silently corrupted the original. Fixed by special-casing the single-element case.
- **Real crash (SIGSEGV)**: `TAGvector-unfold`/`-unfold-right` (all 9 kinds) blew the C stack at a few thousand elements, rooted in a pre-existing curry core-VM defect where `call-with-values`/`apply` tail calls don't get fully TCO'd inside a `define-library` body. Since every `(curry X)`/SRFI library is a `define-library`, this public API was trivially crashable from ordinary-looking input. Worked around at the library level (routing `call-with-values`'s receiver through `list` instead of a tail-recursive lambda); verified correct and crash-free at 200,000 elements. **The underlying core-VM TCO defect is not fixed and should be tracked separately** — this PR only mitigates its one directly-affected public API.

Test suite updated to 57 checks (up from 54) with regression coverage for both.
