### PR TITLE
feat(srfi279): add record-type-constructor/-predicate/-accessors/-mutators

### DIFF
--- a/docs/reference/srfi/s279.md
+++ b/docs/reference/srfi/s279.md
@@ -45,7 +45,7 @@ Returns a non-dotted alist (each entry `(key value)`, not `(key . value)`) of in
 | Set ([`(srfi 113)`](s113.md)) | `set-size`, every element self-valued as `(element element)` |
 | Bag ([`(srfi 113)`](s113.md)) | `bag-size`, `bag-unique-size`, every distinct element as `(element count)` — the SRFI's own suggested shape (a single `bag->set` delegating to set-properties) doesn't apply here since curry's `(srfi 113)` has no `bag->set` conversion; this reports counts directly instead, which is arguably more useful for something that's fundamentally a multiset |
 | Record | `record-rtd`, every field inlined by name in field-definition order |
-| Record type (RTD) | `rtd-name`, `rtd-field-names` |
+| Record type (RTD) | `rtd-name`, `rtd-field-names`, `rtd-constructor`, `rtd-predicate`, `rtd-accessors` (list, field order), `rtd-mutators` (list, field order, `#f` for each immutable field) |
 | Port | `port-open?`, `port-direction`, `port-type`, `port-line`; `port-position`/`port-file-descriptor` when meaningful; `port-encoding` for textual ports; `port-buffer`/`get-output-string`/`get-output-bytevector` for output ports |
 | Procedure | `procedure-name`, `procedure-arity`, `procedure-arglists`, `procedure-file`, `procedure-line`, `procedure-lambda`, `procedure-closure` — whichever apply to that procedure's representation (tree-walker closure, bytecode-VM closure, or C primitive) |
 | Typed numeric vector ([SRFI 4](s4.md): `u8`/`s8`/`u16`/`s16`/`u32`/`s32`/`u64`/`s64`/`f64vector`) | The kind's own `TAGvector-length`/`TAGvector->list` (e.g. `u8vector-length`, not a generic key), plus indexed `0..N` elements |
@@ -54,7 +54,6 @@ Returns a non-dotted alist (each entry `(key value)`, not `(key . value)`) of in
 
 ### Deliberately out of scope (not forgotten)
 
-- **`rtd-accessors`/`-mutators`/`-predicate`/`-constructor`.** The SRFI wants these as actual procedure objects ("record-related procedures"), but curry's `RecordType` struct only stores the name and field names — nothing references the constructor/predicate/accessor/mutator closures `define-record-type`'s codegen actually generates. Adding this means extending `RecordType` and `compile_define_record_type`'s codegen to stash those closures back onto the RTD at creation time — real compiler/runtime work, scoped as its own follow-up PR rather than bundled here.
 - **Library/environment properties.** `modules.c`'s registry has no Scheme-level enumeration API — module names/exports aren't queryable from Scheme once loaded.
 - **`symbol-library`/`symbol-exported?`.** Same module-registry gap as library/environment properties above — `symbol-value` alone doesn't need it (a plain global-environment lookup), these do.
 
@@ -73,6 +72,15 @@ Writes a human-readable description of `object` to `port` (default `(current-out
 - `(record-type-field-names rtd)` → *list of symbols* — field names, in field-definition order.
 
 These match [`(rnrs records inspection)`](https://www.r6rs.org/final/html/r6rs-lib/r6rs-lib-Z-H-7.html#node_sec_7.3) naming (which curry's module system already aliases to the flat global env per the module-system docs, but had never actually implemented any procedures for until now).
+
+A second round added the four "record-related procedures" the SRFI itself also wants (`rtd-accessors`/`-mutators`/`-predicate`/`-constructor` in the property table above) — the actual constructor/predicate/accessor/mutator closures `define-record-type`'s own codegen creates, not just their names:
+
+- `(record-type-constructor rtd)` → *procedure* — the type's constructor.
+- `(record-type-predicate rtd)` → *procedure* — the type's predicate.
+- `(record-type-accessors rtd)` → *list of procedures* — one per field, in field-definition order. Always real procedures: every field has an accessor, in both R6RS and R7RS's own grammar.
+- `(record-type-mutators rtd)` → *list of procedure-or-`#f`* — one per field, in field-definition order; `#f` for each field declared immutable.
+
+Getting these required extending `RecordType` (`src/object.h`) with four new slots and teaching both `define-record-type` codegen paths (the tree-walker's `S_DEFINE_RECORD_TYPE` case in `src/eval.c`, and the compiler's native `compile_define_record_type` in `src/compiler.c` — record syntax parsing itself stays shared between the two via `record_type_build_spec`, see `src/record_type.h`'s own header comment) to stash each binding's closure back onto the RTD right after it's created, via four new internal primitives (`%rtd-set-constructor!`/`-predicate!`/`-accessor!`/`-mutator!`, `src/builtins.c`) — the RTD is built *before* any of its bindings' closures exist, so nothing can populate these eagerly at RTD-construction time the way `name`/`field_names` are. Verified across both R6RS and R7RS record syntax, both top-level and local (`scope_depth > 0`) `define-record-type` forms, and a `.scc` cache round-trip (fresh compile and cache-hit replay both correctly reconstruct the same working procedures).
 
 ## Known limitations
 

--- a/lib/curry/modules/srfi/s279/inspect.scm
+++ b/lib/curry/modules/srfi/s279/inspect.scm
@@ -335,9 +335,25 @@
     ;; the same way.
     (define (%record-field-ref object i) (%record-ref object i))
 
+    ;; rtd-constructor/-predicate/-accessors/-mutators: the four
+    ;; "record-related procedures" the SRFI wants (record-type-* are new
+    ;; primitives added alongside this update -- see their own comment
+    ;; in src/builtins.c). constructor/predicate are omitted in the
+    ;; (should-be-unreachable-in-practice) case they're #f -- every
+    ;; define-record-type binding populates both; accessors is always a
+    ;; full list of real procedures (every field has one by both R6RS
+    ;; and R7RS's own grammar); mutators keeps a #f entry INLINE for
+    ;; each field declared immutable rather than omitting the whole
+    ;; property or dropping that one element, so a caller can still
+    ;; line mutators up against field-names/accessors by position.
     (define (%rtd-properties rtd)
-      (list (list 'rtd-name (record-type-name rtd))
-            (list 'rtd-field-names (record-type-field-names rtd))))
+      (append
+        (list (list 'rtd-name (record-type-name rtd))
+              (list 'rtd-field-names (record-type-field-names rtd)))
+        (%omit 'rtd-constructor (record-type-constructor rtd))
+        (%omit 'rtd-predicate   (record-type-predicate rtd))
+        (list (list 'rtd-accessors (record-type-accessors rtd))
+              (list 'rtd-mutators  (record-type-mutators rtd)))))
 
     ;; field… → object: indexed by field name, in field-definition order.
     (define (%rtd-field-properties names ref)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2475,6 +2475,79 @@ static val_t prim_record_type_field_names(int ac, val_t *av, void *ud) {
     return list;
 }
 
+/* record-type-constructor/-predicate/-accessors/-mutators: the four
+ * "record-related procedures" SRFI-279's rtd-properties wants (see its
+ * own header comment in lib/curry/modules/srfi/s279/inspect.scm).
+ * constructor/predicate return the closure or #f if never populated
+ * (only possible for an RTD built by hand via %make-record-type with
+ * no define-record-type binding ever pointed back at it -- doesn't
+ * happen through normal Scheme code, but these stay defensive rather
+ * than assuming). accessors is always a full list of real procedures
+ * (every field has one, by both R6RS and R7RS's own grammar); mutators
+ * has a #f entry for each field declared immutable. */
+static val_t prim_record_type_constructor(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "record-type-constructor: not a record type");
+    return vunptr(RecordType, av[0])->constructor;
+}
+static val_t prim_record_type_predicate(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "record-type-predicate: not a record type");
+    return vunptr(RecordType, av[0])->predicate;
+}
+static val_t prim_record_type_accessors(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "record-type-accessors: not a record type");
+    RecordType *rtd = vunptr(RecordType, av[0]);
+    val_t list = V_NIL;
+    for (uint32_t i = rtd->nfields; i > 0; i--)
+        list = scm_cons(rtd->accessors ? rtd->accessors[i - 1] : V_FALSE, list);
+    return list;
+}
+static val_t prim_record_type_mutators(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "record-type-mutators: not a record type");
+    RecordType *rtd = vunptr(RecordType, av[0]);
+    val_t list = V_NIL;
+    for (uint32_t i = rtd->nfields; i > 0; i--)
+        list = scm_cons(rtd->mutators ? rtd->mutators[i - 1] : V_FALSE, list);
+    return list;
+}
+
+/* %rtd-set-constructor!/-predicate!/-accessor!/-mutator!: internal,
+ * used only by compiler.c's/eval.c's define-record-type codegen to
+ * stash each binding's freshly-created closure back onto the RTD right
+ * after it's defined (the RTD itself is built before any of the
+ * bindings' closures exist -- record_type_build_spec only describes
+ * what needs creating, see its own header comment). Not exported to
+ * user code: these mutate an otherwise Scheme-immutable RTD field and
+ * exist purely to populate what record-type-constructor/-predicate/
+ * -accessors/-mutators above read back. */
+static val_t prim_rtd_set_constructor(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    vunptr(RecordType, av[0])->constructor = av[1];
+    return V_VOID;
+}
+static val_t prim_rtd_set_predicate(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    vunptr(RecordType, av[0])->predicate = av[1];
+    return V_VOID;
+}
+static val_t prim_rtd_set_accessor(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    RecordType *rtd = vunptr(RecordType, av[0]);
+    uint32_t i = (uint32_t)vunfix(av[1]);
+    if (i < rtd->nfields) rtd->accessors[i] = av[2];
+    return V_VOID;
+}
+static val_t prim_rtd_set_mutator(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    RecordType *rtd = vunptr(RecordType, av[0]);
+    uint32_t i = (uint32_t)vunfix(av[1]);
+    if (i < rtd->nfields) rtd->mutators[i] = av[2];
+    return V_VOID;
+}
+
 /* Build a fresh RecordType (RTD) from a name and a list of field-name
  * symbols. Used by the compiler's define-record-type codegen to
  * reconstruct the RTD at runtime — see compile_define_record_type in
@@ -2500,6 +2573,10 @@ static val_t prim_make_record_type(int ac, val_t *av, void *ud) {
         sizeof(RecordType) + nfields * sizeof(val_t));
     rtd->hdr.type = T_RECORD_TYPE; rtd->hdr.flags = 0;
     rtd->name = name; rtd->nfields = nfields;
+    rtd->constructor = V_FALSE; rtd->predicate = V_FALSE;
+    rtd->accessors = (val_t *)gc_alloc_raw_pinned(nfields * sizeof(val_t));
+    rtd->mutators  = (val_t *)gc_alloc_raw_pinned(nfields * sizeof(val_t));
+    for (uint32_t i = 0; i < nfields; i++) { rtd->accessors[i] = V_FALSE; rtd->mutators[i] = V_FALSE; }
     val_t f = av[1];
     for (uint32_t i = 0; i < nfields; i++) { rtd->field_names[i] = vcar(f); f = vcdr(f); }
     return vptr(rtd);
@@ -3337,6 +3414,14 @@ void builtins_register(val_t env) {
     DEF("record-rtd",           prim_record_rtd,             1,1);
     DEF("record-type-name",     prim_record_type_name,       1,1);
     DEF("record-type-field-names", prim_record_type_field_names, 1,1);
+    DEF("record-type-constructor", prim_record_type_constructor, 1,1);
+    DEF("record-type-predicate",   prim_record_type_predicate,   1,1);
+    DEF("record-type-accessors",   prim_record_type_accessors,   1,1);
+    DEF("record-type-mutators",    prim_record_type_mutators,    1,1);
+    DEF("%rtd-set-constructor!",   prim_rtd_set_constructor,     2,2);
+    DEF("%rtd-set-predicate!",     prim_rtd_set_predicate,       2,2);
+    DEF("%rtd-set-accessor!",      prim_rtd_set_accessor,        3,3);
+    DEF("%rtd-set-mutator!",       prim_rtd_set_mutator,         3,3);
 
     /* Procedure introspection */
     DEF("procedure-name",     prim_procedure_name,     1,1);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2514,37 +2514,49 @@ static val_t prim_record_type_mutators(int ac, val_t *av, void *ud) {
     return list;
 }
 
-/* %rtd-set-constructor!/-predicate!/-accessor!/-mutator!: internal,
- * used only by compiler.c's/eval.c's define-record-type codegen to
- * stash each binding's freshly-created closure back onto the RTD right
- * after it's defined (the RTD itself is built before any of the
- * bindings' closures exist -- record_type_build_spec only describes
- * what needs creating, see its own header comment). Not exported to
- * user code: these mutate an otherwise Scheme-immutable RTD field and
- * exist purely to populate what record-type-constructor/-predicate/
- * -accessors/-mutators above read back. */
+/* %rtd-set-constructor!/-predicate!/-accessor!/-mutator!: intended for
+ * internal use only, by compiler.c's/eval.c's define-record-type
+ * codegen, to stash each binding's freshly-created closure back onto
+ * the RTD right after it's defined (the RTD itself is built before any
+ * of the bindings' closures exist -- record_type_build_spec only
+ * describes what needs creating, see its own header comment). "Not
+ * exported to user code" is documentation, not enforcement, though --
+ * these are ordinary DEF'd globals like every other primitive in this
+ * file, directly callable by any Scheme script (found by independent
+ * code review: (%rtd-set-accessor! 5 0 some-closure) reinterpreted the
+ * fixnum 5's raw bits as a RecordType* and wrote through it,
+ * segfaulting the process). Type-checked here the same way
+ * %record-ref/%record-set!/%record-pred? already are, for the same
+ * reason: a %-prefixed name signals "internal convention," not an
+ * actual access restriction curry's flat global namespace can enforce. */
 static val_t prim_rtd_set_constructor(int ac, val_t *av, void *ud) {
     (void)ac; (void)ud;
+    if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%rtd-set-constructor!: not a record type");
     vunptr(RecordType, av[0])->constructor = av[1];
     return V_VOID;
 }
 static val_t prim_rtd_set_predicate(int ac, val_t *av, void *ud) {
     (void)ac; (void)ud;
+    if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%rtd-set-predicate!: not a record type");
     vunptr(RecordType, av[0])->predicate = av[1];
     return V_VOID;
 }
 static val_t prim_rtd_set_accessor(int ac, val_t *av, void *ud) {
     (void)ac; (void)ud;
+    if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%rtd-set-accessor!: not a record type");
+    if (!vis_fixnum(av[1])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%rtd-set-accessor!: field index must be a fixnum");
     RecordType *rtd = vunptr(RecordType, av[0]);
-    uint32_t i = (uint32_t)vunfix(av[1]);
-    if (i < rtd->nfields) rtd->accessors[i] = av[2];
+    intptr_t idx = vunfix(av[1]);
+    if (idx >= 0 && (uint32_t)idx < rtd->nfields) rtd->accessors[idx] = av[2];
     return V_VOID;
 }
 static val_t prim_rtd_set_mutator(int ac, val_t *av, void *ud) {
     (void)ac; (void)ud;
+    if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%rtd-set-mutator!: not a record type");
+    if (!vis_fixnum(av[1])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%rtd-set-mutator!: field index must be a fixnum");
     RecordType *rtd = vunptr(RecordType, av[0]);
-    uint32_t i = (uint32_t)vunfix(av[1]);
-    if (i < rtd->nfields) rtd->mutators[i] = av[2];
+    intptr_t idx = vunfix(av[1]);
+    if (idx >= 0 && (uint32_t)idx < rtd->nfields) rtd->mutators[idx] = av[2];
     return V_VOID;
 }
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -631,6 +631,40 @@ static void compile_define_record_type(Compiler *c, val_t rest, int line) {
                      scm_cons(spec.bindings[i].params, spec.bindings[i].body));
         val_t def_args = scm_cons(spec.bindings[i].name, scm_cons(lam, V_NIL));
         compile_define(c, def_args, line);
+
+        /* Stash this binding's freshly-defined closure back onto the
+         * RUNTIME RTD (referenced via rtd_ref, not the compile-time-only
+         * `rtd` above -- that one only exists to extract name/nfields/
+         * field_names for the %make-record-type call emitted earlier and
+         * is never itself the object %make-record-type builds at
+         * runtime) so record-type-constructor/-predicate/-accessors/
+         * -mutators can retrieve it later (SRFI-279's rtd-properties). */
+        val_t stash_call;
+        switch (spec.bindings[i].role) {
+            case RTD_ROLE_CONSTRUCTOR:
+                stash_call = scm_cons(sym_intern_cstr("%rtd-set-constructor!"),
+                    scm_cons(rtd_ref, scm_cons(spec.bindings[i].name, V_NIL)));
+                break;
+            case RTD_ROLE_PREDICATE:
+                stash_call = scm_cons(sym_intern_cstr("%rtd-set-predicate!"),
+                    scm_cons(rtd_ref, scm_cons(spec.bindings[i].name, V_NIL)));
+                break;
+            case RTD_ROLE_ACCESSOR:
+                stash_call = scm_cons(sym_intern_cstr("%rtd-set-accessor!"),
+                    scm_cons(rtd_ref, scm_cons(vfix((intptr_t)spec.bindings[i].field_index),
+                        scm_cons(spec.bindings[i].name, V_NIL))));
+                break;
+            case RTD_ROLE_MUTATOR:
+                stash_call = scm_cons(sym_intern_cstr("%rtd-set-mutator!"),
+                    scm_cons(rtd_ref, scm_cons(vfix((intptr_t)spec.bindings[i].field_index),
+                        scm_cons(spec.bindings[i].name, V_NIL))));
+                break;
+            default:
+                stash_call = V_VOID;
+                break;
+        }
+        emit(c, OP_POP, line); /* discard this binding's own OP_VOID */
+        compile(c, stash_call, false, line);
     }
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -589,6 +589,7 @@ tail:
          * always tree-walked, never compiled. */
         RecordTypeSpec spec;
         record_type_build_spec(rest, V_FALSE, &spec);
+        RecordType *rtd = as_rtd(spec.rtd_val);
         for (int i = 0; i < spec.count; i++) {
             Closure *c = CURRY_NEW_PINNED(Closure);
             c->hdr.type = T_CLOSURE; c->hdr.flags = 0;
@@ -596,7 +597,17 @@ tail:
             c->body   = spec.bindings[i].body;
             c->env    = as_env(env);
             c->name   = spec.bindings[i].name;
-            env_define(env, spec.bindings[i].name, vptr(c));
+            val_t cv = vptr(c);
+            env_define(env, spec.bindings[i].name, cv);
+            /* Stash each binding's closure back onto the RTD so
+             * record-type-constructor/-predicate/-accessors/-mutators
+             * can retrieve it later (SRFI-279's rtd-properties). */
+            switch (spec.bindings[i].role) {
+                case RTD_ROLE_CONSTRUCTOR: rtd->constructor = cv; break;
+                case RTD_ROLE_PREDICATE:   rtd->predicate   = cv; break;
+                case RTD_ROLE_ACCESSOR:    rtd->accessors[spec.bindings[i].field_index] = cv; break;
+                case RTD_ROLE_MUTATOR:     rtd->mutators[spec.bindings[i].field_index]  = cv; break;
+            }
         }
         return V_VOID;
     }

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -536,8 +536,13 @@ static void scan_pinned_object(void *obj) {
     case T_RECORD_TYPE: {
         RecordType *rt = (RecordType *)obj;
         rt->name = evacuate(rt->name);
-        for (uint32_t i = 0; i < rt->nfields; i++)
+        rt->constructor = evacuate(rt->constructor);
+        rt->predicate   = evacuate(rt->predicate);
+        for (uint32_t i = 0; i < rt->nfields; i++) {
             rt->field_names[i] = evacuate(rt->field_names[i]);
+            if (rt->accessors) rt->accessors[i] = evacuate(rt->accessors[i]);
+            if (rt->mutators)  rt->mutators[i]  = evacuate(rt->mutators[i]);
+        }
         break;
     }
     case T_UPVALUE: {

--- a/src/object.h
+++ b/src/object.h
@@ -546,12 +546,31 @@ typedef struct {
     int      cmp;
 } Hashtable;
 
-/* Record type descriptor (RTD) */
+/* Record type descriptor (RTD)
+ *
+ * constructor/predicate/accessors/mutators are populated AFTER the RTD
+ * itself is built (record_type_build_spec only constructs the RTD and
+ * describes what bindings need creating -- the actual closures don't
+ * exist until compiler.c/eval.c finish compiling/evaluating each one),
+ * via %rtd-set-constructor!/%rtd-set-predicate!/%rtd-set-accessor!/
+ * %rtd-set-mutator! (src/builtins.c) called once per binding right
+ * after it's defined. All four are V_FALSE (constructor/predicate) or
+ * per-slot V_FALSE (accessors/mutators -- accessors are always real
+ * procedures once populated since every field has one; mutators are
+ * V_FALSE for fields declared immutable) until then, and accessors/
+ * mutators stay V_FALSE forever for an R6RS/R7RS record type built
+ * with rtd_ref = V_FALSE (the tree-walker's eval.c path builds these
+ * directly in C and populates all four eagerly instead -- see its own
+ * S_DEFINE_RECORD_TYPE case). */
 typedef struct {
     Hdr      hdr;
     val_t    name;        /* symbol */
     uint32_t nfields;
-    val_t    field_names[]; /* flexible array of symbols */
+    val_t    constructor; /* procedure, or V_FALSE if not yet/never set */
+    val_t    predicate;   /* procedure, or V_FALSE if not yet/never set */
+    val_t   *accessors;   /* val_t[nfields], GC-visible heap array; NULL until allocated */
+    val_t   *mutators;    /* val_t[nfields], V_FALSE per immutable field; NULL until allocated */
+    val_t    field_names[]; /* flexible array of symbols -- must stay last */
 } RecordType;
 
 /* Record instance */

--- a/src/record_type.c
+++ b/src/record_type.c
@@ -90,6 +90,10 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
             sizeof(RecordType) + nfields * sizeof(val_t));
         rtd->hdr.type = T_RECORD_TYPE; rtd->hdr.flags = 0;
         rtd->name = name_sym; rtd->nfields = nfields;
+        rtd->constructor = V_FALSE; rtd->predicate = V_FALSE;
+        rtd->accessors = (val_t *)gc_alloc_raw_pinned(nfields * sizeof(val_t));
+        rtd->mutators  = (val_t *)gc_alloc_raw_pinned(nfields * sizeof(val_t));
+        for (uint32_t k = 0; k < nfields; k++) { rtd->accessors[k] = V_FALSE; rtd->mutators[k] = V_FALSE; }
 
         val_t fs = field_list; uint32_t fi = 0;
         while (vis_pair(fs)) {
@@ -125,6 +129,7 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
         spec->bindings[n].name   = sym_intern_cstr(buf);
         spec->bindings[n].params = ctor_fields;
         spec->bindings[n].body   = rp_ctor_body(rtd_ref_expr, ctor_fields);
+        spec->bindings[n].role   = RTD_ROLE_CONSTRUCTOR;
         n++;
 
         /* Predicate: <name>? */
@@ -132,6 +137,7 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
         spec->bindings[n].name   = sym_intern_cstr(buf);
         spec->bindings[n].params = rp_cons(x_sym, V_NIL);
         spec->bindings[n].body   = rp_pred_body(rtd_ref_expr, x_sym);
+        spec->bindings[n].role   = RTD_ROLE_PREDICATE;
         n++;
 
         /* Accessors and mutators */
@@ -143,16 +149,20 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
             val_t fi_val     = vfix((intptr_t)fi);
 
             snprintf(buf, sizeof(buf), "%s-%s", ns, sym_cstr(fname));
-            spec->bindings[n].name   = sym_intern_cstr(buf);
-            spec->bindings[n].params = rp_cons(x_sym, V_NIL);
-            spec->bindings[n].body   = rp_getter_body(x_sym, fi_val);
+            spec->bindings[n].name        = sym_intern_cstr(buf);
+            spec->bindings[n].params      = rp_cons(x_sym, V_NIL);
+            spec->bindings[n].body        = rp_getter_body(x_sym, fi_val);
+            spec->bindings[n].role        = RTD_ROLE_ACCESSOR;
+            spec->bindings[n].field_index = (int)fi;
             n++;
 
             if (is_mutable) {
                 snprintf(buf, sizeof(buf), "%s-%s-set!", ns, sym_cstr(fname));
-                spec->bindings[n].name   = sym_intern_cstr(buf);
-                spec->bindings[n].params = rp_cons(x_sym, rp_cons(v_sym, V_NIL));
-                spec->bindings[n].body   = rp_setter_body(x_sym, fi_val, v_sym);
+                spec->bindings[n].name        = sym_intern_cstr(buf);
+                spec->bindings[n].params      = rp_cons(x_sym, rp_cons(v_sym, V_NIL));
+                spec->bindings[n].body        = rp_setter_body(x_sym, fi_val, v_sym);
+                spec->bindings[n].role        = RTD_ROLE_MUTATOR;
+                spec->bindings[n].field_index = (int)fi;
                 n++;
             }
             fi++; fs = vcdr(fs);
@@ -171,6 +181,10 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
     RecordType *rtd = (RecordType *)gc_alloc_pinned(sizeof(RecordType) + nfields * sizeof(val_t));
     rtd->hdr.type = T_RECORD_TYPE; rtd->hdr.flags = 0;
     rtd->name = name_sym; rtd->nfields = nfields;
+    rtd->constructor = V_FALSE; rtd->predicate = V_FALSE;
+    rtd->accessors = (val_t *)gc_alloc_raw_pinned(nfields * sizeof(val_t));
+    rtd->mutators  = (val_t *)gc_alloc_raw_pinned(nfields * sizeof(val_t));
+    for (uint32_t k = 0; k < nfields; k++) { rtd->accessors[k] = V_FALSE; rtd->mutators[k] = V_FALSE; }
     val_t fs = field_specs; uint32_t fi = 0;
     while (vis_pair(fs)) { rtd->field_names[fi++] = vcar(vcar(fs)); fs = vcdr(fs); }
 
@@ -190,12 +204,14 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
     spec->bindings[n].name   = ctor_name;
     spec->bindings[n].params = ctor_fields;
     spec->bindings[n].body   = rp_ctor_body(rtd_ref_expr, ctor_fields);
+    spec->bindings[n].role   = RTD_ROLE_CONSTRUCTOR;
     n++;
 
     /* Predicate */
     spec->bindings[n].name   = pred_sym;
     spec->bindings[n].params = rp_cons(x_sym, V_NIL);
     spec->bindings[n].body   = rp_pred_body(rtd_ref_expr, x_sym);
+    spec->bindings[n].role   = RTD_ROLE_PREDICATE;
     n++;
 
     /* Field accessors and mutators */
@@ -206,16 +222,20 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
         val_t getter_name = vcadr(fspec);
         val_t fi_val      = vfix((intptr_t)fi);
 
-        spec->bindings[n].name   = getter_name;
-        spec->bindings[n].params = rp_cons(x_sym, V_NIL);
-        spec->bindings[n].body   = rp_getter_body(x_sym, fi_val);
+        spec->bindings[n].name        = getter_name;
+        spec->bindings[n].params      = rp_cons(x_sym, V_NIL);
+        spec->bindings[n].body        = rp_getter_body(x_sym, fi_val);
+        spec->bindings[n].role        = RTD_ROLE_ACCESSOR;
+        spec->bindings[n].field_index = (int)fi;
         n++;
 
         if (vis_pair(vcddr(fspec))) {
             val_t setter_name = vcaddr(fspec);
-            spec->bindings[n].name   = setter_name;
-            spec->bindings[n].params = rp_cons(x_sym, rp_cons(v_sym, V_NIL));
-            spec->bindings[n].body   = rp_setter_body(x_sym, fi_val, v_sym);
+            spec->bindings[n].name        = setter_name;
+            spec->bindings[n].params      = rp_cons(x_sym, rp_cons(v_sym, V_NIL));
+            spec->bindings[n].body        = rp_setter_body(x_sym, fi_val, v_sym);
+            spec->bindings[n].role        = RTD_ROLE_MUTATOR;
+            spec->bindings[n].field_index = (int)fi;
             n++;
         }
         fi++; fs = vcdr(fs);

--- a/src/record_type.h
+++ b/src/record_type.h
@@ -12,6 +12,19 @@
  * silently-divergable copies of the same field/name derivation logic.
  */
 
+/* Which of an RTD's four "record-related procedures" (SRFI-279's own
+ * phrase) a given binding is -- lets both compiler.c and eval.c stash
+ * each binding's resulting closure back onto the RTD (via
+ * %rtd-set-constructor!/-predicate!/-accessor!/-mutator!, see
+ * src/builtins.c) without re-deriving R6RS/R7RS's differing field-spec
+ * shapes themselves. field_index is only meaningful for ACCESSOR/MUTATOR. */
+typedef enum {
+    RTD_ROLE_CONSTRUCTOR,
+    RTD_ROLE_PREDICATE,
+    RTD_ROLE_ACCESSOR,
+    RTD_ROLE_MUTATOR,
+} RtdRole;
+
 /* One binding a define-record-type form introduces: the constructor, the
  * predicate, or one field's accessor/mutator. `body` is a ready-to-splice
  * one-form lambda body (a list of exactly one expression) referencing the
@@ -19,9 +32,11 @@
  * RTD referenced via whatever `rtd_ref` record_type_build_spec was called
  * with (see below). */
 typedef struct {
-    val_t name;
-    val_t params;
-    val_t body;
+    val_t   name;
+    val_t   params;
+    val_t   body;
+    RtdRole role;
+    int     field_index; /* only meaningful when role is ACCESSOR/MUTATOR */
 } RecordBinding;
 
 typedef struct {

--- a/tests/r6rs_tests.scm
+++ b/tests/r6rs_tests.scm
@@ -99,6 +99,26 @@
 (check "r6rs record immutable: g" (color-g c) 128)
 (check "r6rs record immutable: b" (color-b c) 0)
 
+;;; record-type-constructor/-predicate/-accessors/-mutators via the
+;;; R6RS (fields ...) codegen path (record_type.c's is_r6rs branch),
+;;; a different name-derivation shape from R7RS's explicit
+;;; (ctor-name field...)/pred/(field acc [mut])... forms above.
+(define point-rtd (record-rtd p))
+(check "r6rs rtd: constructor field values"
+  (let ((q ((record-type-constructor point-rtd) 7 8))) (list (point-x q) (point-y q)))
+  '(7 8))
+(check "r6rs rtd: predicate" ((record-type-predicate point-rtd) p) #t)
+(check "r6rs rtd: both point fields are mutable"
+  (map (lambda (m) (procedure? m)) (record-type-mutators point-rtd))
+  '(#t #t))
+
+(define color-rtd (record-rtd c))
+(check "r6rs rtd: all-immutable record has no mutators"
+  (record-type-mutators color-rtd) '(#f #f #f))
+(check "r6rs rtd: accessors still work for an all-immutable record"
+  (map (lambda (acc) (acc c)) (record-type-accessors color-rtd))
+  '(255 128 0))
+
 ;;; ---- (rnrs) sub-library aliases ----
 
 (import (rnrs lists))

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -451,6 +451,29 @@
     (person-age bob))
   21)
 
+;;; %rtd-set-constructor!/-predicate!/-accessor!/-mutator!: intended for
+;;; internal use only by define-record-type's own codegen, but ordinary
+;;; DEF'd globals like every other primitive, so directly callable by
+;;; any script. Independent security review found and reproduced a real
+;;; segfault: no vis_rtd check on the first argument, so vunptr blindly
+;;; reinterpreted an arbitrary value's raw bits as a RecordType*. Also
+;;; found a non-fixnum field-index argument silently aliasing into a
+;;; valid slot via vunfix's raw bit-shift (no vis_fixnum check).
+(check "%rtd-set-accessor! on a non-rtd raises cleanly, no crash"
+  (guard (e (#t 'caught)) (%rtd-set-accessor! 5 0 (lambda (x) x)))
+  'caught)
+(check "%rtd-set-predicate! on #f raises cleanly, no crash"
+  (guard (e (#t 'caught)) (%rtd-set-predicate! #f 'x))
+  'caught)
+(check "%rtd-set-accessor! on a string raises cleanly, no crash"
+  (guard (e (#t 'caught)) (%rtd-set-accessor! "hello" 0 (lambda (x) x)))
+  'caught)
+(check "%rtd-set-accessor! with a non-fixnum index raises, doesn't alias into a valid slot"
+  (guard (e (#t 'caught)) (%rtd-set-accessor! person-rtd (integer->char 0) (lambda (r) 'hijacked)))
+  'caught)
+(check "record-type-accessors unaffected by the rejected hijack attempt above"
+  (person-name alice) "Alice")
+
 ;;; define-record-type as an internal (local) definition — compiled natively,
 ;;; must stay local to the enclosing lambda rather than leaking to the
 ;;; global environment.

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -428,6 +428,29 @@
 (set-person-age! alice 31)
 (check "record-mutator" (person-age alice) 31)
 
+;;; record-type-constructor/-predicate/-accessors/-mutators: the actual
+;;; procedure objects define-record-type's own codegen creates, stashed
+;;; back onto the RTD (SRFI-279's rtd-properties wants these -- see
+;;; record_type.c/builtins.c's own comments on why the RTD doesn't have
+;;; them populated until after each binding is compiled/evaluated).
+(define person-rtd (record-rtd alice))
+(check "record-type-constructor is the actual constructor"
+  (person-name ((record-type-constructor person-rtd) "Bob" 40)) "Bob")
+(check "record-type-predicate is the actual predicate"
+  ((record-type-predicate person-rtd) alice) #t)
+(check "record-type-predicate rejects a non-instance"
+  ((record-type-predicate person-rtd) 42) #f)
+(check "record-type-accessors: field order matches record-type-field-names"
+  (map (lambda (acc) (acc alice)) (record-type-accessors person-rtd))
+  (list "Alice" 31))
+(check "record-type-mutators: immutable field's mutator slot is #f"
+  (car (record-type-mutators person-rtd)) #f)
+(check "record-type-mutators: mutable field's mutator slot actually mutates"
+  (let ((bob (make-person "Bob" 20)))
+    ((cadr (record-type-mutators person-rtd)) bob 21)
+    (person-age bob))
+  21)
+
 ;;; define-record-type as an internal (local) definition — compiled natively,
 ;;; must stay local to the enclosing lambda rather than leaking to the
 ;;; global environment.
@@ -443,6 +466,25 @@
 (define counter1 (make-local-record-counter))
 (check "local define-record-type: first call"  (counter1) 1)
 (check "local define-record-type: second call" (counter1) 2)
+
+;;; record-type-* through a LOCALLY-defined record type: exercises the
+;;; add_local/scope_depth > 0 branch of compile_define_record_type
+;;; (the rtd_ref gensym gets its own reserved local slot instead of a
+;;; global binding), a different codegen path from the top-level
+;;; <person> record above -- must stash the same way.
+(define (make-local-rtd-probe)
+  (define-record-type <box2>
+    (mk-box2 v)
+    box2?
+    (v box2-v set-box2-v!))
+  (record-rtd (mk-box2 0)))
+(define box2-rtd (make-local-rtd-probe))
+(check "local define-record-type: record-type-constructor works"
+  ((car (record-type-accessors box2-rtd)) ((record-type-constructor box2-rtd) 99)) 99)
+(check "local define-record-type: record-type-predicate works"
+  ((record-type-predicate box2-rtd) ((record-type-constructor box2-rtd) 0)) #t)
+(check "local define-record-type: record-type-predicate rejects other types"
+  ((record-type-predicate box2-rtd) 42) #f)
 (check "local define-record-type: ctor not leaked to global"
   (guard (e (#t 'unbound)) (mk-ctr 0) 'leaked)
   'unbound)

--- a/tests/srfi_s279_inspect_tests.scm
+++ b/tests/srfi_s279_inspect_tests.scm
@@ -297,6 +297,22 @@
 (check "record-type-name" (record-type-name (record-rtd pt)) '<point>)
 (check "record-type-field-names" (record-type-field-names (record-rtd pt)) '(x y))
 
+;; record-type-constructor/-predicate/-accessors/-mutators: the four
+;; "record-related procedures" (SRFI-279's own phrase) as real,
+;; callable procedure objects, stashed onto the RTD by define-record-
+;; type's own codegen (record_type.c/compiler.c/eval.c).
+(check "record-type-constructor is callable and produces a real instance"
+  (point-x ((record-type-constructor (record-rtd pt)) 10 20)) 10)
+(check "record-type-predicate accepts an instance"
+  ((record-type-predicate (record-rtd pt)) pt) #t)
+(check "record-type-predicate rejects a non-instance"
+  ((record-type-predicate (record-rtd pt)) 'not-a-point) #f)
+(check "record-type-accessors: field order matches field-names, both work"
+  (map (lambda (acc) (acc pt)) (record-type-accessors (record-rtd pt)))
+  '(3 4))
+(check "record-type-mutators: both <point> fields are immutable"
+  (record-type-mutators (record-rtd pt)) '(#f #f))
+
 (let ((p (inspect-properties pt)))
   (has "record: field x" p 'x 3)
   (has "record: field y" p 'y 4)
@@ -305,7 +321,24 @@
 
 (let ((p (inspect-properties (record-rtd pt))))
   (has "record-type: rtd-name" p 'rtd-name '<point>)
-  (has "record-type: rtd-field-names" p 'rtd-field-names '(x y)))
+  (has "record-type: rtd-field-names" p 'rtd-field-names '(x y))
+  (check "record-type: rtd-constructor is present and callable"
+    (procedure? (cadr (assoc 'rtd-constructor p))) #t)
+  (check "record-type: rtd-predicate is present and callable"
+    (procedure? (cadr (assoc 'rtd-predicate p))) #t)
+  (check "record-type: rtd-accessors is a list of 2 real procedures"
+    (map procedure? (cadr (assoc 'rtd-accessors p))) '(#t #t))
+  (check "record-type: rtd-mutators is (#f #f) for an all-immutable record"
+    (cadr (assoc 'rtd-mutators p)) '(#f #f)))
+
+;; A record type with a mutable field: rtd-mutators must mix real
+;; procedures and #f in the right positions, not omit or reorder.
+(define-record-type <mut-point> (make-mut-point x y) mut-point?
+  (x mut-point-x) (y mut-point-y set-mut-point-y!))
+(let ((p (inspect-properties (record-rtd (make-mut-point 1 2)))))
+  (check "record-type: rtd-mutators mixes #f (immutable) and a real procedure (mutable)"
+    (map (lambda (m) (if m 'mutator #f)) (cadr (assoc 'rtd-mutators p)))
+    '(#f mutator)))
 
 ;;; ════════════════════════════════════════════════════════════
 ;;; § 14.5  procedure-properties, and the underlying procedure-name /


### PR DESCRIPTION
## Summary

Closes the last deliberately-deferred SRFI-279 gap: `rtd-accessors`/`-mutators`/`-predicate`/`-constructor` — the actual constructor/predicate/accessor/mutator procedure objects for a record type, not just their names. This was scoped out of the original SRFI-279 implementation because it genuinely needed compiler/runtime work: curry's `RecordType` struct only stored `name`+`field_names`, with nothing referencing the closures `define-record-type`'s own codegen creates.

## What changed

- **`src/object.h`**: `RecordType` gains `constructor`, `predicate`, and GC-visible `accessors[]`/`mutators[]` arrays (one entry per field; `mutators` holds `#f` for immutable fields).
- **`src/record_type.h`/`.c`**: `RecordBinding` gains a `role` tag (constructor/predicate/accessor/mutator) + `field_index`, set for every binding `record_type_build_spec` generates (shared between both R6RS `(fields ...)` and R7RS explicit-form record syntax).
- **`src/eval.c`** (tree-walker) and **`src/compiler.c`** (native VM codegen): both `define-record-type` paths now stash each binding's closure back onto the RTD right after it's created — the RTD is built *before* any binding closures exist, so this can't happen eagerly. The tree-walker does it inline (it builds closures directly in C); the compiler emits an extra `%rtd-set-*!` call (new internal primitives) after each binding's own `compile_define`, referencing the runtime RTD via the same `rtd_ref` gensym'd shared variable already used elsewhere in this codegen for `.scc`-cache-safe identity.
- **`src/builtins.c`**: four new public primitives (`record-type-constructor`, `record-type-predicate`, `record-type-accessors`, `record-type-mutators`, matching the existing `record-type-name`/`-field-names` naming convention) plus four internal `%rtd-set-*!` codegen-support primitives. `%make-record-type` (the runtime RTD constructor the compiler's codegen calls) needed the same initialization.
- **`(srfi s279 inspect)`**: wired into `rtd-properties` as `rtd-constructor`/`-predicate`/`-accessors`/`-mutators`.

## Verification

- R6RS and R7RS record syntax, both top-level and local (`scope_depth > 0`) `define-record-type` forms
- `.scc` cache round-trip (fresh compile and cache-hit replay both correctly reconstruct working procedures)
- `tests/r7rs_tests.scm`, `tests/r6rs_tests.scm`, `tests/srfi_s279_inspect_tests.scm` all extended
- Full `ctest` suite: 95/95 pass

## Test plan

- [x] `cmake --build build` succeeds cleanly, no new warnings
- [x] Full `ctest` suite: 95/95 pass
