### PR TITLE
fix(srfi253): fix exponential case-lambda-checked expansion blowup (follow-up to #35)

### DIFF
--- a/docs/reference/srfi/s253.md
+++ b/docs/reference/srfi/s253.md
@@ -88,6 +88,8 @@ Like `define-record-type`, with each field carrying its own predicate. Only the 
 
 **Curry-specific scoping decision**: `ctor-arg` names must appear in the *same order* as the field-specs they're checked against — `ctor-arg` N is checked positionally against field-spec N's predicate, not matched by name. The SRFI's own spec text is terse about the exact cross-referencing rule here; matching by position (rather than by name) is simpler to implement correctly in portable `syntax-rules` (no compile-time identifier-equality machinery needed, which `syntax-rules` genuinely cannot do portably) and matches how every existing `define-record-type` call in this codebase is already written — constructor args always positionally mirror the full field list, in order. A field that isn't a constructor argument at all (legal in plain R7RS `define-record-type`) isn't supported by this macro.
 
+**Known limitation — a narrow window under actors.** This macro expands to plain `define-record-type` first (binding the raw, unchecked constructor/modifiers under their public names), then separately shadows each with a checked wrapper via `set!`. Between those two steps, the raw unchecked constructor/modifiers are briefly live under the public name in the shared global environment — another already-running actor calling the constructor or a modifier by name during that exact window gets the unchecked version, bypassing validation. Evaluate every `define-record-type-checked` form before spawning any actor that uses the type it defines; avoiding the window entirely would need generating distinct fresh identifiers per field, which portable `syntax-rules` can't do.
+
 ## See also
 
 - [`index.md`](index.md) — full SRFI availability table

--- a/lib/curry/modules/srfi/s253/data-checking.scm
+++ b/lib/curry/modules/srfi/s253/data-checking.scm
@@ -130,14 +130,22 @@
     ;; destructuring+checking+evaluating its body if so.
     ;;
     ;; %clc-dispatch's `fail` continuation (the next clause to try, or
-    ;; a final "no match" error) is spliced in UNEXPANDED at every
-    ;; arity-mismatch branch inside %clc-try's own recursion -- correct
-    ;; (no double-evaluation risk, since it's a pure expression with no
-    ;; side effects until actually reached) but means macro-expansion
-    ;; work scales with (parameters per clause) x (sibling clauses).
-    ;; Entirely fine at the realistic clause/parameter counts real code
-    ;; uses; not something a many-dozens-of-clauses case-lambda-checked
-    ;; should be built with.
+    ;; a final "no match" error) is wrapped in a zero-argument thunk,
+    ;; created ONCE per clause, and only the tiny 2-token call
+    ;; (fail-thunk) -- not the unexpanded recursive dispatch tree
+    ;; itself -- gets spliced into %clc-try's several arity-mismatch
+    ;; branches. This is deliberate, not incidental: an earlier version
+    ;; spliced the full unexpanded (%clc-dispatch args rest ...) form
+    ;; in directly at every branch, which independent security review
+    ;; found and measured to be genuinely EXPONENTIAL in clause count
+    ;; (base ~= 2p+1 for p parameters per clause -- an 8-clause x
+    ;; 4-parameter case-lambda-checked form, entirely reasonable-looking
+    ;; user code, took over 2 minutes to even finish compiling). The
+    ;; thunk indirection makes expansion cost linear in (clauses x
+    ;; parameters) again, at the cost of one small closure allocation
+    ;; per clause per call -- a normal, bounded runtime cost, not a
+    ;; macro-expansion-time compile bomb reachable from ordinary-looking
+    ;; source.
     (define-syntax case-lambda-checked
       (syntax-rules ()
         ((_ clause ...)
@@ -148,7 +156,8 @@
         ((_ args)
          (error "case-lambda-checked: no matching clause" args))
         ((_ args (formals body ...) rest ...)
-         (%clc-try formals args (begin body ...) (%clc-dispatch args rest ...)))))
+         (let ((fail-thunk (lambda () (%clc-dispatch args rest ...))))
+           (%clc-try formals args (begin body ...) (fail-thunk))))))
 
     (define-syntax %clc-try
       (syntax-rules ()
@@ -212,6 +221,27 @@
     ;; each field's/the constructor's own let-capture is a separate,
     ;; non-nested sibling form, so reusing the same literal template
     ;; identifier (e.g. %%drtc-orig) across several of them is safe.
+    ;;
+    ;; KNOWN LIMITATION (found by independent security review): between
+    ;; define-record-type binding the raw constructor/modifiers under
+    ;; their public names and the set! calls below replacing them with
+    ;; checked wrappers, there is a real window during which the raw,
+    ;; UNCHECKED constructor/modifiers are live under the public name in
+    ;; GLOBAL_ENV. curry's actors are real OS threads sharing that same
+    ;; global environment, so another already-running actor that calls
+    ;; the constructor/a modifier by name during that exact window gets
+    ;; the unchecked version -- a genuine, if narrow and short-lived,
+    ;; validation bypass. Avoiding it entirely would need each field's
+    ;; raw constructor/modifier bound under its OWN distinct temporary
+    ;; name from the start (never touching the public name until fully
+    ;; checked-and-ready), which needs generating N distinct fresh
+    ;; identifiers for N mutable fields all within one define-record-
+    ;; type call -- something portable syntax-rules genuinely cannot do
+    ;; (no identifier concatenation, no gensym). Given that constraint,
+    ;; this is documented rather than "fixed" with a redesign that would
+    ;; trade a narrow race for a real risk of a new correctness bug:
+    ;; evaluate every define-record-type-checked form before spawning
+    ;; any actor that uses the type it defines.
     ;;
     ;; %drtc-build-raw pre-expands the whole (fname fpred acc [mod])
     ;; field-spec list into plain (fname acc [mod]) forms -- the shape

--- a/tests/srfi_253_tests.scm
+++ b/tests/srfi_253_tests.scm
@@ -112,6 +112,30 @@
        (guard (e (#t 'caught)) (clc))
        'caught)
 
+;; regression: the original %clc-dispatch/%clc-try spliced the next
+;; clause's full unexpanded dispatch form in directly at every
+;; arity-mismatch branch, making macro-expansion time genuinely
+;; EXPONENTIAL in clause count (measured by independent security
+;; review: an 8-clause x 4-parameter form didn't finish compiling in
+;; over 2 minutes). Fixed by wrapping the "try the next clause"
+;; continuation in a thunk, created once per clause, so only a tiny
+;; 2-token call gets duplicated across branches instead of the whole
+;; recursive dispatch tree. This exercises the exact shape that used
+;; to blow up -- if this test suite itself takes more than a couple
+;; seconds to even finish loading this file, the fix has regressed.
+(define clc-stress (case-lambda-checked
+  (((a1 number?) (a2 number?) (a3 number?) (a4 number?)) 1)
+  (((b1 number?) (b2 number?) (b3 number?) (b4 number?) (b5 number?)) 2)
+  (((c1 number?) (c2 number?) (c3 number?) (c4 number?)) 3)
+  (((d1 number?) (d2 number?) (d3 number?) (d4 number?)) 4)
+  (((e1 number?) (e2 number?) (e3 number?) (e4 number?)) 5)
+  (((g1 number?) (g2 number?) (g3 number?) (g4 number?)) 6)
+  (((h1 number?) (h2 number?) (h3 number?) (h4 number?)) 7)
+  ((i1 i2 i3 i4 . rest) 8)))
+(check "case-lambda-checked: 8-clause x 4-parameter form compiles and dispatches correctly"
+       (clc-stress 1 2 3 4)
+       1)
+
 ;;; ---- define-checked ----
 
 (define-checked (mul (a number?) (b number?)) (* a b))


### PR DESCRIPTION
## Summary

PR #35 (SRFI-253 Data Type-Checking) was merged into `main` before a follow-up fix — made in direct response to that PR's own independent security-review finding — was pushed. This PR carries that fix forward onto `main`.

**`main` currently has this bug live** until this merges:

**`case-lambda-checked` macro-expansion is exponential in clause count (real DoS vector).** `%clc-dispatch` spliced the next clause's full unexpanded dispatch form in directly at every arity-mismatch branch inside `%clc-try`'s own recursion, making expansion cost genuinely exponential (base ≈ 2p+1 for p parameters per clause). Measured: 4×4 clauses/params → 0.11s, 5×5 → 2.48s, 6×5 → 27.7s, 8×4 → didn't finish compiling in over 2 minutes — entirely reasonable-looking user code, reachable from any code path compiling less-than-fully-trusted Curry source (an MCP tool, a REPL-as-a-service).

Fixed by wrapping the "try the next clause" continuation in a thunk, created once per clause via `let`, so only the resulting tiny 2-token call gets duplicated across `%clc-try`'s branches — not the whole recursive dispatch tree. Expansion cost is linear again; the same 8×4 stress case now compiles and runs in ~12ms. Regression test added exercising the exact shape that used to blow up.

Also documents (code comment + `docs/reference/srfi/s253.md`) a second, narrower finding from the same review round: `define-record-type-checked` has a real, short-lived window between binding the raw unchecked constructor/modifiers and shadowing them with checked wrappers, during which a concurrently-running actor calling the constructor by name gets the unchecked version. Not fixed with a redesign (would need per-field gensym'd identifiers, which portable `syntax-rules` can't do) — documented as a known limitation with concrete usage guidance instead.

## Test plan

- [x] `cmake --build build` succeeds cleanly
- [x] `tests/srfi_253_tests.scm`: 43/43 pass (new regression test for the exponential-blowup fix)
- [x] Full `ctest` suite: 96/96 pass
