### PR TITLE
fix(tests): remove grep/printf subprocess forking from lsp test assertions

### DIFF
--- a/tests/test_lsp.sh
+++ b/tests/test_lsp.sh
@@ -17,9 +17,18 @@ export CURRY_MODULE_PATH="$MOD_PATH"
 pass=0
 fail=0
 
+# Bash builtin substring test (no grep/printf subprocess) -- under CI-runner
+# or system load, forking a grep+printf pipeline for every single assertion
+# (dozens per run) is itself failure-prone: fork()/exec() can transiently
+# fail or a pipeline stage can be reaped with a misleading exit status for
+# reasons that have nothing to do with the actual haystack content. That
+# produced real, reproducible false-FAILs under load (confirmed by re-
+# grepping a failed run's own saved log afterward and finding the "missing"
+# substring right there, byte for byte). [[ == *needle* ]] does the same
+# literal substring match with zero process creation.
 check_contains() {
     local label="$1" haystack="$2" needle="$3"
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    if [[ "$haystack" == *"$needle"* ]]; then
         echo "PASS: $label"
         (( pass++ )) || true
     else
@@ -32,7 +41,7 @@ check_contains() {
 
 check_not_contains() {
     local label="$1" haystack="$2" needle="$3"
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    if [[ "$haystack" == *"$needle"* ]]; then
         echo "FAIL: $label (string unexpectedly found)"
         echo "  not looking for: $needle"
         echo "  in: $haystack"


### PR DESCRIPTION
## Summary

Fixes #40 (and its sub-issue #41).

Reproduced the intermittent `lsp` ctest failure locally by running 20-30 parallel `test_lsp.sh` instances under artificial CPU load (several `yes > /dev/null` loops + the parallel test runs themselves). This ruled out my original truncation hypothesis from issue #40: re-`grep`-ing a failed run's own saved log afterward found the exact substring `check_contains` had reported missing, present byte-for-byte in the captured output. The data was never corrupted.

Root cause: `check_contains`/`check_not_contains` forked a `printf | grep -qF` pipeline for *every single assertion* (dozens per test run). Under fork/process pressure — exactly what a shared, possibly throttled CI runner or a heavily loaded system produces — that pipeline can fail to spawn or get reaped with a misleading exit status for reasons that have nothing to do with the actual haystack content, producing a false FAIL.

Fix: replaced the `printf | grep` pipeline with bash's builtin `[[ "$haystack" == *"$needle"* ]]` substring test — the same literal match, zero process creation.

## Verification

- Before the fix: 8/20 parallel runs failed under load (`yes` loops + 20 concurrent `test_lsp.sh` invocations)
- After the fix: 0/20, then 0/30 across two separate load runs
- Full `ctest` suite (96/96) still passes

## Test plan

- [x] Local repro under load, before/after comparison (8/20 fail → 0/30 fail)
- [x] Full `ctest` suite passes
- [x] `bash -n tests/test_lsp.sh` (syntax check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
