### PR TITLE
docs(akkadian): fix wrong map glyph, add missing number->string row

### DIFF
--- a/docs/reference/akkadian-reference.md
+++ b/docs/reference/akkadian-reference.md
@@ -1,6 +1,6 @@
 # Akkadian Language Reference
 
-*v1.2.2 — 2026-06-07*
+*v1.20.0 — 2026-08-15*
 
 Curry Scheme accepts three equivalent notations for every name. You can mix them freely within a single program.
 
@@ -69,7 +69,7 @@ The cuneiform signs render in any font that includes the Unicode Cuneiform block
 | `length` | `mīnum` | `𒈠𒈾` | MA.NA — weight/measure |
 | `append` | `redûm` | `𒈠𒂗` | to follow/continue |
 | `reverse` | `turrum` | `𒋻𒀀` | TAR.A — to turn back |
-| `map` | `šutakūlum-nindabî` | `𒈷𒌝` | ME.UM |
+| `map` | `šutakūlum-nindabî` | `𒈷𒅆` | ME.IGI |
 | `for-each` | `ana-kālāma` | `𒀀𒈾𒆠` | A.NA.KI — for all |
 | `filter` | `ṣêrum` | `𒋻` | TAR — to cut/select |
 | `null?` | `šūnum?` | `𒉡𒁹` | NU.DIŠ — not-one = empty |
@@ -106,6 +106,7 @@ These terms are attested in Old Babylonian mathematical tablets.
 | `lcm` | `qallum` | `𒉡𒃲𒁹` | |
 | `exact` | `kinattu` | `𒆠𒋻` | |
 | `inexact` | `lā-kinattu` | `𒉡𒆠𒋻` | |
+| `number->string` | `nikkassum-ana-ṭuppi` | `𒈷𒌝` | ME.UM — "account to tablet"; *nikkassu* "account" is reused (cf. `values`'s `nikkassū` above) |
 
 ### I/O
 


### PR DESCRIPTION
## Summary

Fixes #6.

The Akkadian reference documented `map` as `𒈷𒌝` (ME.UM), but `src/akkadian_names.h` actually binds that glyph to `number->string`; `map`'s real glyph is `𒈷𒅆` (ME.IGI). Following the doc for `(𒈷𒌝 ...)` silently ran `number->string` instead of `map` — no error revealed the mistake, since both glyphs resolve to real (just different) procedures.

Verified directly against `src/akkadian_names.h` and by evaluating both glyphs:
```scheme
(display (𒈷𒅆 (lambda (x) (* x x)) (list 1 2 3)))  ; => (1 4 9) -- map
(display (𒈷𒌝 9 2))                                  ; => "1001" -- number->string
```

- Fixed `map`'s row to the correct glyph/note (`𒈷𒅆`, ME.IGI).
- Added the previously-missing `number->string` row (`𒈷𒌝`, ME.UM) to the Arithmetic table, so the collision would have been visible from the doc's own tables.
- Bumped the stale `v1.2.2` stamp to the current `1.20.0` (issue's item 3 noted the drift; the CI-gating suggestion in that same item is a larger separate piece of work, left out of scope here).

## Test plan
- [x] `ctest --test-dir build -R akkadian` passes
- [x] Manually evaluated both glyphs to confirm the corrected mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
