### PR TITLE
fix(core): close circular-list hang in %indexed-pairs (urgent follow-up to #47)

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2618,25 +2618,48 @@ static val_t prim_rtd_set_mutator(int ac, val_t *av, void *ud) {
  * (project history: "define-library hot loops ~3x slower than
  * top-level"). Doing the same O(n) walk in C sidesteps that entirely.
  *
- * Two passes: count the list's length first (cheap pointer-only walk),
- * then fill a scratch array of the (i car) sub-pairs and build the
- * outer list from the end backward -- avoids both an O(n) Scheme-style
- * reverse pass and any C recursion whose depth would track list length
- * (unbounded recursion here risks a real C stack overflow for a large
- * enough list, unlike the bounded loops below). The scratch array holds
- * heap references (val_t sub-pair pointers), so it's gc_alloc'd (GC-
- * scanned), not gc_alloc_atomic'd. */
+ * Two passes: count the list's length first (Floyd tortoise-and-hare,
+ * same pattern as prim_length above -- a plain vis_pair walk here would
+ * hang forever on a circular list, and this primitive is an ordinary
+ * globally-registered global like everything else in curry's flat
+ * GLOBAL_ENV, directly callable on arbitrary input regardless of
+ * inspect.scm's own callers always passing an already-list?-validated
+ * list; found by independent security review, reproduced via
+ * (%indexed-pairs (let ((x (list 1 2))) (set-cdr! (cdr x) x) x))
+ * hanging uninterruptibly), then fill a scratch array of the (i car)
+ * sub-pairs and build the outer list from the end backward -- avoids
+ * both an O(n) Scheme-style reverse pass and any C recursion whose
+ * depth would track list length (unbounded recursion here risks a real
+ * C stack overflow for a large enough list, unlike the bounded loops
+ * below). The scratch array holds heap references (val_t sub-pair
+ * pointers), so it's gc_alloc'd (GC-scanned), not gc_alloc_atomic'd. */
 static val_t prim_indexed_pairs(int ac, val_t *av, void *ud) {
     (void)ac; (void)ud;
     val_t lst = av[0];
     if (!vis_pair(lst) && !vis_nil(lst))
         scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%indexed-pairs: not a list");
     uint32_t n = 0;
-    for (val_t p = lst; vis_pair(p); p = vcdr(p)) n++;
+    val_t slow = lst, fast = lst;
+    while (vis_pair(fast)) {
+        fast = vcdr(fast); n++;
+        if (!vis_pair(fast)) break;
+        fast = vcdr(fast); n++;
+        slow = vcdr(slow);
+        if (fast == slow) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%indexed-pairs: circular list");
+    }
+    if (!vis_nil(fast)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%indexed-pairs: not a proper list");
     if (n == 0) return V_NIL;
     val_t *entries = (val_t *)gc_alloc((size_t)n * sizeof(val_t));
     uint32_t i = 0;
-    for (val_t p = lst; vis_pair(p); p = vcdr(p), i++)
+    /* i < n as well as vis_pair(p): pass 1 fixes the trip count at n, but
+     * nothing prevents lst from being a still-mutable, shared pair chain
+     * -- if another thread extended it via set-cdr! between the two
+     * passes, an unbounded fill loop could walk past n and write outside
+     * entries[]. No call site actually shares a mutable list across
+     * threads today, but this primitive is an ordinary global like any
+     * other, reachable directly with no such guarantee enforced upstream
+     * (independent code review). */
+    for (val_t p = lst; vis_pair(p) && i < n; p = vcdr(p), i++)
         entries[i] = scm_cons(vfix((intptr_t)i), scm_cons(vcar(p), V_NIL));
     val_t result = V_NIL;
     for (uint32_t k = n; k > 0; k--) result = scm_cons(entries[k-1], result);

--- a/tests/srfi_s279_inspect_tests.scm
+++ b/tests/srfi_s279_inspect_tests.scm
@@ -646,16 +646,24 @@
 (check "%indexed-pairs: raises on a non-list argument"
   (guard (e (#t 'raised)) (%indexed-pairs 5))
   'raised)
+;; Regression: independent security review found the counting pass used
+;; a bare vis_pair walk with no cycle detection, so a circular list
+;; hung the process forever -- reachable from ordinary unprivileged
+;; Scheme (set-cdr! alone builds one), not gated behind inspect.scm's
+;; own list?-before-call convention, since %indexed-pairs is an
+;; ordinary globally-registered primitive like everything else in
+;; curry's flat GLOBAL_ENV. Fixed with the same Floyd tortoise-and-hare
+;; pattern prim_length already uses (also above) -- which as a side
+;; effect makes a dotted/improper-list argument raise too, rather than
+;; the previous silent (and separately flagged) "stop at the first
+;; non-pair cdr and pretend that's the whole list" behavior.
+(check "%indexed-pairs: raises on a circular list"
+  (guard (e (#t 'raised))
+    (%indexed-pairs (let ((x (list 1 2))) (set-cdr! (cdr x) x) x)))
+  'raised)
 (check "%indexed-pairs: raises on a dotted (improper) list"
-  ;; A dotted pair isn't nil-terminated -- the walk stops at the first
-  ;; non-pair cdr, same as it would for any proper-list-only C loop;
-  ;; every real call site (inspect.scm) only ever calls this after its
-  ;; own list?/vector->list/string->list check already guarantees a
-  ;; proper list, so this exercises the primitive's own defensive
-  ;; behavior directly rather than anything reachable through inspect-
-  ;; properties itself.
-  (%indexed-pairs (cons 1 2))
-  '((0 1)))
+  (guard (e (#t 'raised)) (%indexed-pairs (cons 1 2)))
+  'raised)
 ;; Large-scale round-trip: confirms the C fast path produces byte-for-
 ;; byte the same shape the old interpreted Scheme loop did, at a size
 ;; where a correctness regression (e.g. an off-by-one in the length


### PR DESCRIPTION
## Summary

**Urgent follow-up to #47.** Independent security review found a real bug in `%indexed-pairs` (the C primitive added in #47) after that PR had already merged — this is currently live on `main`.

`%indexed-pairs`' counting pass was a bare `vis_pair` walk with no cycle detection. It's an ordinary globally-registered primitive in curry's flat `GLOBAL_ENV`, reachable from any Scheme code — not gated behind `(srfi 279)`'s own `list?`-before-call convention the way its only current caller happens to use it. A circular list (trivially built with `set-cdr!`, no special privileges needed) hangs the process forever in a tight, uninterruptible C loop:

```scheme
(define x (list 1 2))
(set-cdr! (cdr x) x)
(%indexed-pairs x)   ; hangs forever on main today
```

## Fix

- Applied the same Floyd tortoise-and-hare pattern `prim_length` already uses elsewhere in `src/builtins.c`.
- As a side effect, this also makes a dotted/improper-list argument raise instead of silently truncating at the first non-pair cdr — a second, lower-severity issue the same review found (the original test for this was asserting the silent-truncation behavior while its own label claimed the opposite). Both tests corrected.
- Added a defense-in-depth `i < n` bound on the fill loop (pass 1 fixes the trip count; nothing currently enforces the list can't be mutated between the two passes for some future caller).

## Test plan
- [x] Circular-list repro now raises immediately instead of hanging
- [x] Full `ctest` suite (96/96) passes
- [x] The 2M-element-vector `inspect-properties` benchmark from #47 is unaffected (~0.46s — Floyd's algorithm overhead is negligible against the already-necessary single list walk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
