### PR TITLE
feat(vm): thread a per-chunk target environment through Chunk/Compiler/VM

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -128,6 +128,7 @@ Chunk *chunk_new(void) {
     c->local_debug_cap = 0;
     c->src_lambda  = V_VOID;
     c->upval_names = NULL;
+    c->target_env  = V_VOID;
     return c;
 }
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -66,6 +66,36 @@ typedef struct {
      * upval_names[i] = interned symbol for upvalue i; NULL if unavailable. */
     val_t  src_lambda;
     val_t *upval_names;
+
+    /* Which environment OP_LOAD_GLOBAL/OP_STORE_GLOBAL/OP_DEF_GLOBAL
+     * target for this chunk. V_VOID (the default) means "use GLOBAL_ENV",
+     * matching every chunk compiled before this field existed. Set via
+     * compiler_set_target_env() before compiling a define-library body,
+     * so a library's own top-level defines/references resolve against
+     * its isolated root environment instead of the shared global one --
+     * see compiler.c's init_compiler() and vm.c's TARGET_ENV macro. A
+     * compile-time-fixed property of the code (like source_name above),
+     * not a per-call-site or per-closure one: a nested lambda compiled
+     * as part of a library body must keep resolving its global refs
+     * against that same library's env regardless of which unrelated
+     * code later calls it.
+     *
+     * NOT YET SAFE for a target_env other than V_VOID/GLOBAL_ENV to be
+     * reachable from more than one thread until Track 2 of the
+     * eval-elimination migration lands (see docs/thoughts/ and project
+     * memory) -- env.c's frame_is_global() was widened to cover any root
+     * frame, not just literal GLOBAL_ENV, specifically so a
+     * define-library body's env_new_root() frame gets the same seqlock
+     * protection GLOBAL_ENV always has once it becomes possible to call
+     * into it from two actor threads at once, but this has not yet been
+     * verified end-to-end with an actual concurrent test (nothing
+     * currently compiles a chunk with target_env != V_VOID). Also not
+     * yet handled: src/scc.c's .scc cache serializer does not persist
+     * this field, so a chunk compiled against a non-default target_env
+     * would silently revert to GLOBAL_ENV after a cache round-trip --
+     * must be resolved before Track 2 relies on .scc caching for
+     * define-library bodies. */
+    val_t  target_env;
 } Chunk;
 
 /* Allocate a fresh empty chunk */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -126,8 +126,12 @@ static bool is_quoted_symbol(val_t expr, val_t *out_sym);
 /* ── Compiler lifecycle ──────────────────────────────────────────────── */
 
 static _Thread_local const char *g_compile_source_name = NULL;
+static _Thread_local val_t       g_compile_target_env   = V_VOID;
 
 void compiler_set_source_name(const char *name) { g_compile_source_name = name; }
+
+void compiler_set_target_env(val_t env) { g_compile_target_env = env; }
+void compiler_clear_target_env(void)    { g_compile_target_env = V_VOID; }
 
 static void init_compiler(Compiler *c, Compiler *enc, const char *name) {
     c->enclosing   = enc;
@@ -139,6 +143,7 @@ static void init_compiler(Compiler *c, Compiler *enc, const char *name) {
     c->syntax_local_count = 0;
     c->chunk->name = name;
     c->chunk->source_name = g_compile_source_name;
+    c->chunk->target_env  = g_compile_target_env;
 }
 
 static Chunk *end_compiler(Compiler *c) {

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -24,6 +24,18 @@ val_t compiler_compile(val_t expr);
    or a buffer with process lifetime, e.g. argv[]). */
 void compiler_set_source_name(const char *name);
 
+/* Set the target environment stamped onto every chunk compiled from this
+   point on -- which environment that chunk's OP_LOAD_GLOBAL/STORE_GLOBAL/
+   DEF_GLOBAL operate against. Pass V_VOID (the default at process start,
+   and after compiler_clear_target_env()) for the ordinary "use GLOBAL_ENV"
+   behavior every chunk had before this existed; pass a define-library
+   body's own env_new_root() frame to compile that library's top-level
+   forms against its isolated environment instead. Thread-local, like
+   compiler_set_source_name -- must be reset (or explicitly re-set) before
+   the next unrelated compile, since it otherwise stays in effect. */
+void compiler_set_target_env(val_t env);
+void compiler_clear_target_env(void);
+
 /* Compile a list of top-level expressions as a script chunk.
    Returns a zero-argument Closure whose body executes all forms
    left-to-right and returns the value of the last one. */

--- a/src/env.c
+++ b/src/env.c
@@ -62,11 +62,40 @@ void *gc_env_frame_pin = NULL;
  * syms/vals/hidx/size/cap sandwiched inside it. Local, single-thread-owned
  * frames skip all of this (frame_is_global short-circuits to the original
  * unprotected fast path) since they were never the problem.
+ *
+ * frame_is_global is keyed on "is this a ROOT frame" (parent == NULL), not
+ * literal identity with GLOBAL_ENV — GLOBAL_ENV's own frame happens to be a
+ * root frame too (env_new_root_permanent(), same shape as env_new_root()),
+ * so this check already covered it correctly without special-casing it.
+ * Widened deliberately (not merely "happens to also work") once Chunk::
+ * target_env (chunk.h) made it possible for compiled code's OP_LOAD_GLOBAL/
+ * OP_STORE_GLOBAL/OP_DEF_GLOBAL to target a define-library body's own
+ * env_new_root() frame instead of GLOBAL_ENV: once such a frame's exported
+ * closures can be called from more than one actor thread (two actors both
+ * importing and calling the same library concurrently), it is exactly as
+ * exposed to the frame_hash_rehash race above as GLOBAL_ENV always was —
+ * the race was never about GLOBAL_ENV specifically, only about "a root
+ * frame reachable from more than one thread," which used to be exactly one
+ * frame and now, in principle, is not. Every non-root frame (function-call
+ * locals, let bodies, C-extension module envs loaded via env_extend) stays
+ * on the original unprotected fast path, unaffected.
+ *
+ * Coarse-grained by design, not yet optimized: every root frame currently
+ * shares g_global_frame_lock, so a rare structural write to one
+ * define-library's frame briefly serializes against a concurrent write to
+ * an unrelated one (or to GLOBAL_ENV itself) even though they touch
+ * disjoint memory. Root-frame writes are load-time-rare (each top-level
+ * define, once, while a library loads) as opposed to per-call, so this is
+ * expected to be negligible in practice; a per-frame lock would remove even
+ * that if it ever shows up as real contention, not attempted here since
+ * nothing yet exercises a non-GLOBAL_ENV root frame from more than one
+ * thread (Track 2 of the eval-elimination migration, not yet started, is
+ * what would first make that happen).
  */
 static pthread_mutex_t g_global_frame_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static inline bool frame_is_global(const EnvFrame *f) {
-    return GLOBAL_ENV != 0 && f == as_env(GLOBAL_ENV);
+    return f->parent == NULL;
 }
 
 static inline uint32_t seq_begin_write(EnvFrame *f) {

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -575,7 +575,8 @@ static void scan_pinned_object(void *obj) {
         Chunk *ch = (Chunk *)obj;
         for (int i = 0; i < ch->const_len; i++)
             ch->constants[i] = evacuate(ch->constants[i]);
-        ch->src_lambda = evacuate(ch->src_lambda);
+        ch->src_lambda  = evacuate(ch->src_lambda);
+        ch->target_env  = evacuate(ch->target_env);
         break;
     }
     case T_MODULE: {

--- a/src/vm.c
+++ b/src/vm.c
@@ -40,10 +40,15 @@
  *   freely during the transition to full-VM execution.
  *
  * GLOBALS
- *   All global variable operations (OP_LOAD_GLOBAL, OP_STORE_GLOBAL,
- *   OP_DEF_GLOBAL) operate on GLOBAL_ENV, the same environment the
- *   tree-walker uses, keeping one shared namespace throughout the
- *   migration.
+ *   Global variable operations (OP_LOAD_GLOBAL, OP_STORE_GLOBAL,
+ *   OP_DEF_GLOBAL) operate on each chunk's own target environment (the
+ *   TARGET_ENV macro below, reading Chunk::target_env), which defaults to
+ *   GLOBAL_ENV -- every chunk compiled without an explicit
+ *   compiler_set_target_env() call gets GLOBAL_ENV, the same environment
+ *   the tree-walker uses for ordinary top-level code, keeping one shared
+ *   namespace there. A define-library body compiled against its own
+ *   isolated env_new_root() frame instead is the one exception: see
+ *   chunk.h's own comment on Chunk::target_env.
  *
  * OPCODE REFERENCE  (see also opcode.h for the full enum and comments)
  *
@@ -64,10 +69,11 @@
  *     OP_LOAD_LOCAL  A   push slots[A]
  *     OP_STORE_LOCAL A   slots[A] = pop()      (no push; define/set! follow with OP_VOID)
  *
- *   Global variables (constant pool holds the symbol)
- *     OP_LOAD_GLOBAL  A   push GLOBAL_ENV[constants[A]]
- *     OP_STORE_GLOBAL A   GLOBAL_ENV[constants[A]] = pop()   (set! — symbol must exist)
- *     OP_DEF_GLOBAL   A   GLOBAL_ENV[constants[A]] = pop()   (define — creates binding)
+ *   Global variables (constant pool holds the symbol; TARGET_ENV is
+ *   GLOBAL_ENV unless the chunk was compiled with an explicit target env)
+ *     OP_LOAD_GLOBAL  A   push TARGET_ENV[constants[A]]
+ *     OP_STORE_GLOBAL A   TARGET_ENV[constants[A]] = pop()   (set! — symbol must exist)
+ *     OP_DEF_GLOBAL   A   TARGET_ENV[constants[A]] = pop()   (define — creates binding)
  *
  *   Upvalues (closure's upvals[] array)
  *     OP_LOAD_UP  A   push *upvals[A]->location
@@ -509,6 +515,12 @@ val_t vm_run(BcClosure *top_closure, int argc) {
 #define JUMP_ABS(t)  (frame->ip = frame->closure->chunk->code + (t))
 #define CONSTS       (frame->closure->chunk->constants)
 #define GCACHE       (frame->closure->chunk->glob_cache)
+/* V_VOID means "this chunk was compiled without an explicit target env"
+ * (every chunk before this field existed, and every ordinary top-level/
+ * REPL/script compile today) -- falls back to GLOBAL_ENV. See chunk.h's
+ * own comment on Chunk::target_env. */
+#define TARGET_ENV   (frame->closure->chunk->target_env == V_VOID \
+                        ? GLOBAL_ENV : frame->closure->chunk->target_env)
 #define PUSH(v)      do { \
     if (vm->sp >= vm->stack + VM_STACK_MAX) \
         scm_raise_code(EC_STACK_OVERFLOW, "value stack overflow (max %d slots)", VM_STACK_MAX); \
@@ -604,7 +616,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
         CASE(OP_LOAD_GLOBAL) {
             uint8_t ci = READ_U8();
             GlobCacheEntry *cache = GCACHE;
-            EnvFrame *root = as_env(GLOBAL_ENV);
+            EnvFrame *root = as_env(TARGET_ENV);
             /* Acquire load: pairs with the release store in env.c's
              * seq_end_write, so a match against cache[ci].version here
              * guarantees cache[ci].slot (stamped from the same
@@ -633,7 +645,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             uint8_t ci = READ_U8();
             val_t val = POP();
             GlobCacheEntry *cache = GCACHE;
-            EnvFrame *root = as_env(GLOBAL_ENV);
+            EnvFrame *root = as_env(TARGET_ENV);
             uint32_t root_ver = atomic_load_explicit((_Atomic uint32_t *)&root->version, memory_order_acquire);
             if (__builtin_expect(cache != NULL && cache[ci].slot != NULL &&
                                  cache[ci].version == root_ver, 1)) {
@@ -654,7 +666,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             uint8_t ci = READ_U8();
             val_t sym = CONSTS[ci];
             val_t val = POP();
-            env_define(GLOBAL_ENV, sym, val);
+            env_define(TARGET_ENV, sym, val);
             /* Fill cache after define, using the (slot, version) pair from
              * one atomic frame_lookup_versioned call rather than fetching
              * the slot and then separately re-reading root->version — the
@@ -666,7 +678,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
              * regardless of whether it's since gone stale. */
             GlobCacheEntry *cache = GCACHE;
             if (cache) {
-                EnvFrame *root = as_env(GLOBAL_ENV);
+                EnvFrame *root = as_env(TARGET_ENV);
                 uint32_t ver;
                 val_t *slot = frame_lookup_versioned(root, sym, &ver);
                 if (slot) { cache[ci].slot = slot; cache[ci].version = ver; }
@@ -1304,9 +1316,22 @@ val_t vm_run(BcClosure *top_closure, int argc) {
 
 /* ── vm_eval ─────────────────────────────────────────────────────────── */
 
-/* Compile a single Scheme expression and immediately run it in the VM.
-   The `env` argument is accepted for API compatibility with the tree-walker
-   but is ignored; all global operations use GLOBAL_ENV.
+/* Compile a single Scheme expression and immediately run it in the VM,
+   with global operations in the compiled code targeting `env` (GLOBAL_ENV
+   for every caller today; a define-library body's own isolated
+   env_new_root() frame once Track 2 of the eval-elimination migration
+   switches modules.c to call this instead of eval() — see chunk.h's
+   Chunk::target_env comment).
+
+   Not exception-safe against compiler_compile() raising mid-compile: if it
+   does, g_compile_target_env is left set to `env` rather than restored,
+   same as the pre-existing g_compile_source_name (compiler_set_source_name)
+   has always been — in practice every meaningfully different subsequent
+   compile call site re-sets both before use, so a stale value only matters
+   if something compiles without first calling compiler_set_target_env
+   itself. Track 2 should verify this holds for modules.c's actual
+   exception-handling paths (a library body that fails to compile) before
+   relying on it, rather than assuming it from this comment alone.
 
    The closure is pushed as the callee before vm_run: pop_frame's normal
    return path does sp = slots - 1 to drop callee + args, so a frame
@@ -1315,8 +1340,9 @@ val_t vm_run(BcClosure *top_closure, int argc) {
    to the stack base), but nested evaluation — the debugger's p command
    runs inside a paused vm_run — corrupts the suspended frame without it. */
 val_t vm_eval(val_t expr, val_t env) {
-    (void)env;
+    compiler_set_target_env(env);
     val_t cl_val  = compiler_compile(expr);
+    compiler_clear_target_env();
     BcClosure *cl = as_bcclosure(cl_val);
     vm_push(cl_val);
     return vm_run(cl, 0);


### PR DESCRIPTION
## Summary

Infrastructure for making define-library bodies compile+run on the VM instead of being tree-walked (Track 1 of the eval-elimination migration; see docs/thoughts/eval-elimination-migration-plan-2026-07-23.md and project memory). No behavior change: every existing call site keeps getting GLOBAL_ENV, the only value anything passes today.

- Chunk gains a target_env field (V_VOID default, meaning use GLOBAL_ENV), mirroring the existing source_name convention: compiler_set_target_env()/compiler_clear_target_env() set a thread-local the compiler stamps onto every chunk it produces (top-level and nested lambdas alike) until changed again.
- vm.c's OP_LOAD_GLOBAL/OP_STORE_GLOBAL/OP_DEF_GLOBAL (including the inline monomorphic cache) now read a chunks own TARGET_ENV instead of the hard-wired GLOBAL_ENV. vm_eval(expr, env) actually uses its env argument now instead of ignoring it.
- gc_gen.c's T_CHUNK evacuation case (the only actually-compiled experimental GC backend) traces the new field.

Also fixes a real correctness gap this surfaced, found by independent code review: env.cs frame_is_global() (which decides whether a frame needs the actor-thread-safe seqlock protocol around structural mutation) checked literal identity with GLOBAL_ENV. Once a chunks target_env can be a define-library bodys own env_new_root() frame, that frame is exactly as exposed to the concurrent-frame-growth race GLOBAL_ENVs own comment already documents (two actor threads calling into the same library while it is still growing) but was getting none of the protection. Fixed by keying frame_is_global on whether a frame is a root frame (parent == NULL) instead of identity: GLOBAL_ENVs own frame is already a root frame by construction, so this covers it exactly as before while also covering any future target_env frame, with the same existing seqlock mechanism (no new locking primitive).

Two known gaps intentionally left open, documented in-code and in project memory, both to be resolved before Track 2 (which will start actually compiling define-library bodies with a non-default target_env) relies on them: .scc cache serialization does not yet persist target_env (src/scc.c), and vm_evals set/clear-around-compile is not exception-safe against compiler_compile() raising mid-compile (currently dormant -- todays only caller always passes GLOBAL_ENV).

## Test plan

- [x] Full ctest suite passes (100/100)
- [x] Repeated runs of the actors/STM concurrency test (most relevant to the frame_is_global change) pass consistently

Generated with Claude Code