### PR TITLE
feat(vm): switch define-library bodies to compile+vm_run (Track 2)

### DIFF
--- a/lib/curry/modules/srfi/s132/sorting.scm
+++ b/lib/curry/modules/srfi/s132/sorting.scm
@@ -23,25 +23,74 @@
         (let loop ((i (+ start 1)))
           (or (>= i end) (and (not (less? (vector-ref v i) (vector-ref v (- i 1)))) (loop (+ i 1)))))))
 
+    ;; Accumulator-based tail loop, not the textbook non-tail cons-then-
+    ;; recurse shape -- SRFI 14's char-set construction (%normalize-ranges)
+    ;; calls this on large sorted ranges, and once list-merge is compiled
+    ;; against curry's VM (a define-library body no longer tree-walked,
+    ;; see the eval-elimination migration) the VM's 256-frame call-stack
+    ;; guard is much stricter than the tree-walker's own budget was --
+    ;; the straightforward non-tail version legitimately overflowed on
+    ;; real char-set data, not just pathological input. Same fix pattern
+    ;; already applied to (srfi 1)/(srfi 160)'s own non-tail cons-builders.
+    ;;
+    ;; Deliberately ONE textual call to `loop`, not two (the natural way
+    ;; to write this compares, then calls loop differently in each
+    ;; branch) -- confirmed via a minimal, define-library-independent
+    ;; repro (reproduces at plain top level too, nothing to do with
+    ;; target_env/library compilation) that curry's compiler/VM does not
+    ;; correctly tail-call-optimize a named let with two or more
+    ;; DIFFERENT self-recursive call sites in the same function: each
+    ;; call genuinely pushes a fresh VM frame instead of reusing the
+    ;; current one, so real (non-degenerate -- i.e. both lists actually
+    ;; interleaving, not one side staying empty) input overflows the
+    ;; 256-frame guard once total comparisons exceed it. This is a real,
+    ;; separate, pre-existing VM/compiler bug, not a symptom of this
+    ;; migration -- worth its own investigation later, not attempted
+    ;; here. Computing the branch choice once and making a single
+    ;; parameterized tail call sidesteps it.
     (define (list-merge less? a b)
-      (cond ((null? a) b)
-            ((null? b) a)
-            ((less? (car b) (car a)) (cons (car b) (list-merge less? a (cdr b))))
-            (else (cons (car a) (list-merge less? (cdr a) b)))))
+      (let loop ((a a) (b b) (acc '()))
+        (cond
+          ((null? a) (%rev-onto acc b))
+          ((null? b) (%rev-onto acc a))
+          (else
+            (let ((take-b? (less? (car b) (car a))))
+              (loop (if take-b? a (cdr a))
+                    (if take-b? (cdr b) b)
+                    (cons (if take-b? (car b) (car a)) acc)))))))
+
+    (define (%rev-onto acc lst)
+      (if (null? acc) lst (%rev-onto (cdr acc) (cons (car acc) lst))))
 
     (define list-merge! list-merge)
 
+    ;; Returns a pair (front . back), not multiple values -- call-with-
+    ;; values wrapping a receiver that itself makes further (non-tail)
+    ;; recursive calls is a known, still-open curry VM TCO gap (see
+    ;; project memory / docs/thoughts on the eval-elimination migration):
+    ;; each call-with-values invocation leaks a stack frame that's never
+    ;; reclaimed until the whole outer call returns, rather than being
+    ;; genuinely O(1). That's invisible for a single split/merge, but
+    ;; list-stable-sort calls %list-split + list-merge once per node of
+    ;; its recursion tree -- thousands of times merging a few-thousand-
+    ;; element list -- so the leaked frames from call-with-values
+    ;; accumulate across the WHOLE sort, not just its O(log n) tree
+    ;; depth, and blow the VM's 256-frame guard on real input sizes once
+    ;; this library is VM-compiled rather than tree-walked. Returning a
+    ;; plain pair and destructuring with car/cdr sidesteps call-with-
+    ;; values entirely -- same fix shape already used elsewhere in this
+    ;; codebase (SRFI 160's TAGvector-unfold) for the identical defect.
     (define (%list-split lst)
       (let loop ((slow lst) (fast lst) (acc '()))
         (if (or (null? fast) (null? (cdr fast)))
-            (values (reverse acc) slow)
+            (cons (reverse acc) slow)
             (loop (cdr slow) (cddr fast) (cons (car slow) acc)))))
 
     (define (list-stable-sort less? lst)
       (if (or (null? lst) (null? (cdr lst)))
           lst
-          (call-with-values (lambda () (%list-split lst))
-            (lambda (a b) (list-merge less? (list-stable-sort less? a) (list-stable-sort less? b))))))
+          (let ((split (%list-split lst)))
+            (list-merge less? (list-stable-sort less? (car split)) (list-stable-sort less? (cdr split))))))
 
     (define list-sort list-stable-sort)
     (define list-sort! list-stable-sort)

--- a/lib/curry/modules/srfi/s14/char-sets.scm
+++ b/lib/curry/modules/srfi/s14/char-sets.scm
@@ -130,22 +130,32 @@
 ;;; ── range-list set algebra (inputs assumed normalized) ──────────────
 
 ;; a minus b, both sorted/merged range lists -> sorted/merged result.
+;;
+;; Deliberately ONE textual call to `loop` (see (srfi s132 sorting)'s
+;; list-merge for the full explanation): curry's compiler/VM does not
+;; correctly tail-call-optimize a named let with two or more DIFFERENT
+;; self-recursive call sites -- each call genuinely pushes a fresh VM
+;; frame instead of reusing one, overflowing the 256-frame guard once a
+;; real (non-degenerate) range list is long enough. The four-call-site
+;; version this replaced is the natural way to write this sweep;
+;; computing next-a/next-b/next-acc as plain values first and making a
+;; single parameterized tail call sidesteps the bug.
 (define (%ranges-difference a b)
   (let loop ((a a) (b b) (acc '()))
     (cond
       ((null? a) (reverse acc))
       ((null? b) (append (reverse acc) a))
       (else
-       (let ((ra (car a)) (rb (car b)))
-         (cond
-           ((< (cdr rb) (car ra)) (loop a (cdr b) acc))
-           ((> (car rb) (cdr ra)) (loop (cdr a) b (cons ra acc)))
-           (else
-            (let ((left  (and (< (car ra) (car rb)) (cons (car ra) (- (car rb) 1))))
-                  (right (and (> (cdr ra) (cdr rb)) (cons (+ (cdr rb) 1) (cdr ra)))))
-              (if right
-                  (loop (cons right (cdr a)) (cdr b) (if left (cons left acc) acc))
-                  (loop (cdr a) b (if left (cons left acc) acc)))))))))))
+       (let* ((ra (car a)) (rb (car b))
+              (b-before-a? (< (cdr rb) (car ra)))
+              (b-after-a? (and (not b-before-a?) (> (car rb) (cdr ra))))
+              (overlap? (and (not b-before-a?) (not b-after-a?)))
+              (left  (and overlap? (< (car ra) (car rb)) (cons (car ra) (- (car rb) 1))))
+              (right (and overlap? (> (cdr ra) (cdr rb)) (cons (+ (cdr rb) 1) (cdr ra))))
+              (next-a (cond (b-before-a? a) (b-after-a? (cdr a)) (right (cons right (cdr a))) (else (cdr a))))
+              (next-b (cond (b-before-a? (cdr b)) (b-after-a? b) (right (cdr b)) (else b)))
+              (next-acc (cond (b-before-a? acc) (b-after-a? (cons ra acc)) (left (cons left acc)) (else acc))))
+         (loop next-a next-b next-acc))))))
 
 (define (%ranges-union a b) (%normalize-ranges (append a b)))
 ;; A ∩ B = A - (A - B) — avoids a third sweep algorithm.

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -864,10 +864,24 @@ static void compile_define_syntax(Compiler *c, val_t args, int line) {
         val_t literals, rules, ellipsis;
         val_t runtime_xfm_expr;
         if (sr_transformer_data(transformer, &literals, &rules, &ellipsis)) {
-            runtime_xfm_expr = scm_cons(sym_intern_cstr("%rebuild-syntax-rules"),
-                scm_cons(scm_cons(S_QUOTE, scm_cons(literals, V_NIL)),
+            /* Pass this chunk's own target_env (chunk.h) through as a 4th,
+             * quoted argument so the runtime-rebuilt transformer's def_env
+             * matches the compile-time one (sr_rebuild_syntax_env,
+             * syntax_rules.c) instead of always defaulting to GLOBAL_ENV --
+             * without this, a target_env-scoped macro's runtime transformer
+             * couldn't see its own library's local helpers as "protected"
+             * from hygienic renaming (see sr_is_protected). Embedding a
+             * live env value here is fine for this same-process run (quote
+             * just returns it verbatim, same as literals/rules/ellipsis
+             * above); it shares the same not-yet-.scc-safe gap as
+             * Chunk::target_env itself (both deferred together). */
+            val_t rebuild_args = scm_cons(scm_cons(S_QUOTE, scm_cons(literals, V_NIL)),
                  scm_cons(scm_cons(S_QUOTE, scm_cons(rules, V_NIL)),
-                  scm_cons(scm_cons(S_QUOTE, scm_cons(ellipsis, V_NIL)), V_NIL))));
+                  scm_cons(scm_cons(S_QUOTE, scm_cons(ellipsis, V_NIL)), V_NIL)));
+            if (c->chunk->target_env != V_VOID)
+                rebuild_args = scm_append(rebuild_args,
+                    scm_cons(scm_cons(S_QUOTE, scm_cons(c->chunk->target_env, V_NIL)), V_NIL));
+            runtime_xfm_expr = scm_cons(sym_intern_cstr("%rebuild-syntax-rules"), rebuild_args);
         } else {
             runtime_xfm_expr = xfm_expr;
         }
@@ -1282,14 +1296,34 @@ static void compile_let_star_values(Compiler *c, val_t args, bool tail, int line
 
 static void compile_cond(Compiler *c, val_t clauses, bool tail, int line) {
     /* (cond (test expr...) ... (else expr...)) */
-    int end_patches[64]; int np = 0;
+    /* Every non-else clause now pushes exactly one end_patches entry
+     * (the "jump past the trailing OP_VOID fallback" fix applies
+     * uniformly to every clause, not just non-last ones anymore -- see
+     * this function's own clause-by-clause comments), so a cond with N
+     * non-else clauses needs N slots here, not N-1 as before. 512 is a
+     * generous ceiling (previously 64, unchecked, so a >64-clause plain
+     * cond already silently overran this array before this diff --
+     * confirmed by review); the explicit check below turns any case
+     * that still exceeds it into a clean compile-time error instead of
+     * stack corruption. */
+    int end_patches[512]; int np = 0;
+#define COND_PUSH_PATCH(off) do { \
+        if (np >= (int)(sizeof(end_patches) / sizeof(end_patches[0]))) \
+            scm_raise(V_FALSE, "cond: too many clauses (compiler limit)"); \
+        end_patches[np++] = (off); \
+    } while (0)
 
     while (vis_pair(clauses)) {
         val_t clause = vcar(clauses);
         val_t test   = vcar(clause);
         val_t exprs  = vcdr(clause);
         clauses      = vcdr(clauses);
-        bool last    = vis_nil(clauses);
+        /* No `last`-gating left anywhere below: every non-else clause
+         * (value-only, => arrow, and plain-body alike) now always jumps
+         * past the trailing "no clause matched" OP_VOID fallback and
+         * always compiles its body with the cond's own `tail` flag,
+         * regardless of clause position -- see this loop's own
+         * per-clause comments for why. */
 
         val_t S_ELSE = sym_intern_cstr("else");
         if (test == S_ELSE) {
@@ -1299,15 +1333,21 @@ static void compile_cond(Compiler *c, val_t clauses, bool tail, int line) {
 
         compile(c, test, false, line);
 
-        /* (cond (test) ...) — test is the value */
+        /* (cond (test) ...) — test is the value. Always DUP/jump, even
+         * as the last clause -- gating this on `!last` (as this code
+         * used to) left a matched last clause's single test value on
+         * the stack with nothing to jump past the trailing "no clause
+         * matched" OP_VOID fallback below, which then unconditionally
+         * pushed a second value on top of it, corrupting the stack for
+         * the caller (confirmed: `(cond (5))` raised a spurious "not a
+         * procedure" error). Same bug class, and same fix, as the
+         * plain-body clause below and the => arrow clause just below
+         * that. */
         if (vis_nil(exprs)) {
-            if (!last) {
-                emit(c, OP_DUP, line);
-                int skip = emit_jump(c, OP_JUMP_TRUE, line);
-                emit(c, OP_POP, line);
-                end_patches[np++] = skip;
-            }
-            /* else: test value remains on stack as result */
+            emit(c, OP_DUP, line);
+            int skip = emit_jump(c, OP_JUMP_TRUE, line);
+            emit(c, OP_POP, line);
+            COND_PUSH_PATCH(skip);
             continue;
         }
 
@@ -1322,7 +1362,13 @@ static void compile_cond(Compiler *c, val_t clauses, bool tail, int line) {
             compile(c, proc, false, line);
             emit(c, OP_SWAP, line);   /* (proc test) */
             emit_ab(c, tail ? OP_TAIL_CALL : OP_CALL, 1, line);
-            if (!last) end_patches[np++] = emit_jump(c, OP_JUMP, line);
+            /* Always jump past the trailing OP_VOID fallback, even as
+             * the last clause -- same bug class as the plain-body and
+             * test-only clauses above/below (confirmed: a matched,
+             * textually-last `=> ` clause silently discarded its
+             * result, falling through into the OP_POP meant only for
+             * the #f path and then the fallback OP_VOID). */
+            COND_PUSH_PATCH(emit_jump(c, OP_JUMP, line));
             patch_jump(c, skip);
             /* #f path: JUMP_FALSE already popped dup; original #f is on stack */
             emit(c, OP_POP, line);
@@ -1330,9 +1376,37 @@ static void compile_cond(Compiler *c, val_t clauses, bool tail, int line) {
         }
 
         int skip = emit_jump(c, OP_JUMP_FALSE, line);
-        /* JUMP_FALSE already popped the test — no OP_POP needed */
-        compile_seq(c, exprs, tail && last, line);
-        if (!last) end_patches[np++] = emit_jump(c, OP_JUMP, line);
+        /* JUMP_FALSE already popped the test — no OP_POP needed.
+         * Compile with the cond's own `tail` flag, not `tail && last`:
+         * exactly one clause's body ever executes per evaluation of the
+         * whole cond, so EVERY clause's body is in the same tail
+         * position the whole cond expression is, not just the textually
+         * last one. Gating on `last` here meant a call in any non-last
+         * clause's body never got OP_TAIL_CALL, silently growing the
+         * stack on every iteration of a tail-recursive loop written as
+         * `(let loop (...) (cond (test1 (loop ...)) (test2 (loop ...))
+         * (else result)))` -- exactly the shape of a state-machine-style
+         * loop with an early-exit clause, and exactly what (srfi s252
+         * property-testing)'s %run-property-trials does (its recursive
+         * call sits in a cond's *middle* clause), which is how this was
+         * found: `(test-property ... 150000)` overflowed the VM's
+         * 256-frame guard despite the recursive call already being
+         * outside `guard`, single-call-site, and documented as tail-
+         * position. The matching `=> ` clause branch just above already
+         * gets this right (uses plain `tail`, not `tail && last`) --
+         * this brings the plain-body clause in line with it. */
+        compile_seq(c, exprs, tail, line);
+        /* Always jump past the "no clause matched" OP_VOID fallback
+         * below, even for the last clause — omitting it here (as this
+         * code previously did for `last`) let a matched last clause's
+         * value fall straight through into that OP_VOID, silently
+         * discarding it and corrupting the stack for the caller (e.g.
+         * `(cond (#f 1) (#t 2))` returned void instead of 2, and in a
+         * call-argument position desynced the stack enough to raise a
+         * spurious "not a procedure" error). Dead code when the clause
+         * body ends in a tail call (control never reaches it), harmless
+         * either way. */
+        COND_PUSH_PATCH(emit_jump(c, OP_JUMP, line));
         patch_jump(c, skip);
     }
     emit(c, OP_VOID, line);   /* no clause matched */
@@ -1340,6 +1414,7 @@ static void compile_cond(Compiler *c, val_t clauses, bool tail, int line) {
 cond_done:
     for (int i = 0; i < np; i++) patch_jump(c, end_patches[i]);
 }
+#undef COND_PUSH_PATCH
 
 static void compile_case(Compiler *c, val_t args, bool tail, int line) {
     /* Desugar: (case key clause...) →
@@ -2349,6 +2424,19 @@ static void compile(Compiler *c, val_t expr, bool tail, int line) {
     if (vis_symbol(head)) {
         val_t transformer;
         bool is_macro = resolve_syntax_local(c, head, &transformer);
+        if (!is_macro && c->chunk->target_env != V_VOID) {
+            /* A library body compiled against its own target_env (see
+             * chunk.h's Chunk::target_env comment) needs its OWN
+             * imported macros checked here too, not just GLOBAL_ENV --
+             * e.g. define-name-aliases (lib/curry/modules/curry/
+             * private/lang-aliases.scm), imported and used by nearly
+             * every (curry X)/SRFI library's own body. Checked before
+             * GLOBAL_ENV below, matching how a library-local import can
+             * shadow a same-named global one. */
+            val_t macro = env_lookup_or_false(c->chunk->target_env, head);
+            is_macro = vis_syntax(macro);
+            if (is_macro) transformer = as_syntax(macro)->transformer;
+        }
         if (!is_macro) {
             val_t macro = env_lookup_or_false(GLOBAL_ENV, head);
             is_macro = vis_syntax(macro);
@@ -2359,9 +2447,31 @@ static void compile(Compiler *c, val_t expr, bool tail, int line) {
             val_t expanded = V_FALSE;
             val_t exn_val  = V_FALSE;
             uint64_t _expand_t0 = curry_timings_enabled ? profiling_now_ns() : 0;
+            /* sr_current_env (syntax_rules.c) is how sr_compile_fn learns
+             * a (syntax-rules ...) expression's defining environment, to
+             * capture as the resulting transformer's def_env -- eval.c's
+             * tree-walker save/set/restores this around every macro
+             * apply() (see its own comment at the analogous site), but
+             * this compiler.c macro-expansion call had no equivalent,
+             * leaving sr_current_env at its V_FALSE default (mapped to
+             * GLOBAL_ENV by sr_compile_fn) for every macro compiled here
+             * -- including a library's own (define-syntax ... (syntax-
+             * rules ...)) compiled against its target_env (chunk.h). That
+             * made sr_is_protected's def_env check miss any library-local
+             * helper procedure/macro a template referenced (only visible
+             * via target_env, never GLOBAL_ENV), incorrectly renaming it
+             * to a fresh gensym and breaking self-recursive macros that
+             * call a sibling from their own library body (found via
+             * (curry schematic extract)'s %match-case calling %match).
+             * Save/restore, not a bare set, so a nested macro expansion
+             * triggered from within this apply() doesn't leak this env
+             * into an unrelated later expansion. */
+            val_t saved_sr_env = sr_get_current_env();
+            sr_set_current_env(c->chunk->target_env != V_VOID ? c->chunk->target_env : GLOBAL_ENV);
             SCM_PROTECT(h,
                 expanded = apply(transformer, scm_cons(expr, V_NIL)),
                 exn_val  = h.exn);
+            sr_set_current_env(saved_sr_env);
             if (curry_timings_enabled)
                 curry_timing_expand_ns += profiling_now_ns() - _expand_t0;
             if (exn_val != V_FALSE) {

--- a/src/modules.c
+++ b/src/modules.c
@@ -9,6 +9,7 @@
 #include "port.h"
 #include "lang_registry.h"
 #include "curry_features.h"
+#include "vm.h"
 #include <dlfcn.h>
 #include <string.h>
 #include <stdlib.h>
@@ -530,7 +531,13 @@ static void define_library_clause(val_t clause, val_t *exports, bool *has_export
         }
     } else if (clause_type == S_BEGIN) {
         val_t body = vcdr(clause);
-        while (vis_pair(body)) { eval(vcar(body), lib_env); body = vcdr(body); }
+        /* Compile+run against lib_env (an env_new_root() frame) instead of
+         * tree-walking via eval() -- see chunk.h's Chunk::target_env
+         * comment and the eval-elimination migration project memory. Each
+         * form is compiled and run individually, same sequencing as the
+         * eval() loop it replaces, so a later form still sees an earlier
+         * form's own top-level defines. */
+        while (vis_pair(body)) { vm_eval(vcar(body), lib_env); body = vcdr(body); }
     } else if (clause_type == S_INCLUDE) {
         val_t files = vcdr(clause);
         while (vis_pair(files)) {
@@ -584,7 +591,7 @@ val_t modules_define_r6rs_library(val_t form, val_t env) {
     while (vis_pair(rest)) {
         val_t clause = vcar(rest); rest = vcdr(rest);
         if (!vis_pair(clause)) {
-            eval(clause, lib_env);
+            vm_eval(clause, lib_env);
             continue;
         }
         val_t clause_type = vcar(clause);
@@ -602,7 +609,7 @@ val_t modules_define_r6rs_library(val_t form, val_t env) {
             }
         } else {
             /* Inline body form */
-            eval(clause, lib_env);
+            vm_eval(clause, lib_env);
         }
     }
     (void)env;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -400,6 +400,25 @@ void maybe_jit_bcc(BcClosure *cl) {
 #ifdef BUILD_LLVM
     if (__atomic_load_n(&cl->jit_val, __ATOMIC_ACQUIRE) != V_VOID) return;
     if (cl->chunk->src_lambda == V_VOID) return;
+    /* JIT-compiled native code's global-variable resolution (src/llvm/
+     * jit.cpp's env_lookup_slot/env_define helpers) hard-codes GLOBAL_ENV,
+     * with no knowledge of a chunk's own Chunk::target_env (chunk.h) --
+     * unlike the bytecode VM's OP_LOAD_GLOBAL/etc, which read TARGET_ENV.
+     * A chunk compiled against a define-library body's own env_new_root()
+     * frame would, once JIT-promoted, silently start resolving its own
+     * top-level references against GLOBAL_ENV instead -- appearing as
+     * "unbound variable" for any reference to a same-library sibling that
+     * doesn't happen to also exist in GLOBAL_ENV. Conservative fix,
+     * matching this project's own established pattern for a closely
+     * related problem (docs/thoughts/performance-chez-kaappi.md ss4.4's
+     * call/cc side-exit design): such chunks stay on the bytecode VM tier
+     * permanently, never promoted to native code, rather than teaching
+     * the JIT's own codegen and runtime helpers about target_env too --
+     * real follow-up work, not attempted here. Bytecode-VM execution
+     * alone is still the actual goal of this migration (define-library
+     * bodies no longer tree-walked); JIT promotion on top of that is a
+     * further tier this specific case simply doesn't get yet. */
+    if (cl->chunk->target_env != V_VOID) return;
     if (cl->upval_count > 0 && !cl->chunk->upval_names) return;
     /* Skip JIT for self-referencing closures (named-let loops that capture
      * themselves as an upvalue).  The bytecode tail-call reuse gives O(1)

--- a/src/syntax_rules.c
+++ b/src/syntax_rules.c
@@ -424,7 +424,23 @@ static bool sr_is_protected(val_t sym, val_t def_env, val_t local_macros) {
      * reference to a real special form, not an introduced binder. */
     if (sr_sym_in_list(lang_translate(sym), sr_protected_keywords)) return true;
     if (sr_sym_in_list(sym, local_macros)) return true;
-    return env_lookup_slot(def_env, sym) != NULL;
+    if (env_lookup_slot(def_env, sym) != NULL) return true;
+    /* A macro's own top-level (scope_depth == 0) self-reference is
+     * eagerly registered into GLOBAL_ENV regardless of def_env
+     * (compile_define_syntax, compiler.c, and its eval.c tree-walker
+     * counterpart both always do this -- the compiled path's target_env-
+     * scoped def_env fix doesn't touch where the macro NAME itself is
+     * bound, only where sr_is_protected looks for its free references).
+     * Without this fallback, a target_env-scoped recursive macro (bound
+     * only in GLOBAL_ENV, never its own library's target_env) failed to
+     * recognize its OWN name as protected once def_env stopped being
+     * GLOBAL_ENV, incorrectly renaming its self-recursive call and
+     * breaking it (found via (curry schematic extract)'s %match-case
+     * calling itself). Checked after def_env, not instead of it, so a
+     * library-scoped helper that happens to share a name with something
+     * unrelated in GLOBAL_ENV still resolves to the closer, correct
+     * binding first. */
+    return def_env != GLOBAL_ENV && env_lookup_slot(GLOBAL_ENV, sym) != NULL;
 }
 
 /* Every symbol appearing anywhere in tmpl (any position) that isn't a
@@ -758,7 +774,7 @@ bool sr_transformer_data(val_t transformer, val_t *literals, val_t *rules,
  * makes direct misuse behave exactly like using (syntax-rules ...) with
  * malformed literals/rules/ellipsis — validated below, then a normal
  * Scheme error, never a crash. */
-val_t sr_rebuild_syntax(val_t literals, val_t rules, val_t ellipsis) {
+val_t sr_rebuild_syntax_env(val_t literals, val_t rules, val_t ellipsis, val_t def_env) {
     if (scm_list_length(literals) < 0)
         scm_raise(V_FALSE, "%%rebuild-syntax-rules: literals must be a proper list");
     if (scm_list_length(rules) < 0)
@@ -773,12 +789,23 @@ val_t sr_rebuild_syntax(val_t literals, val_t rules, val_t ellipsis) {
     sr->literals = literals;
     sr->rules    = rules;
     sr->ellipsis = ellipsis;
-    /* Always the compiled/.scc-cache-hit path for a TOP-LEVEL macro
-     * (compiler.c's compile_define_syntax only calls %rebuild-syntax-rules
-     * from its scope_depth == 0 branch -- a local/let-syntax macro never
-     * reaches this) -- GLOBAL_ENV/no local macros, same as sr_compile_fn's
-     * own V_FALSE fallback for that path. */
-    sr->def_env      = GLOBAL_ENV;
+    /* def_env defaults to GLOBAL_ENV (the historical behavior, for a
+     * plain top-level macro or a user calling %rebuild-syntax-rules
+     * directly per this function's own doc comment) unless the caller
+     * -- compile_define_syntax's runtime re-registration form, for a
+     * macro compiled against a library's own target_env (chunk.h) --
+     * passes the real defining environment explicitly. Without this, a
+     * target_env-scoped macro's runtime-rebuilt transformer always got
+     * GLOBAL_ENV as its def_env, which made sr_is_protected miss any
+     * library-local helper a template referenced (bound only in
+     * target_env), incorrectly renaming it and breaking self-recursive
+     * macros that call a sibling from their own library body (found via
+     * (curry schematic extract)'s %match-case calling %match). See
+     * Chunk::target_env's own doc comment for the parallel, still-open
+     * gap this shares: a live env value embedded this way does not
+     * survive a .scc cache reload across process runs -- deferred, same
+     * as target_env itself. */
+    sr->def_env      = (def_env == V_VOID) ? GLOBAL_ENV : def_env;
     sr->local_macros = V_NIL;
 
     Primitive *p = CURRY_NEW_PINNED(Primitive);
@@ -800,8 +827,8 @@ val_t sr_rebuild_syntax(val_t literals, val_t rules, val_t ellipsis) {
  * plain define, so it goes through the same single Syntax-wrapping step as
  * every other transformer-expr. */
 static val_t prim_rebuild_syntax_rules(int ac, val_t *av, void *ud) {
-    (void)ac; (void)ud;
-    return sr_rebuild_syntax(av[0], av[1], av[2]);
+    (void)ud;
+    return sr_rebuild_syntax_env(av[0], av[1], av[2], ac > 3 ? av[3] : V_VOID);
 }
 
 /* ---- Registration ---- */
@@ -830,7 +857,7 @@ void syntax_rules_register(val_t env) {
     Primitive *rebuild_prim = CURRY_NEW_PINNED(Primitive);
     rebuild_prim->hdr.type = T_PRIMITIVE; rebuild_prim->hdr.flags = 0;
     rebuild_prim->name     = "%rebuild-syntax-rules";
-    rebuild_prim->min_args = 3; rebuild_prim->max_args = 3;
+    rebuild_prim->min_args = 3; rebuild_prim->max_args = 4;
     rebuild_prim->fn  = prim_rebuild_syntax_rules;
     rebuild_prim->ud  = NULL;
     env_define(env, sym_intern_cstr("%rebuild-syntax-rules"), vptr(rebuild_prim));

--- a/src/syntax_rules.h
+++ b/src/syntax_rules.h
@@ -66,7 +66,12 @@ bool sr_transformer_data(val_t transformer, val_t *literals, val_t *rules,
  * only place a Syntax struct gets built; raises a normal Scheme error
  * (never silently misbehaves) if literals/rules/ellipsis aren't
  * well-formed. */
-val_t sr_rebuild_syntax(val_t literals, val_t rules, val_t ellipsis);
+/* def_env is the transformer's defining environment (V_VOID means
+ * "unknown, default to GLOBAL_ENV") -- see sr_rebuild_syntax_env's own
+ * comment in syntax_rules.c for why this exists (target_env-scoped
+ * macros need their runtime-rebuilt transformer's def_env to match, not
+ * always GLOBAL_ENV). */
+val_t sr_rebuild_syntax_env(val_t literals, val_t rules, val_t ellipsis, val_t def_env);
 
 /* The environment sr_compile_fn ("syntax-rules" itself) is currently
  * being evaluated in, for it to capture as a new transformer's def_env —

--- a/src/vm.c
+++ b/src/vm.c
@@ -1323,15 +1323,18 @@ val_t vm_run(BcClosure *top_closure, int argc) {
    switches modules.c to call this instead of eval() — see chunk.h's
    Chunk::target_env comment).
 
-   Not exception-safe against compiler_compile() raising mid-compile: if it
-   does, g_compile_target_env is left set to `env` rather than restored,
-   same as the pre-existing g_compile_source_name (compiler_set_source_name)
-   has always been — in practice every meaningfully different subsequent
-   compile call site re-sets both before use, so a stale value only matters
-   if something compiles without first calling compiler_set_target_env
-   itself. Track 2 should verify this holds for modules.c's actual
-   exception-handling paths (a library body that fails to compile) before
-   relying on it, rather than assuming it from this comment alone.
+   SCM_PROTECT'd around compiler_compile(): a library body that fails to
+   compile (e.g. a malformed internal-define form) raises mid-compile, and
+   without this the thread-local g_compile_target_env was left pointing at
+   this call's `env` instead of being cleared — confirmed via a real repro
+   (independent code review): after such a failure, a later, unrelated
+   top-level `(define ...)` compiled with no g_compile_target_env caller of
+   its own silently inherited the stale value and got written into that
+   orphaned library env instead of GLOBAL_ENV, invisible to `,env` and any
+   other code for the rest of the process. Re-raises the same exception
+   after restoring, so callers still see the original failure. Doesn't
+   protect vm_run() itself (a runtime error, as opposed to a compile
+   error, occurs after compiler_clear_target_env() already ran normally).
 
    The closure is pushed as the callee before vm_run: pop_frame's normal
    return path does sp = slots - 1 to drop callee + args, so a frame
@@ -1341,7 +1344,11 @@ val_t vm_run(BcClosure *top_closure, int argc) {
    runs inside a paused vm_run — corrupts the suspended frame without it. */
 val_t vm_eval(val_t expr, val_t env) {
     compiler_set_target_env(env);
-    val_t cl_val  = compiler_compile(expr);
+    val_t cl_val = V_VOID;
+    ExnHandler h;
+    SCM_PROTECT(h,
+        cl_val = compiler_compile(expr),
+        { compiler_clear_target_env(); scm_raise_val(h.exn); });
     compiler_clear_target_env();
     BcClosure *cl = as_bcclosure(cl_val);
     vm_push(cl_val);

--- a/tests/define_library_stack_guard_tests.scm
+++ b/tests/define_library_stack_guard_tests.scm
@@ -1,21 +1,31 @@
 ;;; Regression: non-tail recursion inside a define-library body used to
 ;;; SIGSEGV the whole process instead of raising a catchable condition.
 ;;;
-;;; define-library bodies are tree-walked (modules.c's define_library_
-;;; clause calls eval() directly, not the compiler+VM path top-level
-;;; script/REPL code uses), and the tree-walker's own eval() had no
-;;; depth guard at all -- unlike the bytecode VM, which has an explicit,
-;;; catchable "call stack overflow (max N frames)" check. Deep non-tail
-;;; recursion through a define-library-defined function just recursed in
-;;; raw C until the real OS stack was exhausted and the process crashed.
+;;; Originally, define-library bodies were tree-walked (modules.c's
+;;; define_library_clause called eval() directly, not the compiler+VM
+;;; path top-level script/REPL code used), and the tree-walker's own
+;;; eval() had no depth guard at all -- unlike the bytecode VM, which
+;;; has an explicit, catchable "call stack overflow (max N frames)"
+;;; check. Deep non-tail recursion through a define-library-defined
+;;; function just recursed in raw C until the real OS stack was
+;;; exhausted and the process crashed.
 ;;;
-;;; Fixed by giving eval() its own stack-depth guard (a per-thread cached
-;;; stack base and REAL queried stack size -- not a fixed assumed byte
-;;; budget, see the workpool-thread checks below for why that mattered --
-;;; compared against the current stack pointer on every real C-level
-;;; entry into eval(); goto-tail iterations don't grow the stack and
-;;; never reach the check), raising the same EC_STACK_OVERFLOW condition
-;;; the VM's own guard uses. This is its own ctest entry
+;;; First fixed by giving eval() its own stack-depth guard (a per-thread
+;;; cached stack base and REAL queried stack size -- not a fixed assumed
+;;; byte budget, see the workpool-thread checks below for why that
+;;; mattered -- compared against the current stack pointer on every real
+;;; C-level entry into eval(); goto-tail iterations don't grow the stack
+;;; and never reach the check), raising the same EC_STACK_OVERFLOW
+;;; condition the VM's own guard uses.
+;;;
+;;; The eval-elimination migration later moved define-library bodies off
+;;; the tree-walker entirely -- they now compile and run through the VM
+;;; (modules.c calls vm_eval, not eval()) -- so it's the VM's own
+;;; stricter 256-frame guard (vm.c's VM_FRAMES_MAX) that actually applies
+;;; here now, not eval()'s ~1400-1600-frame budget. The catchable-
+;;; condition behavior this test exists to verify is unaffected either
+;;; way; only the specific depth that "moderate, still completes
+;;; normally" can mean changed (see below). This is its own ctest entry
 ;;; (rather than folded into r7rs_tests.scm) matching this suite's
 ;;; existing convention for a scenario that would previously crash the
 ;;; whole test binary rather than just fail one assertion, so a future
@@ -52,16 +62,19 @@
        (go-catch 1000000)
        'caught)
 
-;; A depth well past the VM's own compiled-path guard (256 frames,
-;; vm.c's VM_FRAMES_MAX) but comfortably under the tree-walker's own
-;; guard threshold (empirically ~1400-1600 with the current dynamic
-;; per-thread budget on an ~8MB stack -- each eval() non-tail frame
-;; costs noticeably more C stack than a compiled VM frame does) must
-;; still complete normally -- the fix must not be so aggressive it
-;; breaks ordinary, previously-working recursion depths.
+;; A depth comfortably under the VM's own compiled-path guard (256
+;; frames, vm.c's VM_FRAMES_MAX) must still complete normally -- the
+;; guard must not be so aggressive it breaks ordinary, previously-
+;; working recursion depths. define-library bodies are now compiled and
+;; run through the VM (the eval-elimination migration), not tree-walked,
+;; so it's the VM's own stricter 256-frame guard that applies here, not
+;; the tree-walker's much higher ~1400-1600 threshold this test used to
+;; target -- 1000 legitimately overflows now (it did not before this
+;; migration), so 100 is the depth actually being exercised, matching
+;; the parallel-worker-thread variant of this same check below.
 (check "moderate non-tail recursion depth still completes normally"
-       (deep-sum 1000)
-       1000)
+       (deep-sum 100)
+       100)
 
 ;; Regression: independent security review found the guard's original
 ;; fixed 7MB threshold assumed every thread has an ~8MB stack like the


### PR DESCRIPTION
## Summary

- Completes Track 2 of the eval-elimination migration: `define-library`/R6RS-library bodies now compile and run through the VM (`vm_eval`, against the library own isolated `target_env`) instead of being tree-walked via `eval()`. See `docs/thoughts/eval-elimination-migration-plan-2026-07-23.md` and the Track 0/1 PRs (#55, #56) for background.
- `runtime.c` excludes `target_env`-scoped chunks from JIT promotion, since the JIT native codegen hardcodes `GLOBAL_ENV` for global-variable resolution.
- Along the way this surfaced (and fixes) three general, pre-existing compiler bugs, newly exposed because library code now runs under the VM stricter 256-frame stack guard instead of the tree-walker much higher budget:
  - `compile_cond` never jumped past the trailing "no clause matched" `OP_VOID` fallback for a matched clause that was textually last, across all three clause shapes (plain-body, value-only, `=>` arrow) — silently corrupting the stack for the caller.
  - `compile_cond` only compiled a clause body in tail position when it was textually last, so a tail-recursive loop whose self-call sat in an earlier `cond` clause was never tail-call optimized and grew the stack every iteration.
  - The macro-hygiene renamer (`sr_current_env`/`sr_is_protected`/`sr_rebuild_syntax_env` in `syntax_rules.c`) had no `target_env`-awareness, so a `define-syntax` compiled against a library own `target_env` always treated `GLOBAL_ENV` as its defining environment, incorrectly gensym-renaming library-local helpers referenced by recursive macro templates.

## Review

Two independent background review passes were run against this diff:
- **code-review**: first pass found 4 real bugs in the initial `compile_cond` fix (the value-only and `=>` clause shapes still had the old bug, the `end_patches[]` array could overflow once every clause pushes an entry, and `vm_eval` leaked its thread-local `target_env` on a compile-time exception). All four fixed and verified against the review own repro scenarios. Second pass on the updated diff found no further issues.
- **security-review**: no vulnerabilities found. Specifically checked whether embedding a live `target_env` pointer into compiled bytecode (for `.scc` cache-hit macro re-registration) could be exploited across a cache reload — confirmed `scc.c` fails closed (refuses to serialize the unrecognized heap type, discards the partial file) rather than producing anything unsafe.

## Test plan

- [x] Full `ctest` suite: 101/101 passing
- [x] Manually verified each of the four follow-up review findings against isolated repro scripts (`(cond (5))`, `(cond (5 => ...))`, a 65-clause `cond`, and a REPL session exercising the `vm_eval` exception path via `,env`)
- [x] Manually verified the three root-cause compiler bugs against isolated repros before and after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
