### PR TITLE
feat(llvm): swap JIT-failure fallback from eval() to vm_eval()

### DIFF
--- a/src/llvm/curry_llvm.cpp
+++ b/src/llvm/curry_llvm.cpp
@@ -12,6 +12,7 @@
 extern "C" {
 #include "../value.h"
 #include "../eval.h"
+#include "../vm.h"
 }
 
 #include <llvm/IR/LLVMContext.h>
@@ -84,8 +85,17 @@ val_t curry_jit_call(val_t thunk) {
 }
 
 val_t curry_jit_eval_expr(val_t expr) {
+    /* Compile-to-bytecode-and-interpret (vm_eval) rather than tree-walk
+     * (eval()) for both the "JIT unavailable" and "JIT compile failed"
+     * paths -- part of the eval-elimination migration (see
+     * docs/thoughts/eval-elimination-migration-plan-2026-07-23.md's
+     * "Other eval() callers" section and the project memory). A JIT
+     * compile failure by definition already has `expr` in hand as a
+     * plain, uncompiled Scheme form (this function's own argument, not
+     * bytecode) -- vm_eval compiles it fresh against GLOBAL_ENV, exactly
+     * as eval() would have tree-walked it, just through the VM instead. */
     if (!g_initialised.load())
-        return eval(expr, GLOBAL_ENV);
+        return vm_eval(expr, GLOBAL_ENV);
 
     static std::atomic<uint64_t> seq{0};
     std::string fn_name = "curry_expr_" + std::to_string(seq.fetch_add(1));
@@ -110,7 +120,7 @@ val_t curry_jit_eval_expr(val_t expr) {
     } catch (const std::exception &e) {
         fprintf(stderr, "[curry-llvm] JIT failed (%s), falling back: %s\n",
                 fn_name.c_str(), e.what());
-        return eval(expr, GLOBAL_ENV);
+        return vm_eval(expr, GLOBAL_ENV);
     }
 }
 


### PR DESCRIPTION
## Summary

- Deferred step from the eval-elimination migration plan (`docs/thoughts/eval-elimination-migration-plan-2026-07-23.md`, "Other eval() callers" section): swaps the LLVM JIT-compile-failure fallback from `eval()` (tree-walker) to `vm_eval()` (compile+run through the VM).
- `curry_jit_eval_expr` (backs the `curry-jit-eval` builtin, `src/llvm/curry_llvm.cpp`) had two `eval(expr, GLOBAL_ENV)` call sites: JIT-subsystem-unavailable, and JIT-compile-threw-a-C++-exception. Both now call `vm_eval(expr, GLOBAL_ENV)` instead. A JIT-compile failure by definition already has the plain Scheme expression in hand — nothing to re-derive, just a swap of which evaluator runs it.

## Review

An independent code-review pass checked: whether `vm_eval` is a safe, behavior-equivalent replacement (yes — same `setjmp`/`longjmp` exception chain, no new exposure versus what `eval()` already had); whether adding `vm.h`'s inclusion (pulling in `chunk.h`/`object.h`) inside the file existing `extern "C"` block risks an ODR/linkage issue (no — `object.h` is include-guarded and declares no non-static functions, `chunk.h` is included for the first time here entirely inside `extern "C"`); and any other regression (none found).

## Test plan

- [x] Full `ctest` suite: 101/101 passing
- [x] `tests/jit_tests.scm`: 263/263 passing
- [x] Manually forced both fallback paths and confirmed each routes through `vm_eval` (the JIT-compile-exception path shows the compiler own diagnostic output on the fallback route, confirming it, not `eval()`, now handles it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
