### PR TITLE
perf(vm): Tier 1 quick wins — self-tail-call, fused global calls, cached tree-eval

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -31,6 +31,7 @@
 #include "symbol.h"
 #include "object.h"
 #include "set.h"
+#include "eval.h"
 
 const char *opcode_name[OP_COUNT] = {
     [OP_CONST]          = "CONST",
@@ -94,6 +95,10 @@ const char *opcode_name[OP_COUNT] = {
     [OP_CALL]           = "CALL",
     [OP_TAIL_CALL]      = "TAIL_CALL",
     [OP_RETURN]         = "RETURN",
+    [OP_SELF_TAIL_CALL]   = "SELF_TAIL_CALL",
+    [OP_CALL_GLOBAL]      = "CALL_GLOBAL",
+    [OP_TAIL_CALL_GLOBAL] = "TAIL_CALL_GLOBAL",
+    [OP_TREE_EVAL_CACHED] = "TREE_EVAL_CACHED",
     [OP_CLOSURE]        = "CLOSURE",
     [OP_CLOSE_UP]       = "CLOSE_UP",
     [OP_APPLY]          = "APPLY",
@@ -123,6 +128,7 @@ Chunk *chunk_new(void) {
     c->name       = NULL;
     c->source_name = NULL;
     c->glob_cache = NULL;
+    c->tree_eval_cache = NULL;
     c->local_debug = NULL;
     c->local_debug_len = 0;
     c->local_debug_cap = 0;
@@ -217,6 +223,20 @@ int chunk_add_const(Chunk *c, val_t v) {
         if (vis_string(e) && vis_string(v) &&
             strcmp(str_data(as_str(e)), str_data(as_str(v))) == 0) return i;
     }
+    /* Every bytecode operand indexing into constants[] is a single uint8_t
+     * (OP_LOAD_GLOBAL/OP_STORE_GLOBAL/OP_CALL_GLOBAL/OP_TAIL_CALL_GLOBAL/
+     * OP_TREE_EVAL_CACHED/emit_const, ...) -- a chunk that accumulates a
+     * 257th DISTINCT constant would silently wrap the returned index back
+     * into uint8_t range and every later use of that index would load or
+     * call the WRONG constant instead of failing loudly. This has always
+     * been possible (emit_load/emit_store hit this same path for every
+     * distinct global reference, pre-dating this check), but is worth a
+     * hard, clear compile-time stop rather than silent misbehavior --
+     * mirrors the existing "cond: too many clauses (compiler limit)"
+     * precedent below for the same category of fixed-width-operand
+     * limit. */
+    if (c->const_len >= 256)
+        scm_raise(V_FALSE, "compiler limit: too many distinct constants in one chunk (max 256)");
     if (c->const_len == c->const_cap) {
         int cap = c->const_cap < 8 ? 8 : c->const_cap * 2;
         c->constants = GC_REALLOC(c->constants, (size_t)cap * sizeof(val_t));
@@ -229,6 +249,18 @@ int chunk_add_const(Chunk *c, val_t v) {
         memset(new_gc + c->const_len, 0,
                (size_t)(cap - c->const_len) * sizeof(GlobCacheEntry));
         c->glob_cache = new_gc;
+        /* Grow tree_eval_cache the same way, parallel to constants --
+         * see chunk.h's Chunk::tree_eval_cache comment. Unlike
+         * glob_cache this holds real val_t values (not raw pointers), so
+         * it needs gc_alloc_raw_pinned for the same "Boehm traces this"
+         * reason but ALSO needs a gc_gen.c evacuation case (added
+         * alongside T_CHUNK's existing one) for correctness under
+         * --gc generational. */
+        val_t *new_tc = (val_t *)gc_alloc_raw_pinned((size_t)cap * sizeof(val_t));
+        if (c->tree_eval_cache)
+            memcpy(new_tc, c->tree_eval_cache, (size_t)c->const_len * sizeof(val_t));
+        memset(new_tc + c->const_len, 0, (size_t)(cap - c->const_len) * sizeof(val_t));
+        c->tree_eval_cache = new_tc;
     }
     int idx = c->const_len++;
     c->constants[idx] = v;
@@ -252,10 +284,10 @@ static int disasm_one(const Chunk *c, int off) {
     case OP_LOAD_LOCAL: case OP_STORE_LOCAL:
     case OP_LOAD_GLOBAL: case OP_STORE_GLOBAL: case OP_DEF_GLOBAL:
     case OP_LOAD_UP: case OP_STORE_UP:
-    case OP_CALL: case OP_TAIL_CALL:
+    case OP_CALL: case OP_TAIL_CALL: case OP_SELF_TAIL_CALL:
     case OP_CLOSURE: case OP_CLOSE_UP:
     case OP_VALUES: case OP_MAKEVEC: case OP_APPLY:
-    case OP_SLIDE: {
+    case OP_SLIDE: case OP_TREE_EVAL_CACHED: {
         uint8_t a = c->code[off++];
         fprintf(stderr, "%-16s %4d", name, a);
         if ((OpCode)op == OP_CONST || (OpCode)op == OP_LOAD_GLOBAL ||
@@ -276,6 +308,17 @@ static int disasm_one(const Chunk *c, int off) {
         uint16_t b = (uint16_t)(c->code[off] | (c->code[off+1] << 8));
         off += 2;
         fprintf(stderr, "%-16s %4d\n", name, (int)b);
+        break;
+    }
+    case OP_CALL_GLOBAL: case OP_TAIL_CALL_GLOBAL: {
+        uint8_t a = c->code[off++];
+        uint8_t b = c->code[off++];
+        fprintf(stderr, "%-16s %4d %4d", name, a, b);
+        if (a < c->const_len) {
+            val_t v = c->constants[a];
+            if (vis_symbol(v)) fprintf(stderr, "  ; %s", as_sym(v)->data);
+        }
+        fprintf(stderr, "\n");
         break;
     }
     default:

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -57,6 +57,37 @@ typedef struct {
 
     GlobCacheEntry *glob_cache; /* parallel to constants[], filled lazily; GC-traced */
 
+    /* Per-call-site cache for OP_TREE_EVAL_CACHED (the tree-eval
+     * passthrough for import/define-library/library -- see
+     * compiler.c's tree-eval punt block). Parallel to constants[] like
+     * glob_cache, grown alongside it in chunk_add_const. NULL/unset
+     * slots hold 0 (not a valid heap pointer, matching glob_cache's own
+     * NULL-slot convention); a non-zero slot holds the memoized result
+     * of already having run constants[i] through eval() once.
+     *
+     * Deliberately NEVER touched by src/scc.c's serializer, the same way
+     * glob_cache never is: every chunk, whether freshly compiled or
+     * loaded from .scc, starts with this NULL and rebuilds lazily during
+     * execution. This is what makes the cache safe to have at all --
+     * .scc writes happen AFTER the compiling process has already run the
+     * chunk once (see main.c's write_pending_scc_atexit), so if this
+     * array's post-execution state were serialized, a "already imported"
+     * cached slot would leak into the file; a FRESH process loading that
+     * .scc would then wrongly skip re-running import/define-library
+     * against its own empty GLOBAL_ENV. Not serializing it at all sidesteps
+     * that entirely, at the cost (same as glob_cache) of the cache
+     * starting cold again on every new process -- fine, since it only
+     * ever helps within one process's repeated execution of the same
+     * chunk (e.g. an import nested inside a function called from a loop),
+     * never across process boundaries anyway.
+     *
+     * Unlike glob_cache, THIS array needs a gc_gen.c evacuation case:
+     * glob_cache stores raw val_t* slot pointers validated by a separate
+     * version check (safe to go stale under --gc generational), but this
+     * array stores real cached val_t RESULT values that must move with
+     * everything else. */
+    val_t *tree_eval_cache;
+
     LocalDebugEntry *local_debug; /* debugger's slot→name map; may be NULL */
     int       local_debug_len;
     int       local_debug_cap;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -116,6 +116,17 @@ typedef struct Compiler {
 
     SyntaxLocal syntax_locals[MAX_SYNTAX_LOCALS];
     int         syntax_local_count;
+
+    /* Named-let self-tail-call (OP_SELF_TAIL_CALL, see compile_call and
+     * compile_let's named-let branch): self_tail_name is the loop's own
+     * symbol when this Compiler is compiling exactly that loop's body
+     * (V_FALSE otherwise); self_tail_mutated is set once, before body
+     * compilation begins, if the raw body ever textually targets that
+     * name with set! anywhere (conservative, shadowing-unaware --see
+     * body_mentions_set_target) -- when true, every self-tail-call site
+     * in this body falls back to the ordinary call path instead. */
+    val_t self_tail_name;
+    bool  self_tail_mutated;
 } Compiler;
 
 /* ── Forward declarations ────────────────────────────────────────────── */
@@ -127,6 +138,14 @@ static bool is_quoted_symbol(val_t expr, val_t *out_sym);
 
 static _Thread_local const char *g_compile_source_name = NULL;
 static _Thread_local val_t       g_compile_target_env   = V_VOID;
+/* Set by compile_let's named-let branch right before compiling the loop
+ * lambda's own body, consumed-and-cleared by init_compiler below the same
+ * way g_compile_target_env is -- see Compiler::self_tail_name's own
+ * comment. Mirrors the established thread-local hand-off pattern used
+ * throughout this file rather than adding a parameter to compile_lambda
+ * (which has many other callers that don't care about this at all). */
+static _Thread_local val_t       g_compile_self_tail_name    = V_FALSE;
+static _Thread_local bool        g_compile_self_tail_mutated = false;
 
 void compiler_set_source_name(const char *name) { g_compile_source_name = name; }
 
@@ -144,6 +163,10 @@ static void init_compiler(Compiler *c, Compiler *enc, const char *name) {
     c->chunk->name = name;
     c->chunk->source_name = g_compile_source_name;
     c->chunk->target_env  = g_compile_target_env;
+    c->self_tail_name     = g_compile_self_tail_name;
+    c->self_tail_mutated  = g_compile_self_tail_mutated;
+    g_compile_self_tail_name    = V_FALSE;
+    g_compile_self_tail_mutated = false;
 }
 
 static Chunk *end_compiler(Compiler *c) {
@@ -176,6 +199,14 @@ static void emit_const(Compiler *c, val_t v, int line) {
 static void emit_ab(Compiler *c, uint8_t op, uint8_t a, int line) {
     chunk_emit(c->chunk, op, line);
     chunk_emit(c->chunk, a,  line);
+}
+
+/* Opcode + two single-byte operands (e.g. OP_CALL_GLOBAL's const-pool
+ * index and argc) */
+static void emit_abc(Compiler *c, uint8_t op, uint8_t a, uint8_t b, int line) {
+    chunk_emit(c->chunk, op, line);
+    chunk_emit(c->chunk, a,  line);
+    chunk_emit(c->chunk, b,  line);
 }
 
 /* Emit a jump; returns offset of the 16-bit placeholder to patch later */
@@ -1015,6 +1046,65 @@ static void compile_or(Compiler *c, val_t args, bool tail, int line) {
         patch_jump(c, patches[i]);
 }
 
+/* Conservative textual scan: does `expr` (or anything nested inside it,
+ * except inside a (quote ...) subform) contain (set! name ...) anywhere,
+ * OR any macro use at all (local syntax-local, or a global/target_env
+ * T_SYNTAX binding)? Deliberately ignores lexical shadowing for the
+ * set!-target check -- a false positive there (an inner binding that
+ * happens to share `name` but isn't really the same variable) only costs
+ * a missed optimization. The macro-use check is a SEPARATE, unconditional
+ * bail-out (found by code review, confirmed via repro): a plain textual
+ * scan of the RAW body can only ever see set! forms written literally in
+ * source -- it is blind to a macro that itself EXPANDS to (set! name
+ * ...), since expansion happens later, during compile(). A named-let
+ * loop whose body used a macro that expanded to `(set! loop other-fn)`
+ * previously still got OP_SELF_TAIL_CALL (the scan found no literal
+ * set!), so the compiler kept trusting "this call always means myself"
+ * even after the loop variable was reassigned to something else --
+ * confirmed: the loop silently kept calling the stale closure instead of
+ * the reassigned one. Rather than expanding every macro here just to
+ * scan the result (duplicating compile()'s own expansion machinery), any
+ * macro use anywhere in the body unconditionally disables the
+ * optimization -- correct by construction (no expansion result can ever
+ * need scanning if the whole body already bails out), at the cost of
+ * also declining the optimization for named-let loops that happen to use
+ * some unrelated macro that doesn't touch the loop variable at all. That
+ * tradeoff is deliberate: only a hard NO is guaranteed to never regress
+ * to a wrong answer as new macros get written.
+ *
+ * Mirrors sr_collect_free_symbols's own "don't descend into quote"
+ * pattern (syntax_rules.c), and compile()'s own is-macro check (checked
+ * local-syntax first, then target_env, then GLOBAL_ENV) for the macro
+ * detection. lang_translate on the head catches an Akkadian-spelled
+ * set! too, matching how compile()'s own dispatch translates every head
+ * before comparing against S_SET. */
+static bool expr_mentions_set_target(Compiler *c, val_t expr, val_t name) {
+    if (!vis_pair(expr)) return false;
+    val_t raw_head = vcar(expr);
+    val_t head = lang_translate(raw_head);
+    if (head == S_QUOTE) return false;
+    if (head == S_SET && vis_pair(vcdr(expr)) && vcar(vcdr(expr)) == name)
+        return true;
+    if (vis_symbol(raw_head)) {
+        val_t transformer;
+        bool is_macro = resolve_syntax_local(c, raw_head, &transformer);
+        if (!is_macro && c->chunk->target_env != V_VOID)
+            is_macro = vis_syntax(env_lookup_or_false(c->chunk->target_env, raw_head));
+        if (!is_macro)
+            is_macro = vis_syntax(env_lookup_or_false(GLOBAL_ENV, raw_head));
+        if (is_macro) return true;  /* unconditional bail-out, see comment above */
+    }
+    for (val_t p = expr; vis_pair(p); p = vcdr(p))
+        if (expr_mentions_set_target(c, vcar(p), name)) return true;
+    return false;
+}
+
+static bool body_mentions_set_target(Compiler *c, val_t body, val_t name) {
+    for (val_t p = body; vis_pair(p); p = vcdr(p))
+        if (expr_mentions_set_target(c, vcar(p), name)) return true;
+    return false;
+}
+
 static void compile_let(Compiler *c, val_t args, bool tail, int line) {
     val_t bindings = vcar(args);
     val_t body     = vcdr(args);
@@ -1058,7 +1148,18 @@ static void compile_let(Compiler *c, val_t args, bool tail, int line) {
         mark_initialised(&outer);
         emit(&outer, OP_VOID, line);
 
-        /* Inner loop lambda; loop_name resolves as upvalue from outer's slot 0 */
+        /* Inner loop lambda; loop_name resolves as upvalue from outer's slot 0.
+         * Arm the self-tail-call thread-local so a tail-position call to
+         * loop_name within this exact body compiles to OP_SELF_TAIL_CALL
+         * instead of the ordinary upvalue-load-then-call sequence -- see
+         * Compiler::self_tail_name's comment and compile_call. The
+         * set!-scan runs over the RAW (uncompiled) body once, up front,
+         * so every self-tail-call site compiled anywhere in this body
+         * consistently sees the same answer regardless of where in the
+         * body a set! to loop_name might textually appear relative to
+         * a given tail call. */
+        g_compile_self_tail_name    = loop_name;
+        g_compile_self_tail_mutated = body_mentions_set_target(c, body, loop_name);
         compile_lambda(&outer, fwd, body, as_sym(loop_name)->data, line);
         emit_ab(&outer, OP_STORE_LOCAL, 0, line);  /* store closure → slot 0 */
         emit_ab(&outer, OP_LOAD_LOCAL,  0, line);  /* callee */
@@ -2147,11 +2248,85 @@ static void compile_receive(Compiler *c, val_t args, bool tail, int line) {
 
 /* ── Application compilation ─────────────────────────────────────────── */
 
+/* Matches compile()'s own "#:keyword symbols are self-evaluating" check
+ * (below) so compile_call's fused-global-call fast path can defer to it:
+ * a #:keyword head must still compile to "push the symbol itself as a
+ * constant, then try to call it" (raising not-a-procedure at runtime),
+ * not "look it up as a global variable" (raising unbound-variable) --
+ * the fast path bypasses compile()'s general symbol handling entirely,
+ * so without this guard it silently changed the error a caller sees for
+ * `(#:foo 1 2)` from one condition type to another (found by code
+ * review). */
+static bool is_keyword_symbol(val_t v) {
+    Symbol *s = as_sym(v);
+    return s->len >= 2 && s->data[0] == '#' && s->data[1] == ':';
+}
+
 static void compile_call(Compiler *c, val_t head, val_t args, bool tail, int line) {
     /* Count args */
     int argc = 0;
     val_t a = args;
     while (vis_pair(a)) { argc++; a = vcdr(a); }
+
+    /* Self-tail-call: a tail-position call whose head is exactly the
+     * enclosing named-let loop's own self-reference (Compiler::
+     * self_tail_name, set up by compile_let's named-let branch). Trusted
+     * at compile time ONLY because that reference is a private upvalue
+     * slot no code outside this one lambda body can ever reach, and the
+     * set!-scan (body_mentions_set_target, run once up front over the
+     * whole raw body) already ruled out this body ever mutating it.
+     * resolve_local guards against an inner local of the same name
+     * shadowing the loop variable at THIS call site specifically (e.g. a
+     * nested (let ((loop 5)) (loop)) inside the loop body must resolve to
+     * the LOCAL 5, not the outer loop closure). */
+    if (tail && vis_symbol(head) && c->self_tail_name != V_FALSE &&
+        head == c->self_tail_name && !c->self_tail_mutated &&
+        resolve_local(c, head) < 0) {
+        /* Still register the self-reference as a captured upvalue (for
+         * its SIDE EFFECT, discarding the returned index -- the bytecode
+         * itself never loads it via OP_LOAD_UP, since OP_SELF_TAIL_CALL
+         * needs no callee on the stack at all) rather than skipping this
+         * call entirely. Without this, the closure's own upval_count/
+         * upvals[] never gets the self-capture entry that maybe_jit_bcc
+         * (src/runtime.c) depends on to detect "this is a self-
+         * referencing named-let loop, never promote it to native code" --
+         * omitting it let a hot loop cross the JIT threshold and hit a
+         * real, previously-dormant JIT codegen bug for self-referencing
+         * closures the very guard this restores exists to prevent
+         * (confirmed by reproducing: an identical loop failed with
+         * "unbound variable: loop" past ~50 iterations before this fix,
+         * worked correctly after). */
+        resolve_upvalue(c, head);
+        a = args;
+        while (vis_pair(a)) { compile(c, vcar(a), false, line); a = vcdr(a); }
+        emit_ab(c, OP_SELF_TAIL_CALL, (uint8_t)argc, line);
+        return;
+    }
+
+    /* Fused global call: a call whose head is a symbol resolving to
+     * neither a local nor an upvalue (the same condition emit_load uses
+     * to fall through to OP_LOAD_GLOBAL) -- look the global up and call
+     * it in one dispatch instead of two. Every non-BcClosure callee type
+     * still goes through call_foreign inside the opcode handler itself,
+     * exactly as OP_CALL/OP_TAIL_CALL already do -- see the vm.c handler's
+     * own comment for why this is safe for every callee type curry has
+     * (primitives, continuations, parameter objects, FFI functions), not
+     * just closures -- the specific failure Kaappi's own postmortem
+     * documented for a naively-fused call opcode that only dispatched two
+     * of the possible callee types directly. resolve_upvalue has the
+     * side effect of marking an enclosing local captured/registering the
+     * upvalue slot if `head` turns out to resolve as one -- unavoidable
+     * and harmless here: that bookkeeping is required regardless of
+     * which call opcode ultimately gets emitted. */
+    if (vis_symbol(head) && !is_keyword_symbol(head) &&
+        resolve_local(c, head) < 0 && resolve_upvalue(c, head) < 0) {
+        int ci = chunk_add_const(c->chunk, head);
+        a = args;
+        while (vis_pair(a)) { compile(c, vcar(a), false, line); a = vcdr(a); }
+        emit_abc(c, tail ? OP_TAIL_CALL_GLOBAL : OP_CALL_GLOBAL,
+                 (uint8_t)ci, (uint8_t)argc, line);
+        return;
+    }
 
     /* Compile callee */
     compile(c, head, false, line);
@@ -2404,14 +2579,18 @@ static void compile(Compiler *c, val_t expr, bool tail, int line) {
 
     /* Forms the compiler delegates to the tree-walker at runtime:
        import, define-library, library.
-       Emitted as: (tree-eval '<form>) */
+       Emitted as OP_TREE_EVAL_CACHED, not a (tree-eval '<form>) call --
+       see chunk.h's Chunk::tree_eval_cache and opcode.h's own comment.
+       Memoizes per call SITE (this exact bytecode instruction, keyed by
+       constant-pool index), not globally: re-executing the SAME chunk
+       (e.g. an import nested inside a function called from a loop) only
+       actually runs the form through eval() once. No tail/non-tail
+       distinction needed -- these forms are side-effecting declarations
+       that always return normally, never altering control flow. */
     if (head == S_IMPORT        ||
         head == S_DEFINE_LIBRARY || head == S_LIBRARY) {
-        val_t tree_eval_sym = sym_intern_cstr("tree-eval");
-        emit_ab(c, OP_LOAD_GLOBAL,
-                (uint8_t)chunk_add_const(c->chunk, tree_eval_sym), line);
-        emit_const(c, expr, line);
-        emit_ab(c, tail ? OP_TAIL_CALL : OP_CALL, 1, line);
+        int ci = chunk_add_const(c->chunk, expr);
+        emit_ab(c, OP_TREE_EVAL_CACHED, (uint8_t)ci, line);
         return;
     }
 

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -577,6 +577,37 @@ static void scan_pinned_object(void *obj) {
             ch->constants[i] = evacuate(ch->constants[i]);
         ch->src_lambda  = evacuate(ch->src_lambda);
         ch->target_env  = evacuate(ch->target_env);
+        /* tree_eval_cache (chunk.h) holds real cached val_t RESULT
+         * values (not raw pointers validated some other way, unlike
+         * glob_cache, which is deliberately NOT evacuated here since its
+         * slot pointers are re-validated via a version check instead) --
+         * these must move with everything else. 0 is the "not yet
+         * cached" sentinel (never a valid tagged val_t), skip it rather
+         * than handing evacuate() a non-value bit pattern.
+         *
+         * This runs on the main thread mid-collection while OTHER actor
+         * threads may be concurrently executing OP_TREE_EVAL_CACHED on
+         * this exact chunk (chunks are shared verbatim across actors, see
+         * vm_snapshot_closure_for_escape) -- gc_minor_pending is a
+         * per-thread flag, so a minor collection here is NOT a
+         * stop-the-world pause for other threads. Use the same
+         * acquire/release atomics OP_TREE_EVAL_CACHED itself uses so a
+         * concurrent reader either sees the pre- or post-evacuation
+         * value, never a torn one. Skip the store entirely when
+         * evacuation didn't move anything (the common case today: every
+         * current caller of OP_TREE_EVAL_CACHED -- import/define-library/
+         * library -- always evaluates to the immediate V_VOID, which
+         * evacuate() passes through unchanged) to avoid a redundant
+         * atomic write racing a concurrent reader for no reason. */
+        if (ch->tree_eval_cache)
+            for (int i = 0; i < ch->const_len; i++) {
+                _Atomic val_t *slot = (_Atomic val_t *)&ch->tree_eval_cache[i];
+                val_t old = atomic_load_explicit(slot, memory_order_acquire);
+                if (old == 0) continue;
+                val_t moved = evacuate(old);
+                if (moved != old)
+                    atomic_store_explicit(slot, moved, memory_order_release);
+            }
         break;
     }
     case T_MODULE: {

--- a/src/main.c
+++ b/src/main.c
@@ -489,7 +489,10 @@ static void usage(const char *argv0) {
         "                    Note: generational backend is experimental. Actor-heavy workloads\n"
         "                    may accumulate nursery garbage between main-thread GC cycles.\n"
         "  --timings         Print a read/expand/compile/execute pipeline timing\n"
-        "                    report to stderr on exit\n",
+        "                    report to stderr on exit\n"
+        "  --clear-cache     Delete any existing .scc cache for the script being\n"
+        "                    run (both cache-location tiers) before compiling,\n"
+        "                    forcing a fresh compile instead of a stale cache hit\n",
         argv0);
 }
 
@@ -552,6 +555,7 @@ int main(int argc, char **argv) {
     const char *compile_file = NULL;
     const char *compile_out  = NULL;
     bool compile_executable  = false;
+    bool clear_cache_flag    = false;
 
     static const struct option long_opts[] = {
         { "version",      no_argument,       NULL, 'v' },
@@ -560,6 +564,7 @@ int main(int argc, char **argv) {
         { "gc",              required_argument, NULL, 0   },  /* handled pre-scan */
         { "gc-nursery-size", required_argument, NULL, 0   },  /* handled pre-scan */
         { "timings",         no_argument,       NULL, 0   },
+        { "clear-cache",     no_argument,       NULL, 0   },
         { NULL, 0, NULL, 0 }
     };
 
@@ -572,6 +577,8 @@ int main(int argc, char **argv) {
             /* long option with no short form */
             if (!strcmp(long_opts[long_idx].name, "timings"))
                 curry_timings_enabled = true;
+            else if (!strcmp(long_opts[long_idx].name, "clear-cache"))
+                clear_cache_flag = true;
             break;   /* --gc / --gc-nursery-size already handled in the pre-scan */
         case 'v':
             printf("Curry Scheme %s (R7RS)" LLVM_TAG FFI_TAG "\n", CURRY_VERSION);
@@ -772,6 +779,16 @@ int main(int argc, char **argv) {
                     }
                 }
             }
+            /* --clear-cache: discard any existing cache for this script
+             * before deciding HIT or MISS, so a stale .scc (e.g. left
+             * behind by a curry build with a different bytecode format
+             * mid-development -- see scc_clear's own comment) is never
+             * consulted, and the run below always recompiles fresh and
+             * rewrites it. No-op when the positional argument is itself a
+             * .scc file (is_scc): there is no separate cache to clear in
+             * that case, the file *is* the thing being run. */
+            if (clear_cache_flag && !is_scc)
+                scc_clear(argv[i]);
             if (is_scc) {
                 /* Direct .scc run — no source file, skip mtime check.
                    .scc caching doesn't persist source_name (see scc.c), so

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -103,6 +103,28 @@ typedef enum {
     OP_CALL,        /* A: call top-of-stack with A args below it         */
     OP_TAIL_CALL,   /* A: tail call (reuses current frame)               */
     OP_RETURN,      /* return top of stack to caller                     */
+    OP_SELF_TAIL_CALL, /* A: tail-call the CURRENTLY EXECUTING closure with
+                         A args already on the stack (no callee pushed) --
+                         compiler-proven self-recursion only (named-let
+                         loops whose own name is never set!'d); see
+                         compile_call's own comment in compiler.c for the
+                         safety argument                                  */
+    OP_CALL_GLOBAL,      /* A: constants[A] const-pool index of the global
+                            symbol to look up (via the same cache
+                            OP_LOAD_GLOBAL uses) and call; B: argc, args
+                            already on the stack, no callee pushed        */
+    OP_TAIL_CALL_GLOBAL, /* same as OP_CALL_GLOBAL but tail (reuses frame) */
+    OP_TREE_EVAL_CACHED, /* A: constants[A] holds a raw form still punted to
+                            the tree-walker (import/define-library/library
+                            -- see compiler.c's tree-eval punt block);
+                            chunk->tree_eval_cache[A] memoizes the result
+                            of already having run it through eval() once,
+                            so repeated executions of this exact bytecode
+                            site (e.g. an import nested inside a function
+                            called from a loop) only actually evaluate it
+                            the first time. See chunk.h's Chunk::
+                            tree_eval_cache comment for why this cache is
+                            deliberately not .scc-persisted             */
 
     /* ── Closures ───────────────────────────────────────────────────── */
     OP_CLOSURE,     /* A: push new closure wrapping constants[A] (Chunk*)

--- a/src/scc.c
+++ b/src/scc.c
@@ -873,6 +873,13 @@ void scc_write_to(const char *out_path, const char *src_path,
     write_scc(out_path, src_path, chunks, n_chunks, executable);
 }
 
+void scc_clear(const char *src_path) {
+    char *p = primary_path(src_path);
+    if (p) { remove(p); free(p); }
+    char *fb = fallback_path(src_path);
+    if (fb) { remove(fb); free(fb); }
+}
+
 bool scc_load(const char *src_path, Chunk ***chunks_out, int *n_out) {
     char *p = primary_path(src_path);
     if (p && read_scc(p, src_path, chunks_out, n_out)) {

--- a/src/scc.h
+++ b/src/scc.h
@@ -47,4 +47,16 @@ void scc_write_to(const char *out_path, const char *src_path,
    Used when running a .scc file explicitly (no corresponding .scm present). */
 bool scc_load_direct(const char *scc_path, Chunk ***chunks_out, int *n_out);
 
+/* Delete any cached .scc for src_path, checking both cache-location tiers
+   (source-adjacent, then ~/.cache/curry/) -- silently no-ops for a location
+   that doesn't exist. Used by the --clear-cache CLI flag (main.c) to
+   force a stale cache to be discarded and freshly recompiled, rather than
+   relying on scc_write()'s own overwrite-on-recompile to eventually
+   replace it. Distinct from that overwrite path because a flag named
+   "clear" should visibly remove the file even if, for whatever reason,
+   the run that follows never reaches a successful scc_write() of its own
+   (e.g. a script that raises before finishing) -- leaving no stale file
+   behind is the whole point, not just "usually gets replaced." */
+void scc_clear(const char *src_path);
+
 #endif /* CURRY_SCC_H */

--- a/src/vm.c
+++ b/src/vm.c
@@ -412,7 +412,9 @@ static bool pop_frame(CallFrame **frame_ptr, val_t result) {
         *vm->sp++ = result;
         return true;
     }
-    vm->sp = frame->slots - 1;   /* remove callee + args */
+    /* Remove callee (if this frame's calling convention reserved one --
+     * see CallFrame::has_callee_slot's own comment, vm.h) + args. */
+    vm->sp = frame->slots - (frame->has_callee_slot ? 1 : 0);
     *vm->sp++ = result;
     *frame_ptr = &vm->frames[vm->frame_count - 1];
     return false;
@@ -487,6 +489,33 @@ static int vm_bind_args(BcClosure *cl, val_t *base, int argc) {
     return fixed + 1;
 }
 
+/* Shared cached global-variable lookup for OP_CALL_GLOBAL/
+ * OP_TAIL_CALL_GLOBAL, which need this exact lookup fused with a call
+ * rather than as a separate dispatch. Mirrors (does not replace)
+ * OP_LOAD_GLOBAL's own inline copy below -- deliberately NOT refactored
+ * to share one implementation, since OP_LOAD_GLOBAL's copy carries a
+ * detailed comment about the acquire/release memory-ordering contract
+ * with env.c's seqlock and is exactly the kind of already-reviewed,
+ * concurrency-sensitive code not worth touching for a de-dup that isn't
+ * otherwise necessary. Takes `chunk` explicitly (rather than the frame-
+ * local CONSTS/GCACHE/TARGET_ENV macros below) so it reads as a plain,
+ * self-contained function. Raises unbound-variable the same way. */
+static inline val_t load_global_cached(Chunk *chunk, uint8_t ci) {
+    GlobCacheEntry *cache = chunk->glob_cache;
+    EnvFrame *root = as_env(chunk->target_env == V_VOID ? GLOBAL_ENV : chunk->target_env);
+    uint32_t root_ver = atomic_load_explicit((_Atomic uint32_t *)&root->version, memory_order_acquire);
+    if (__builtin_expect(cache != NULL && cache[ci].slot != NULL &&
+                         cache[ci].version == root_ver, 1)) {
+        return *cache[ci].slot;
+    }
+    val_t sym = chunk->constants[ci];
+    uint32_t ver;
+    val_t *slot = frame_lookup_versioned(root, sym, &ver);
+    if (!slot) scm_raise_code(EC_UNBOUND_VARIABLE, "unbound variable: %s", sym_cstr(sym));
+    if (cache) { cache[ci].slot = slot; cache[ci].version = ver; }
+    return *slot;
+}
+
 /* ── Main dispatch loop ──────────────────────────────────────────────── */
 
 val_t vm_run(BcClosure *top_closure, int argc) {
@@ -505,6 +534,10 @@ val_t vm_run(BcClosure *top_closure, int argc) {
         scm_raise_code(EC_STACK_OVERFLOW, "call stack overflow (max %d frames)", VM_FRAMES_MAX);
     CallFrame *frame  = &vm->frames[vm->frame_count++];
     frame->closure    = top_closure;
+    frame->has_callee_slot = true;  /* irrelevant in practice: pop_frame's
+                                        frame_count==0 path never reads it
+                                        for the outermost frame, set for
+                                        consistency anyway */
     frame->ip         = top_closure->chunk->code;
     frame->slots      = vm->sp - argc;
     frame->slot_count = vm_bind_args(top_closure, frame->slots, argc);
@@ -567,6 +600,10 @@ val_t vm_run(BcClosure *top_closure, int argc) {
         [OP_JUMP_TRUE]   = &&L_OP_JUMP_TRUE,
         [OP_CALL]        = &&L_OP_CALL,        [OP_TAIL_CALL]    = &&L_OP_TAIL_CALL,
         [OP_RETURN]      = &&L_OP_RETURN,
+        [OP_SELF_TAIL_CALL]   = &&L_OP_SELF_TAIL_CALL,
+        [OP_CALL_GLOBAL]      = &&L_OP_CALL_GLOBAL,
+        [OP_TAIL_CALL_GLOBAL] = &&L_OP_TAIL_CALL_GLOBAL,
+        [OP_TREE_EVAL_CACHED] = &&L_OP_TREE_EVAL_CACHED,
         [OP_CLOSURE]     = &&L_OP_CLOSURE,     [OP_CLOSE_UP]     = &&L_OP_CLOSE_UP,
         [OP_APPLY]       = &&L_OP_APPLY,       [OP_VALUES]       = &&L_OP_VALUES,
         [OP_CALL_WITH_VALUES] = &&L_OP_CALL_WITH_VALUES,
@@ -940,6 +977,9 @@ val_t vm_run(BcClosure *top_closure, int argc) {
                     scm_raise_code(EC_STACK_OVERFLOW, "call stack overflow (max %d frames)", VM_FRAMES_MAX);
                 CallFrame *nf  = &vm->frames[vm->frame_count++];
                 nf->closure    = cl;
+                nf->has_callee_slot = true;  /* PEEK(argc2) above found the
+                                                 callee already on the
+                                                 stack below the args */
                 nf->ip         = cl->chunk->code;
                 nf->slots      = vm->sp - argc2;
                 nf->slot_count = vm_bind_args(cl, nf->slots, argc2);
@@ -1014,6 +1054,252 @@ val_t vm_run(BcClosure *top_closure, int argc) {
                 vm->sp -= argc2 + 1;
                 if (pop_frame(&frame, result)) return *--vm->sp;
                 if (vm->frame_count == entry_depth) return *--vm->sp;
+            }
+            NEXT;
+        }
+
+        CASE(OP_SELF_TAIL_CALL) {
+            /* Tail-call the CURRENTLY EXECUTING closure -- the compiler
+             * only ever emits this when it has proven (compile_call,
+             * compiler.c) the callee is always this exact closure (a
+             * named-let loop's own private, never-set!'d upvalue self-
+             * reference), so no PEEK/vis_bcclosure branch is needed at
+             * all: cl is definitionally frame->closure, and there is no
+             * callee slot on the stack to skip past when reading args or
+             * adjusting sp -- unlike OP_TAIL_CALL, argc2 args are the
+             * ENTIRE stack contribution of this call. */
+            uint8_t argc2 = READ_U8();
+            BcClosure *cl = frame->closure;
+            /* Tiered JIT: hot-swap to native code once compiled. jit_val
+             * is dynamic per-closure state a hot self-recursive loop's
+             * own iterations can cross the promotion threshold during --
+             * unlike callee identity (statically proven), jit_val is NOT
+             * statically known and must still be checked every
+             * iteration. */
+            if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+                && curry_profiling_level == 0 && !vm_debug_active) {
+                vm_check_arity(cl, argc2);
+                JitClosure *jc = as_jitclos(cl->jit_val);
+                val_t *call_args = vm->sp - argc2;
+                typedef uint64_t (*jit_fn_t)(int32_t, uint64_t *, uint64_t *);
+                g_jit_call_depth++;
+                gc_inhibit_minor();
+                val_t result = ((jit_fn_t)GC_REVEAL_POINTER(jc->fn))((int32_t)argc2,
+                                                                     (uint64_t *)call_args,
+                                                                     (uint64_t *)jc->caps);
+                gc_resume_minor();
+                g_jit_call_depth--;
+                vm->sp -= argc2;
+                if (pop_frame(&frame, result)) return *--vm->sp;
+                if (vm->frame_count == entry_depth) return *--vm->sp;
+                NEXT;
+            }
+            vm_maybe_jit(cl);
+            if (curry_profiling_level >= 2 && frame->prof_start_ns &&
+                    frame->closure->chunk->name) {
+                val_t sym = sym_intern_cstr(frame->closure->chunk->name);
+                profiling_record_timed(sym, frame->prof_start_ns);
+            }
+            /* Not counted as a cross-function tail call -- matches
+             * OP_TAIL_CALL's own "not self-tail-call loops" comment. */
+            val_t *new_args = vm->sp - argc2;
+            vm_close_upvalues(frame->slots);
+            memmove(frame->slots, new_args, argc2 * sizeof(val_t));
+            vm->sp            = frame->slots + argc2;
+            frame->ip         = cl->chunk->code;
+            frame->slot_count = vm_bind_args(cl, frame->slots, argc2);
+            frame->prof_start_ns = 0;
+            if (curry_profiling_level >= 2 && cl->chunk->name)
+                frame->prof_start_ns = profiling_now_ns();
+            NEXT;
+        }
+
+        CASE(OP_CALL_GLOBAL) {
+            /* Fused OP_LOAD_GLOBAL + OP_CALL: one dispatch instead of two
+             * for the most common call shape (calling a plain top-level
+             * function), with NO callee slot pushed at all -- unlike an
+             * earlier version of this opcode, which inserted the looked-
+             * up callee back onto the stack via memmove to match OP_CALL's
+             * layout. That worked but measured no real performance win
+             * (the memmove roughly cancelled out the dispatch savings);
+             * CallFrame::has_callee_slot (vm.h) now lets pop_frame handle
+             * a frame with no callee slot correctly, so the callee is
+             * simply never pushed, matching Kaappi's own design (see
+             * docs/thoughts/performance-chez-kaappi.md §4.1) and actually
+             * delivering the dispatch-iteration saving. Every non-
+             * BcClosure callee still goes through call_foreign here
+             * exactly as OP_CALL itself does, which is what makes this
+             * safe for every callee type curry has (primitives,
+             * continuations, parameter objects, FFI functions), not just
+             * closures -- the specific failure Kaappi's own postmortem
+             * documented for a naively-fused call opcode that only
+             * dispatched two callee types directly instead of reusing the
+             * universal trampoline. */
+            uint8_t ci     = READ_U8();
+            uint8_t argc2  = READ_U8();
+            val_t callee   = load_global_cached(frame->closure->chunk, ci);
+
+            if (vis_bcclosure(callee)) {
+                BcClosure *cl = as_bcclosure(callee);
+                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+                    && curry_profiling_level == 0 && !vm_debug_active) {
+                    vm_check_arity(cl, argc2);
+                    JitClosure *jc = as_jitclos(cl->jit_val);
+                    val_t *call_args = vm->sp - argc2;
+                    typedef uint64_t (*jit_fn_t)(int32_t, uint64_t *, uint64_t *);
+                    g_jit_call_depth++;
+                    gc_inhibit_minor();
+                    val_t result = ((jit_fn_t)GC_REVEAL_POINTER(jc->fn))((int32_t)argc2,
+                                                                         (uint64_t *)call_args,
+                                                                         (uint64_t *)jc->caps);
+                    gc_resume_minor();
+                    g_jit_call_depth--;
+                    vm->sp -= argc2;
+                    PUSH(result);
+                    NEXT;
+                }
+                vm_maybe_jit(cl);
+                if (vm->frame_count >= VM_FRAMES_MAX)
+                    scm_raise_code(EC_STACK_OVERFLOW, "call stack overflow (max %d frames)", VM_FRAMES_MAX);
+                CallFrame *nf  = &vm->frames[vm->frame_count++];
+                nf->closure    = cl;
+                nf->has_callee_slot = false;  /* no callee pushed above */
+                nf->ip         = cl->chunk->code;
+                nf->slots      = vm->sp - argc2;
+                nf->slot_count = vm_bind_args(cl, nf->slots, argc2);
+                nf->prof_start_ns = 0;
+                if (curry_profiling_level >= 1 && cl->chunk->name) {
+                    val_t sym = sym_intern_cstr(cl->chunk->name);
+                    if (curry_profiling_level >= 2)
+                        nf->prof_start_ns = profiling_now_ns();
+                    else
+                        profiling_record_call(sym);
+                }
+                frame = nf;
+            } else {
+                val_t *call_args = vm->sp - argc2;
+                val_t result     = call_foreign(callee, (int)argc2, call_args);
+                vm->sp -= argc2;
+                PUSH(result);
+            }
+            NEXT;
+        }
+
+        CASE(OP_TAIL_CALL_GLOBAL) {
+            /* Fused OP_LOAD_GLOBAL + OP_TAIL_CALL -- see OP_CALL_GLOBAL's
+             * comment just above for the full rationale (no callee slot
+             * pushed at all, CallFrame::has_callee_slot lets pop_frame
+             * handle it). This branch never creates a new CallFrame (a
+             * tail call reuses the current one in place), so it never
+             * touches has_callee_slot -- that flag describes how the
+             * CURRENT frame was originally entered, unaffected by which
+             * opcode later tail-calls within it. */
+            uint8_t ci     = READ_U8();
+            uint8_t argc2  = READ_U8();
+            val_t callee   = load_global_cached(frame->closure->chunk, ci);
+
+            if (vis_bcclosure(callee)) {
+                BcClosure *cl = as_bcclosure(callee);
+                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+                    && curry_profiling_level == 0 && !vm_debug_active) {
+                    vm_check_arity(cl, argc2);
+                    JitClosure *jc = as_jitclos(cl->jit_val);
+                    val_t *call_args = vm->sp - argc2;
+                    typedef uint64_t (*jit_fn_t)(int32_t, uint64_t *, uint64_t *);
+                    g_jit_call_depth++;
+                    gc_inhibit_minor();
+                    val_t result = ((jit_fn_t)GC_REVEAL_POINTER(jc->fn))((int32_t)argc2,
+                                                                         (uint64_t *)call_args,
+                                                                         (uint64_t *)jc->caps);
+                    gc_resume_minor();
+                    g_jit_call_depth--;
+                    vm->sp -= argc2;
+                    if (pop_frame(&frame, result)) return *--vm->sp;
+                    if (vm->frame_count == entry_depth) return *--vm->sp;
+                    NEXT;
+                }
+                vm_maybe_jit(cl);
+                if (curry_profiling_level >= 2 && frame->prof_start_ns &&
+                        frame->closure->chunk->name) {
+                    val_t sym = sym_intern_cstr(frame->closure->chunk->name);
+                    profiling_record_timed(sym, frame->prof_start_ns);
+                }
+                if (curry_profiling_level >= 1 && cl != frame->closure &&
+                        cl->chunk->name) {
+                    profiling_record_call_tco(sym_intern_cstr(cl->chunk->name));
+                }
+                val_t *new_args = vm->sp - argc2;
+                vm_close_upvalues(frame->slots);
+                memmove(frame->slots, new_args, argc2 * sizeof(val_t));
+                vm->sp            = frame->slots + argc2;
+                frame->closure    = cl;
+                frame->ip         = cl->chunk->code;
+                frame->slot_count = vm_bind_args(cl, frame->slots, argc2);
+                frame->prof_start_ns = 0;
+                if (curry_profiling_level >= 2 && cl->chunk->name)
+                    frame->prof_start_ns = profiling_now_ns();
+            } else {
+                val_t *call_args = vm->sp - argc2;
+                val_t result     = call_foreign(callee, (int)argc2, call_args);
+                vm->sp -= argc2;
+                if (pop_frame(&frame, result)) return *--vm->sp;
+                if (vm->frame_count == entry_depth) return *--vm->sp;
+            }
+            NEXT;
+        }
+
+        CASE(OP_TREE_EVAL_CACHED) {
+            /* See chunk.h's Chunk::tree_eval_cache and opcode.h's own
+             * comment. Not tail/non-tail-distinguished -- eval()'s
+             * dispatch for import/define-library/library always returns
+             * normally (side-effecting declarations, never altering
+             * control flow), so this is a plain value-producing
+             * instruction regardless of the surrounding call's tail
+             * position, unlike an ordinary call.
+             *
+             * The chunk this cache lives in is shared VERBATIM (not
+             * copied) across actor threads (vm_snapshot_closure_for_escape
+             * only snapshots upvalues), so two actors can race on the same
+             * cache slot for the same chunk. A plain load/store of a
+             * val_t across threads with no ordering is a data race under
+             * the C11 memory model even though every write here happens
+             * to store the exact same value (V_VOID -- import/
+             * define-library/library's result is always immediate, never
+             * a heap pointer, so there is nothing to lose from two
+             * threads both losing the race and both calling eval() once
+             * each; the redundant eval() is no worse than what happened
+             * every time before this cache existed). Use acquire/release
+             * atomics on the slot itself so the race is well-defined
+             * instead of relying on that coincidence.
+             *
+             * Deliberately do NOT also call gc_wb_slot() on this slot
+             * (independent security review caught this: an earlier
+             * version called both gc_wb_slot() -- a plain, non-atomic
+             * `*slot = newval` -- and the atomic store below on the same
+             * slot, which is undefined behavior under C11 regardless of
+             * whether the two writes agree, and gc_wb_slot's own dirty-
+             * slot bookkeeping (gc_dirty_slots/gc_dirty_count, gc.h) is
+             * itself unsynchronized, so a future value that actually took
+             * its vis_ptr(newval) branch concurrently from two racing
+             * actor threads would corrupt that fixed-size array via an
+             * unlocked, non-atomic gc_dirty_count++). No write barrier is
+             * needed here in the first place: unlike a general heap
+             * mutation, this array is fully re-scanned every minor GC via
+             * gc_gen.c's T_CHUNK evacuation case (every chunk is a pinned
+             * Boehm object, walked in full each pass), so there is no
+             * "remembered set" for the barrier to populate. */
+            uint8_t ci = READ_U8();
+            Chunk *chunk = frame->closure->chunk;
+            _Atomic val_t *slot = chunk->tree_eval_cache
+                ? (_Atomic val_t *)&chunk->tree_eval_cache[ci] : NULL;
+            val_t cached = slot ? atomic_load_explicit(slot, memory_order_acquire) : 0;
+            if (cached != 0) {
+                PUSH(cached);
+            } else {
+                val_t result = eval(chunk->constants[ci], GLOBAL_ENV);
+                if (slot)
+                    atomic_store_explicit(slot, result, memory_order_release);
+                PUSH(result);
             }
             NEXT;
         }

--- a/src/vm.h
+++ b/src/vm.h
@@ -50,6 +50,24 @@ typedef struct {
     val_t    *slots;      /* base of this frame's window into vm->stack  */
     int       slot_count; /* number of slots (locals + args)             */
     uint64_t  prof_start_ns; /* profiling: call entry time (level 2+)   */
+    /* Was a callee value pushed onto the stack directly below `slots`
+     * when this frame was created (true: OP_CALL's convention -- callee,
+     * then args) or not (false: OP_CALL_GLOBAL's convention -- the
+     * callee is resolved by the opcode handler itself via a fused
+     * lookup, never pushed at all)? pop_frame() (vm.c) needs this to
+     * know how many slots to remove on return: `frame->slots - 1` only
+     * when a callee slot genuinely exists. Set once, at frame creation
+     * (OP_CALL/OP_CALL_GLOBAL); UNCHANGED by a tail call that reuses
+     * this same frame in place (OP_TAIL_CALL/OP_SELF_TAIL_CALL/
+     * OP_TAIL_CALL_GLOBAL/OP_TAIL_CALL_WITH_VALUES) -- a tail call
+     * doesn't add or remove the callee slot this frame was originally
+     * entered with, it just changes which closure/code is running in it.
+     * Found the hard way: an earlier version of OP_CALL_GLOBAL skipped
+     * the callee slot without telling pop_frame, which unconditionally
+     * assumed one always existed and silently clobbered the CALLER's own
+     * next-lower stack slot on every return -- see git history / PR
+     * discussion for the (+ 1 (g 5)) repro that caught it. */
+    bool      has_callee_slot;
 } CallFrame;
 
 /*


### PR DESCRIPTION
## Summary

Three dispatch-cost VM optimizations from `docs/thoughts/performance-chez-kaappi.md` §5 Tier 1:

- **`OP_SELF_TAIL_CALL`** — named-let self-recursion skips the global/upvalue lookup, arity check reuse only. Gated to named-let only (a global self-reference could be reassigned by unrelated code); the self-reference is a private upvalue slot no code outside the loop body can reach.
- **`OP_CALL_GLOBAL` / `OP_TAIL_CALL_GLOBAL`** — fused global lookup + call in one dispatch. Reuses the exact same `call_foreign` trampoline `OP_CALL` already uses for every non-closure callee type (primitives, continuations, parameter objects, FFI functions) — the specific failure mode Kaappi's own postmortem documented for a naively-fused opcode that only dispatched two callee types directly.
- **`OP_TREE_EVAL_CACHED`** — memoizes the tree-walked `eval()` result for `import`/`define-library`/`library`, the only three forms still punted to the tree-walker.

`CallFrame` gained `has_callee_slot` so the shared `pop_frame()` return path knows whether a fused-global call left a callee on the stack.

## Review

Independently reviewed twice by fresh subagents with no shared context (code-review + security-review, per this repo's CLAUDE.md policy). All findings fixed:

- A macro-blind-spot correctness bug: the self-tail-call safety scan only looked for literal `(set! loop ...)` text, missing a macro that expands to one. Now bails out conservatively on any macro use in the loop body.
- Missing synchronization on `tree_eval_cache` (shared verbatim across actor threads, plus a concurrent minor-GC evacuation case) — now uses C11 acquire/release atomics throughout.
- The fused-call fast path bypassed the `#:keyword` self-evaluating check, changing `(#:foo 1 2)`'s error from `not-a-procedure` to `unbound-variable`. Fixed.
- `chunk_add_const`'s unchecked `uint8_t` cast could silently wrap past 256 distinct constants. Now raises a clear compiler-limit error.
- A stray non-atomic `gc_wb_slot()` write alongside the atomic store on `tree_eval_cache` (real C11 data race) — found by the security-review pass, confirmed via ThreadSanitizer by the code-review pass, removed (no write barrier needed there since the array is already fully rescanned every minor GC).

Also adds a `--clear-cache` CLI flag to delete a script's cached `.scc` before running it (came up while debugging a stale-cache issue mid-development).

## Test plan

- [x] Full `ctest` suite: 99/99 passing
- [x] Correctness repros for each fix (macro-expanding-to-set!, `#:foo` call, 300-distinct-globals compiler-limit, actor-shared `import`)
- [x] Benchmarks confirm the win survives all fixes: named-let loop (5M iterations) ~15% faster, `fib(30)` ~5-8% faster, vs. pre-Tier-1 main (Debug build)
- [x] Independent code-review + security-review subagent passes, both clean after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
