### PR TITLE
feat(compiler): Tier 2.1 IR skeleton, verified via differential self-check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ set(CORE_SOURCES
   src/gc.c
   src/gc_gen.c
   src/chunk.c
+  src/ir.c
   src/symbol.c
   src/curry_features.c
   src/numeric.c

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -51,6 +51,7 @@
 
 #include "compiler.h"
 #include "chunk.h"
+#include "ir.h"
 #include "opcode.h"
 #include "value.h"
 #include "object.h"
@@ -127,6 +128,15 @@ typedef struct Compiler {
      * in this body falls back to the ordinary call path instead. */
     val_t self_tail_name;
     bool  self_tail_mutated;
+
+    /* Tier 2.1 IR arena (src/ir.h) -- one per top-level compiled form,
+     * shared by every nested Compiler in that form's compile tree (a
+     * child Compiler inherits its enclosing's pointer rather than
+     * allocating its own, see init_compiler). Created by the root
+     * Compiler, freed once by whichever of compiler_compile/
+     * compiler_compile_script created that root -- never freed by a
+     * child. */
+    IRArena *ir_arena;
 } Compiler;
 
 /* ── Forward declarations ────────────────────────────────────────────── */
@@ -167,6 +177,16 @@ static void init_compiler(Compiler *c, Compiler *enc, const char *name) {
     c->self_tail_mutated  = g_compile_self_tail_mutated;
     g_compile_self_tail_name    = V_FALSE;
     g_compile_self_tail_mutated = false;
+    /* Lazily NULL, not eagerly allocated, on the ordinary (enc == NULL,
+     * i.e. compiler_compile/compiler_compile_script) path -- independent
+     * security review noted that eagerly allocating here for every single
+     * top-level compile leaked the arena on any ordinary compile-time
+     * error (compile() longjmps out via scm_raise with nothing to free
+     * it), since ir_lower/ir_emit are never actually invoked from that
+     * path in this landing. compiler_ir_self_check (the only real
+     * consumer right now) sets its own two scratch Compilers' ir_arena
+     * fields explicitly after calling this. */
+    c->ir_arena = enc ? enc->ir_arena : NULL;
 }
 
 static Chunk *end_compiler(Compiler *c) {
@@ -2687,6 +2707,278 @@ static void compile_seq(Compiler *c, val_t list, bool tail, int line) {
         if (!last) emit(c, OP_POP, line);
         list = rest;
     }
+}
+
+/* ── Tier 2.1 IR: lowering + codegen (src/ir.h) ──────────────────────────
+ *
+ * ir_lower walks the same raw S-expressions compile() does, but only ever
+ * recognizes a small, deliberately bounded subset natively: self-
+ * evaluating literals, #:keyword symbols, ordinary variable references
+ * (local/upvalue/global -- resolution decided here, once, exactly as
+ * emit_load does today), quote, if, and begin. Every other form --
+ * anything compile() would otherwise handle further down its dispatch
+ * chain (let, cond, case, named-let, lambda, set!, define, and, or,
+ * calls, define-record-type, define-syntax, the CAS forms, import/
+ * define-library/library, ...) -- is wrapped whole as an IR_FALLBACK
+ * leaf, whose ir_emit case is simply `compile(c, expr, tail, line)`:
+ * byte-for-byte whatever would have happened had ir_lower never run.
+ * This is what lets IR_IF/IR_SEQ cover real programs (whose branches and
+ * begin-bodies routinely contain calls and lets) without needing to
+ * natively lower those forms first -- see the Tier 2.1 plan's
+ * "explicitly deferred" list for what widens this in a follow-up.
+ *
+ * ir_lower is guaranteed to never return NULL: every input either matches
+ * one of the native cases above or becomes an IR_FALLBACK leaf. Neither
+ * function is wired into compile()'s own dispatch in this landing --
+ * they exist, are exercised via compiler_ir_self_check (below and in
+ * compiler.h) and tests/test_core.c, but the live compile path is
+ * completely unchanged. Wiring them in behind the differential check is
+ * the natural next increment once this skeleton is proven stable. */
+
+static IRNode *ir_lower(Compiler *c, val_t expr, bool tail, int line);
+static void    ir_emit(Compiler *c, IRNode *n);
+
+static IRNode *ir_lower_if(Compiler *c, val_t args, bool tail, int line) {
+    val_t test = vcar(args);  args = vcdr(args);
+    val_t then = vcar(args);  args = vcdr(args);
+    val_t els  = vis_pair(args) ? vcar(args) : V_VOID;
+
+    IRNode *n = ir_node_new(c->ir_arena, IR_IF, tail, line);
+    n->as.iff.test = ir_lower(c, test, false, line);
+    n->as.iff.then = ir_lower(c, then, tail, line);
+    n->as.iff.els  = ir_lower(c, els,  tail, line);
+    return n;
+}
+
+/* Mirrors compile_seq's exact line-tracking (a mutable `line` threaded
+ * through the loop, updated from each cons cell's own hdr.flags when
+ * present) so IR_SEQ's pop_lines[] carries the same per-item line
+ * compile_seq would have used for that item's OP_POP -- see IR_SEQ's own
+ * field comment in ir.h for why this must be tracked SEPARATELY from
+ * items[i]->line (a real, differential-self-check-invisible bug, found
+ * by independent code review, when the two were conflated). */
+static IRNode *ir_lower_seq(Compiler *c, val_t list, bool tail, int line) {
+    if (vis_nil(list)) {
+        IRNode *n = ir_node_new(c->ir_arena, IR_CONST, tail, line);
+        n->as.konst.value = V_VOID;
+        return n;
+    }
+    /* size_t, not int: an int `count` could wrap on a pathologically long
+     * list (independent security review) -- overflow of the counting
+     * loop itself, and of the byte-size multiplications below, both
+     * become well-defined-but-wrong at `int` width. size_t avoids the
+     * multiplication overflow in practice (a list long enough to
+     * overflow size_t's range cannot exist -- each cons cell alone
+     * exceeds available memory first); the arena's own OOM abort
+     * (ir_arena_block_new, ir.c) is the actual backstop. */
+    size_t count = 0;
+    for (val_t p = list; vis_pair(p); p = vcdr(p)) count++;
+
+    IRNode *n = ir_node_new(c->ir_arena, IR_SEQ, tail, line);
+    n->as.seq.items     = (IRNode **)ir_arena_alloc(c->ir_arena,
+                                                     sizeof(IRNode *) * count);
+    n->as.seq.pop_lines = (int *)ir_arena_alloc(c->ir_arena,
+                                                 sizeof(int) * count);
+    n->as.seq.count = (int)count;
+
+    size_t i = 0;
+    while (vis_pair(list)) {
+        val_t expr = vcar(list);
+        val_t rest = vcdr(list);
+        bool  last = vis_nil(rest);
+        if (as_pair(list)->hdr.flags) line = (int)as_pair(list)->hdr.flags;
+        n->as.seq.pop_lines[i] = line;
+        n->as.seq.items[i]     = ir_lower(c, expr, tail && last, line);
+        i++;
+        list = rest;
+    }
+    return n;
+}
+
+static IRNode *ir_lower(Compiler *c, val_t expr, bool tail, int line) {
+    if (vis_pair(expr) && as_pair(expr)->hdr.flags)
+        line = (int)as_pair(expr)->hdr.flags;
+
+    /* ── Self-evaluating atoms (mirrors compile()'s own checks exactly) ── */
+    if (vis_fixnum(expr) || vis_flonum(expr) || vis_bignum(expr) ||
+        vis_rational(expr) || vis_complex(expr) || vis_string(expr) ||
+        vis_char(expr)) {
+        IRNode *n = ir_node_new(c->ir_arena, IR_CONST, tail, line);
+        n->as.konst.value = expr;
+        return n;
+    }
+    if (expr == V_TRUE || expr == V_FALSE || expr == V_NIL || expr == V_VOID) {
+        IRNode *n = ir_node_new(c->ir_arena, IR_CONST, tail, line);
+        n->as.konst.value = expr;
+        return n;
+    }
+
+    /* ── Symbol → variable reference ── */
+    if (vis_symbol(expr)) {
+        Symbol *ksym = as_sym(expr);
+        if (ksym->len >= 2 && ksym->data[0] == '#' && ksym->data[1] == ':') {
+            IRNode *n = ir_node_new(c->ir_arena, IR_CONST, tail, line);
+            n->as.konst.value = expr;
+            return n;
+        }
+        /* Resolution (local vs upvalue vs global) is deliberately NOT
+         * decided here -- see IRNode::as.var_ref's comment in ir.h for
+         * why: resolve_upvalue/chunk_add_const have ordering-sensitive
+         * side effects that must happen in the same left-to-right order
+         * ir_emit walks the tree, not the order ir_lower happens to
+         * build it in. */
+        IRNode *n = ir_node_new(c->ir_arena, IR_VAR_REF, tail, line);
+        n->as.var_ref.name = expr;
+        return n;
+    }
+
+    /* ── Non-pair non-symbol: quote it ── */
+    if (!vis_pair(expr)) {
+        IRNode *n = ir_node_new(c->ir_arena, IR_CONST, tail, line);
+        n->as.konst.value = expr;
+        return n;
+    }
+
+    /* ── Compound form ── */
+    val_t head = lang_translate(vcar(expr));
+    val_t args = vcdr(expr);
+
+    if (head == S_QUOTE) {
+        IRNode *n = ir_node_new(c->ir_arena, IR_CONST, tail, line);
+        n->as.konst.value  = vis_pair(args) ? vcar(args) : V_NIL;
+        n->as.konst.quoted = true;
+        return n;
+    }
+    if (head == S_IF)    return ir_lower_if(c, args, tail, line);
+    if (head == S_BEGIN) return ir_lower_seq(c, args, tail, line);
+
+    /* Not (yet) natively lowered -- delegate the whole subform. */
+    IRNode *n = ir_node_new(c->ir_arena, IR_FALLBACK, tail, line);
+    n->as.fallback.expr = expr;
+    return n;
+}
+
+static void ir_emit(Compiler *c, IRNode *n) {
+    switch (n->kind) {
+    case IR_CONST: {
+        val_t v = n->as.konst.value;
+        /* quote's own codegen (compile()'s S_QUOTE case) always uses
+         * emit_const, never the special-cased immediate opcodes below --
+         * see this struct field's comment in ir.h. */
+        if (!n->as.konst.quoted) {
+            if (v == V_TRUE)  { emit(c, OP_TRUE,  n->line); return; }
+            if (v == V_FALSE) { emit(c, OP_FALSE, n->line); return; }
+            if (v == V_NIL)   { emit(c, OP_NIL,   n->line); return; }
+            if (v == V_VOID)  { emit(c, OP_VOID,  n->line); return; }
+        }
+        emit_const(c, v, n->line);
+        return;
+    }
+    case IR_VAR_REF:
+        /* Resolution happens here, at emit time -- see ir.h's comment on
+         * IRNode::as.var_ref for why. emit_load is the exact function
+         * compile()'s own symbol-handling calls. */
+        emit_load(c, n->as.var_ref.name, n->line);
+        return;
+    case IR_FALLBACK:
+        compile(c, n->as.fallback.expr, n->tail, n->line);
+        return;
+    case IR_IF: {
+        ir_emit(c, n->as.iff.test);
+        int else_jmp = emit_jump(c, OP_JUMP_FALSE, n->line);
+        ir_emit(c, n->as.iff.then);
+        int end_jmp  = emit_jump(c, OP_JUMP, n->line);
+        patch_jump(c, else_jmp);
+        ir_emit(c, n->as.iff.els);
+        patch_jump(c, end_jmp);
+        return;
+    }
+    case IR_SEQ: {
+        int count = n->as.seq.count;
+        if (count == 0) { emit(c, OP_VOID, n->line); return; }
+        for (int i = 0; i < count; i++) {
+            ir_emit(c, n->as.seq.items[i]);
+            /* pop_lines[i], NOT items[i]->line -- see IR_SEQ's field
+             * comment in ir.h. */
+            if (i != count - 1) emit(c, OP_POP, n->as.seq.pop_lines[i]);
+        }
+        return;
+    }
+    case IR_LAMBDA:
+    case IR_CALL:
+    case IR_SELF_TAIL_CALL:
+    case IR_SET:
+    case IR_DEFINE:
+        /* Reserved for a future widening pass; ir_lower never constructs
+         * these yet (see this section's header comment). */
+        fprintf(stderr, "ir_emit: node kind %d not yet lowered\n", (int)n->kind);
+        abort();
+    }
+}
+
+bool compiler_ir_self_check(val_t expr) {
+    gc_inhibit_minor();
+
+    /* init_compiler leaves ir_arena NULL for a root Compiler (see its own
+     * comment) since ordinary compiler_compile/compiler_compile_script
+     * never touch ir_lower/ir_emit; this is the one real consumer, so it
+     * sets up its own two scratch arenas explicitly. */
+    Compiler old_c;
+    init_compiler(&old_c, NULL, "<ir-check-old>");
+    old_c.ir_arena = ir_arena_new();
+
+    Compiler new_c;
+    init_compiler(&new_c, NULL, "<ir-check-new>");
+    new_c.ir_arena = ir_arena_new();
+
+    int  line   = g_reader_last_line;
+    bool same   = false;
+    bool raised = false;
+
+    /* compile()/ir_lower/ir_emit can scm_raise on malformed input
+     * (unbound variable, bad special-form syntax, ...); without this,
+     * such a longjmp would skip both arena frees below and leave
+     * gc_inhibit_count unbalanced for the rest of the process -- exactly
+     * the hazard compile_time_eval's own SCM_PROTECT usage documents and
+     * guards against (independent security review). */
+    ExnHandler h;
+    SCM_PROTECT(h, {
+        compile(&old_c, expr, false, line);
+        chunk_emit(old_c.chunk, OP_RETURN, line);
+
+        IRNode *ir = ir_lower(&new_c, expr, false, line);
+        ir_emit(&new_c, ir);
+        chunk_emit(new_c.chunk, OP_RETURN, line);
+
+        same = old_c.chunk->code_len == new_c.chunk->code_len &&
+               memcmp(old_c.chunk->code, new_c.chunk->code,
+                      (size_t)old_c.chunk->code_len) == 0;
+        /* Also compare per-byte source lines: code-identical but
+         * lines[]-divergent output is a real, silent bug class a
+         * code-only comparison would miss entirely (this is exactly how
+         * the IR_SEQ pop_lines bug -- see ir.h's field comment --
+         * initially got past this same self-check; found by independent
+         * code review). */
+        if (same)
+            same = memcmp(old_c.chunk->lines, new_c.chunk->lines,
+                           (size_t)old_c.chunk->code_len * sizeof(int)) == 0;
+
+        if (!same) {
+            fprintf(stderr, "ir self-check: MISMATCH\n--- old (direct compile) ---\n");
+            chunk_disasm(old_c.chunk, "old");
+            fprintf(stderr, "--- new (ir_lower + ir_emit) ---\n");
+            chunk_disasm(new_c.chunk, "new");
+        }
+    }, {
+        raised = true;
+    });
+
+    ir_arena_free(old_c.ir_arena);
+    ir_arena_free(new_c.ir_arena);
+    gc_resume_minor();
+
+    if (raised) scm_raise_val(h.exn);
+    return same;
 }
 
 /* ── Public API ──────────────────────────────────────────────────────── */

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -41,4 +41,16 @@ void compiler_clear_target_env(void);
    left-to-right and returns the value of the last one. */
 val_t compiler_compile_script(val_t expr_list);
 
+/* Tier 2.1 IR differential self-check (docs/thoughts/
+ * performance-chez-kaappi.md §5, src/ir.h): compiles `expr` twice, once
+ * via the existing direct S-expr-to-bytecode compile() path and once via
+ * the new ir_lower()+ir_emit() path, and returns true iff the resulting
+ * bytecode is byte-for-byte identical. Prints a disassembly of both sides
+ * to stderr on mismatch. Neither compile run has any side effect outside
+ * its own scratch Compiler/Chunk (does not touch GLOBAL_ENV, does not
+ * produce a runnable closure) -- this is a verification tool, not part
+ * of any live compile path; ir_lower/ir_emit are not otherwise called
+ * from compiler_compile/compiler_compile_script in this landing. */
+bool compiler_ir_self_check(val_t expr);
+
 #endif /* CURRY_COMPILER_H */

--- a/src/ir.c
+++ b/src/ir.c
@@ -1,0 +1,81 @@
+#include "ir.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+/* Simple growable bump allocator. Blocks double in size (starting at 4K)
+ * and are never individually freed until ir_arena_free tears down the
+ * whole chain -- IRNode trees are short-lived (one top-level form's
+ * compile) and small, so per-node free() bookkeeping would be pure
+ * overhead. Not thread-shared: each Compiler tree gets its own arena
+ * (see ir.h's lifetime comment), and compilation of one top-level form
+ * runs on a single thread. */
+
+#define IR_ARENA_INITIAL_BLOCK 4096
+
+typedef struct IRArenaBlock {
+    struct IRArenaBlock *next;
+    size_t used;
+    size_t cap;
+    char   data[];
+} IRArenaBlock;
+
+struct IRArena {
+    IRArenaBlock *head;
+};
+
+static IRArenaBlock *ir_arena_block_new(size_t min_cap) {
+    size_t cap = IR_ARENA_INITIAL_BLOCK;
+    while (cap < min_cap) cap *= 2;
+    IRArenaBlock *b = (IRArenaBlock *)malloc(sizeof(IRArenaBlock) + cap);
+    if (!b) { fprintf(stderr, "ir: out of memory\n"); abort(); }
+    b->next = NULL;
+    b->used = 0;
+    b->cap  = cap;
+    return b;
+}
+
+IRArena *ir_arena_new(void) {
+    IRArena *a = (IRArena *)malloc(sizeof(IRArena));
+    if (!a) { fprintf(stderr, "ir: out of memory\n"); abort(); }
+    a->head = ir_arena_block_new(IR_ARENA_INITIAL_BLOCK);
+    return a;
+}
+
+void ir_arena_free(IRArena *a) {
+    if (!a) return;
+    IRArenaBlock *b = a->head;
+    while (b) {
+        IRArenaBlock *next = b->next;
+        free(b);
+        b = next;
+    }
+    free(a);
+}
+
+/* Round up to 8-byte alignment -- every IRNode member (val_t, pointers,
+ * int/bool) is at most 8-byte aligned on every platform curry targets. */
+static size_t align8(size_t n) { return (n + 7u) & ~(size_t)7u; }
+
+void *ir_arena_alloc(IRArena *a, size_t size) {
+    size = align8(size);
+    IRArenaBlock *b = a->head;
+    if (b->used + size > b->cap) {
+        IRArenaBlock *nb = ir_arena_block_new(size);
+        nb->next = b;
+        a->head = nb;
+        b = nb;
+    }
+    void *p = b->data + b->used;
+    b->used += size;
+    return p;
+}
+
+IRNode *ir_node_new(IRArena *a, IRKind kind, bool tail, int line) {
+    IRNode *n = (IRNode *)ir_arena_alloc(a, sizeof(IRNode));
+    memset(n, 0, sizeof(IRNode));
+    n->kind = kind;
+    n->tail = tail;
+    n->line = line;
+    return n;
+}

--- a/src/ir.h
+++ b/src/ir.h
@@ -1,0 +1,136 @@
+#ifndef CURRY_IR_H
+#define CURRY_IR_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include "value.h"
+
+/*
+ * ir.h — the Tier 2.1 tree IR (docs/thoughts/performance-chez-kaappi.md
+ * §5, item 2.1) and its arena allocator.
+ *
+ * This header intentionally holds ONLY the node representation and the
+ * arena -- data structures with no dependency on the compiler's internal
+ * state. The two passes that actually produce/consume IRNode trees
+ * (ir_lower, ir_emit) live in compiler.c itself, not here, because they
+ * need direct access to Compiler's private helpers (resolve_local,
+ * resolve_upvalue, chunk_add_const, emit/emit_jump/patch_jump, and
+ * compile() itself for IR_FALLBACK) which are static to that translation
+ * unit. Keeping this split -- types here, passes in compiler.c -- avoids
+ * exposing Compiler's internals through a second header just to satisfy
+ * a file-layout preference from the original plan.
+ *
+ * Lifetime: one IRArena per top-level compiled form, shared by every
+ * nested Compiler in that form's compile tree (root Compiler creates it;
+ * every child Compiler inherits the same pointer -- see compiler.c's
+ * init_compiler). Freed once that top-level form's Chunk is fully
+ * emitted. IRNode trees are never reachable from Scheme code and are
+ * never GC-traced -- purely compiler-transient scratch memory.
+ */
+
+typedef enum {
+    /* Leaves */
+    IR_CONST,       /* a self-evaluating value, or a quoted datum */
+    IR_VAR_REF,     /* a variable reference -- see this kind's own comment
+                     * on IRNode::as.var_ref below for why resolution is
+                     * deferred to ir_emit rather than decided here */
+    IR_FALLBACK,    /* not-yet-lowered subtree: ir_emit calls compile()
+                     * on the raw val_t directly, byte-for-byte identical
+                     * to what would have happened had ir_lower never run
+                     * at all. This is what lets IR_IF/IR_SEQ cover forms
+                     * whose subexpressions include calls, lambdas, etc.
+                     * that this landing doesn't lower natively yet -- see
+                     * ir.h's header comment and the Tier 2.1 plan's
+                     * "explicitly deferred" list. */
+
+    /* Combinators */
+    IR_IF,
+    IR_SEQ,         /* begin; only the last element inherits `tail` */
+
+    /* Reserved for a future widening pass (see Tier 2.1 plan's deferred
+     * list) -- not constructed by ir_lower in this landing. Listed here
+     * so the schema doesn't need another revision when calls/lambda/set!/
+     * define get lowered natively. */
+    IR_LAMBDA,
+    IR_CALL,
+    IR_SELF_TAIL_CALL,
+    IR_SET,
+    IR_DEFINE,
+} IRKind;
+
+typedef struct IRNode IRNode;
+
+struct IRNode {
+    IRKind kind;
+    bool   tail;
+    int    line;
+    union {
+        /* quoted: true for a (quote ...) datum, compiled via emit_const
+         * unconditionally (matching compile()'s S_QUOTE case, which never
+         * special-cases V_NIL/V_TRUE/V_FALSE/V_VOID); false for a bare
+         * self-evaluating atom, compiled via compile()'s own top-of-
+         * dispatch special-casing of those four immediates into dedicated
+         * opcodes before ever considering emit_const. Same underlying
+         * value, genuinely different codegen -- collapsing this
+         * distinction produced a real, caught-by-test bytecode mismatch
+         * for (quote ()) during Tier 2.1 development (emits OP_CONST in
+         * compile() today, would have wrongly emitted OP_NIL). */
+        struct { val_t value; bool quoted; } konst;          /* IR_CONST */
+        /* Deliberately just the raw symbol, NOT a pre-resolved local
+         * slot / upvalue index / constant-pool index. An earlier version
+         * resolved eagerly here (matching the original Tier 2.1 plan's
+         * "resolution already decided during lowering" framing) -- caught
+         * by the differential self-check as a real bug: resolve_upvalue
+         * and chunk_add_const both have ordering-sensitive side effects
+         * (they assign indices in first-seen order), and ir_lower builds
+         * the WHOLE tree before ir_emit walks any of it, so a natively-
+         * lowered var-ref sibling that resolves eagerly during lowering
+         * can register its upvalue/constant-pool slot BEFORE an earlier
+         * IR_FALLBACK sibling gets a chance to (fallback nodes only touch
+         * the chunk when ir_emit finally calls compile() on them) --
+         * silently reordering the constant pool / upvalue table relative
+         * to the original interleaved compile() and breaking the byte-
+         * identical guarantee. Fix: resolve_local/resolve_upvalue/
+         * chunk_add_const only ever run at ir_emit time now (via
+         * emit_load), in the same left-to-right tree-walk order ir_emit
+         * itself proceeds in -- which matches original compile()'s
+         * interleaved order exactly, natively-lowered and fallback nodes
+         * alike. Eager resolution at lower time can only be safely
+         * reintroduced once no IR_FALLBACK escape hatch remains for
+         * anything that could appear as a sibling. */
+        struct { val_t name; } var_ref;                       /* IR_VAR_REF */
+        struct { val_t expr; } fallback;                      /* IR_FALLBACK */
+        struct { IRNode *test, *then, *els; } iff;             /* IR_IF */
+        /* pop_lines[i] is the line compile_seq would stamp on the
+         * OP_POP emitted after items[i] (i.e. the SEQ SPINE cons cell's
+         * own hdr.flags at that position) -- deliberately NOT the same
+         * as items[i]->line, which is whatever line ir_lower recursively
+         * refined the ITEM's own subtree to internally (e.g. from the
+         * item pair's own hdr.flags, which can differ from the spine
+         * cell's when the item came from a macro-rebuilt cons whose
+         * spine cell has hdr.flags == 0 but whose captured/spliced
+         * subexpression retains its original non-zero flags).
+         * compile_seq's own `line` variable is never affected by
+         * whatever compile() does internally to ITS copy of `line`
+         * (plain C pass-by-value) -- collapsing this into a single
+         * per-item line and using it for OP_POP produced a real,
+         * differential-self-check-invisible divergence (code-identical,
+         * lines[]-divergent) for macro-synthesized begin spines, found
+         * by independent code review during Tier 2.1 development. */
+        struct { IRNode **items; int *pop_lines; int count; } seq;  /* IR_SEQ */
+    } as;
+};
+
+/* ── Arena ────────────────────────────────────────────────────────────── */
+
+typedef struct IRArena IRArena;
+
+IRArena *ir_arena_new(void);
+void     ir_arena_free(IRArena *a);
+void    *ir_arena_alloc(IRArena *a, size_t size);
+
+/* Convenience: allocate and zero-init one IRNode from the arena. */
+IRNode  *ir_node_new(IRArena *a, IRKind kind, bool tail, int line);
+
+#endif /* CURRY_IR_H */

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -276,10 +276,25 @@ static void test_ir_self_check(void) {
      * nothing state afterward. */
     {
         char src[8192];
-        int off = snprintf(src, sizeof(src), "(begin");
-        for (int i = 0; i < 300; i++)
-            off += snprintf(src + off, sizeof(src) - (size_t)off, " sym%d", i);
-        snprintf(src + off, sizeof(src) - (size_t)off, ")");
+        /* snprintf's return value is how many bytes WOULD have been
+         * written, not how many actually were -- accumulating it
+         * unchecked into `off` and using `sizeof(src) - off` for the
+         * next call's size argument underflows (size_t is unsigned) the
+         * moment off exceeds sizeof(src), turning "buffer full" into
+         * "here, take this huge size and write past the end" (flagged by
+         * CodeQL). 300 short symbol names comfortably fit in 8192 bytes
+         * in practice, but the pattern itself is the bug, independent of
+         * whether today's fixed inputs happen to avoid it -- clamp `off`
+         * to the buffer size so a future change to the loop bound or
+         * symbol-name length can't silently reintroduce an overflow. */
+        size_t off = (size_t)snprintf(src, sizeof(src), "(begin");
+        if (off > sizeof(src)) off = sizeof(src);
+        for (int i = 0; i < 300 && off < sizeof(src); i++) {
+            int n = snprintf(src + off, sizeof(src) - off, " sym%d", i);
+            off += (size_t)n;
+            if (off > sizeof(src)) off = sizeof(src);
+        }
+        if (off < sizeof(src)) snprintf(src + off, sizeof(src) - off, ")");
         val_t port = port_open_input_string(src, (uint32_t)strlen(src));
         val_t expr = scm_read(port);
 

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -9,6 +9,7 @@
 #include "modules.h"
 #include "set.h"
 #include "object.h"
+#include "compiler.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -203,6 +204,99 @@ static void test_guard(void) {
     CHECK(r == sym_intern_cstr("caught"), "guard catches error");
 }
 
+/* Tier 2.1 IR (src/ir.h, docs/thoughts/performance-chez-kaappi.md §5):
+ * compiler_ir_self_check(expr) compiles expr both via the existing direct
+ * compile() path and via the new ir_lower+ir_emit path and asserts the
+ * resulting bytecode is byte-for-byte identical. Covers the bounded
+ * subset ir_lower recognizes natively (literals, quote, symbol refs at
+ * every scope depth, if, begin) plus IR_FALLBACK's delegation for
+ * everything else (calls, lambda, let, and/or, ...) nested inside those
+ * forms -- exercising both the native cases and the fallback composition
+ * they need to work with real code. */
+static void test_ir_self_check(void) {
+    static const char *cases[] = {
+        "42",
+        "3.14",
+        "\"hello\"",
+        "#\\a",
+        "#t",
+        "#f",
+        "'()",
+        "#:foo",
+        "(quote (1 2 3))",
+        "(quote ())",
+        "(quote #t)",
+        "(quote #f)",
+        "(if #t (quote ()) (quote ()))",
+        "(if #t 1 2)",
+        "(if #f 1)",
+        "(begin)",
+        "(begin 1)",
+        "(begin 1 2 3)",
+        "(if (> 3 2) (begin (+ 1 2) 'yes) 'no)",
+        "((lambda (x) (if x (+ x 1) 0)) 5)",
+        "(begin (define x 10) (if (> x 5) (* x 2) x))",
+        "(let ((a 1) (b 2)) (if (< a b) (begin a (+ a b)) b))",
+        "(if (if #t #f #t) 'a (begin 'b 'c))",
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        val_t port = port_open_input_string(cases[i], (uint32_t)strlen(cases[i]));
+        val_t expr = scm_read(port);
+        char msg[256];
+        snprintf(msg, sizeof(msg), "ir self-check: %s", cases[i]);
+        CHECK(compiler_ir_self_check(expr), msg);
+    }
+
+    /* Regression case for a real bug independent code review found: a
+     * macro-rebuilt `begin` spine (scm_cons always stamps hdr.flags = 0
+     * on the cells IT conses, unlike the reader) whose spliced-in items
+     * retain their own original, non-zero reader-stamped lines. This is
+     * exactly the shape that let items[i]->line silently diverge from
+     * the seq-spine line compile_seq itself would use for OP_POP -- a
+     * divergence invisible to a code-only bytecode comparison (only
+     * chunk->lines[] differs), which is also why compiler_ir_self_check
+     * itself now compares lines[] too, not just code. */
+    run("(define-syntax my-begin2 (syntax-rules () ((_ a b) (begin a b))))");
+    {
+        const char *src = "(my-begin2 1 2)";
+        val_t port = port_open_input_string(src, (uint32_t)strlen(src));
+        val_t expr = scm_read(port);
+        CHECK(compiler_ir_self_check(expr), "ir self-check: macro-expanded begin spine");
+    }
+
+    /* Exception-safety regression: compiler_ir_self_check must not crash
+     * or corrupt gc_inhibit_count when compile() raises mid-way
+     * (independent security review -- see this function's own
+     * SCM_PROTECT comment in compiler.c). A begin with >256 distinct
+     * symbols overflows chunk_add_const's compiler-limit check, a
+     * reliable, clean compile-time scm_raise. Wrap the call in our own
+     * SCM_PROTECT since compiler_ir_self_check correctly RE-raises (it
+     * is a verification tool, not an error-swallowing one) -- catching
+     * it here just confirms the process is still in a sane, unbalanced-
+     * nothing state afterward. */
+    {
+        char src[8192];
+        int off = snprintf(src, sizeof(src), "(begin");
+        for (int i = 0; i < 300; i++)
+            off += snprintf(src + off, sizeof(src) - (size_t)off, " sym%d", i);
+        snprintf(src + off, sizeof(src) - (size_t)off, ")");
+        val_t port = port_open_input_string(src, (uint32_t)strlen(src));
+        val_t expr = scm_read(port);
+
+        int before = gc_inhibit_save();
+        ExnHandler h;
+        bool raised = false;
+        SCM_PROTECT(h, {
+            compiler_ir_self_check(expr);
+        }, {
+            raised = true;
+        });
+        int after = gc_inhibit_save();
+        CHECK(raised, "ir self-check: >256-constant overflow raises");
+        CHECK(before == after, "ir self-check: gc_inhibit_count balanced after raise");
+    }
+}
+
 #define RUN_TEST(fn) do { fprintf(stderr, ">> " #fn "\n"); fn(); fflush(stdout); } while(0)
 
 int main(void) {
@@ -225,6 +319,7 @@ int main(void) {
     RUN_TEST(test_hash_tables);
     RUN_TEST(test_records);
     RUN_TEST(test_guard);
+    RUN_TEST(test_ir_self_check);
 
     printf("\n%d passed, %d failed\n", pass, fail);
     return fail > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

First, deliberately narrow landing of `docs/thoughts/performance-chez-kaappi.md` §5 Tier 2 item 2.1 — a small tree IR between the expander and bytecode emission, the enabling investment everything else in Tier 2 (constant folding, dead-branch elimination, a cp0-style inliner, closure elision, unchecked primitives, pointing the LLVM tier at something other than raw S-expressions) is gated behind.

- **`src/ir.h`/`src/ir.c`**: a new `IRNode` tagged union (`IR_CONST`, `IR_VAR_REF`, `IR_FALLBACK`, `IR_IF`, `IR_SEQ`; plus `IR_LAMBDA`/`IR_CALL`/`IR_SELF_TAIL_CALL`/`IR_SET`/`IR_DEFINE` reserved for a future widening pass, never constructed here) and a bump-allocator arena, one per top-level compiled form.
- **`ir_lower`/`ir_emit`** (new, in `compiler.c`): `ir_lower` natively recognizes only a bounded subset — self-evaluating literals, `#:keyword` symbols, `quote`, `if`, `begin`, and variable references. Everything else (calls, `lambda`, `let`, `define`, `set!`, `and`/`or`, ...) becomes an `IR_FALLBACK` leaf whose `ir_emit` case delegates unchanged to the existing `compile()` — this is what lets `if`/`begin` cover real programs without needing to natively lower every form first.

**Critically: `compile()` itself is untouched, and `ir_lower`/`ir_emit` are not wired into any live compile path.** They're only reachable via a new public `compiler_ir_self_check(expr)`, which compiles the same expression through both the old and new paths into separate scratch `Chunk`s and asserts the bytecode — and, after review, the per-byte source lines too — are identical. Wiring this into the live dispatch is the natural next increment once this skeleton is proven stable over more of the language.

## The differential harness earned its keep

It caught two real bugs during development, before either could reach anything real:
1. `(quote ())` diverged because `compile()`'s `S_QUOTE` case always uses `emit_const` (never special-casing `V_NIL`/`V_TRUE`/`V_FALSE`/`V_VOID`), while the self-evaluating-atom dispatch DOES special-case those — the first `IR_CONST` design conflated the two.
2. More fundamentally: `chunk_add_const`/`resolve_upvalue` have ordering-sensitive side effects (assign indices in first-seen order). Resolving variable references eagerly during `ir_lower` — before any emission — could register a slot for a natively-lowered sibling before an earlier `IR_FALLBACK` sibling's own (emit-time-only) resolution happened, silently reordering the constant pool. Fixed by deferring ALL resolution to `ir_emit` time.

## Review

Independently reviewed twice (code-review + security-review, no shared context with the implementation). All findings fixed:

- **A third instance of the same ordering-bug class**, found by code review: `IR_SEQ`'s `OP_POP` line number could diverge from `compile_seq`'s for a macro-rebuilt `begin` spine (`scm_cons` always zeroes `hdr.flags` on synthesized cells) — code-identical, `lines[]`-divergent, invisible to a code-only differential comparison. Fixed by tracking the seq-spine line separately from each item's own internally-refined line; `compiler_ir_self_check` now also compares `chunk->lines[]`, closing the blind spot that let this one through initially.
- **Exception-unsafe self-check**, found by security review: a raising expression would `longjmp` past both arena frees and leave `gc_inhibit_count` permanently unbalanced — mirroring a hazard `compile_time_eval` already documents and guards against elsewhere in this file. Fixed with the same `SCM_PROTECT` pattern.
- **Arena leak on the ordinary compile path**: `init_compiler` eagerly allocated an `IRArena` for every top-level compile, including ordinary ones that never touch `ir_lower`/`ir_emit`, leaking it on any routine compile-time error. Fixed: the arena is now `NULL` by default, allocated explicitly only by `compiler_ir_self_check`.
- **Latent `int` overflow** in `ir_lower_seq`'s item count (an out-of-bounds-write class for a pathologically long `begin` body). Fixed with `size_t` arithmetic throughout the allocation sizing.

## Test plan

- [x] Full `ctest` suite: 99/99 passing (unaffected — `compile()` is unmodified)
- [x] New `test_ir_self_check` in `tests/test_core.c`: covers the native subset, `IR_FALLBACK` composition with real code (`let`, `lambda`, calls nested inside `if`/`begin`), the macro-spine regression (`define-syntax` + `syntax-rules` building a `begin` via `scm_cons`), and the exception-safety fix (a >256-distinct-constant compile-time raise, confirmed `gc_inhibit_count` stays balanced afterward)
- [x] Independent code-review + security-review subagent passes, both clean after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
