### PR TITLE
feat(compiler): and/or simplification, let/named-let IR widening, cache fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,20 +86,24 @@ cmake -B build -DBUILD_LLVM=ON -DCMAKE_PREFIX_PATH="$(brew --prefix llvm)"
 
 ## Tests
 
+**When working on the compiler, VM, or anything else that changes codegen, always run `curry` against `.scm` test files with `--clear-cache`** (or delete stale `.scc` files first — `find tests -name '*.scc' -delete`). The transparent `.scc` cache (see below) is keyed on source *content* hash, not compiler version: a `.scc` file compiled by yesterday's binary is still a cache HIT today if the `.scm` source hasn't changed, silently serving old bytecode instead of re-running your changes through the compiler. `ctest`'s Scheme-based suites (`scheme_r7rs`, `scheme_r6rs`, `syntax_rules`, every `srfi_*`/module test, etc. — everything except the pure-C `core` target) invoke `curry` on checked-in `.scm` files this same way and are just as exposed: a stale `.scc` left over from before your change can make `ctest` report a pass that never actually exercised the new code. Confirmed concretely during Tier 2.1/2.2 IR development: `ctest` reported 99/99 passing against `.scc` files compiled the day before a live-dispatch refactor landed (`curry --timings tests/r7rs_tests.scm` showed `cache HIT`) — the suite wasn't lying, but it also wasn't testing the refactor. Clearing all `.scc` files and rerunning was the only way to get a genuine result.
+
 ```bash
 cmake --build build && ctest --test-dir build -V
 
 # Run only the C unit tests
 ./build/tests/curry_test
 
-# Run only the Scheme R7RS tests
-./build/curry tests/r7rs_tests.scm
+# Run only the Scheme R7RS tests -- --clear-cache forces a fresh
+# compile instead of a possible stale cache hit (see above)
+./build/curry --clear-cache tests/r7rs_tests.scm
 
 # Run a specific test file
-./build/curry tests/actors_tests.scm
-./build/curry tests/numeric_ext_tests.scm
+./build/curry --clear-cache tests/actors_tests.scm
+./build/curry --clear-cache tests/numeric_ext_tests.scm
 
-# Run a specific expression
+# Run a specific expression (not cached -- -e is never subject to the
+# .scc cache, which only applies to a positional script-file argument)
 ./build/curry -e '(display (+ 1 2)) (newline)'
 ```
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -3556,13 +3556,23 @@ bool compiler_ir_self_check(val_t expr) {
 /* ── Tier 2.2: cheap IR optimizations (docs/thoughts/
  * performance-chez-kaappi.md §5, item 2.2) ─────────────────────────────
  *
- * ir_optimize runs on an already-lowered tree, between ir_lower and
+ * ir_optimize_andor (below) recurses via ir_optimize before ir_optimize
+ * itself is defined -- forward-declared here. */
+static IRNode *ir_optimize(IRNode *n);
+
+/* ir_optimize runs on an already-lowered tree, between ir_lower and
  * ir_emit, and rewrites it in place (no arena allocation -- it only ever
  * splices existing subtrees into a parent's slot or leaves a node
- * untouched, never builds a new one). Landing one transform for now:
- * dead-branch elimination on IR_IF, `(if <const> then else)` folding to
- * whichever branch the constant's truthiness picks, entirely discarding
- * the OTHER branch's bytecode and the test's own load+jump instructions.
+ * untouched, never builds a new one). Two transforms land here:
+ *   - dead-branch elimination on IR_IF: `(if <const> then else)` folds
+ *     to whichever branch the constant's truthiness picks, discarding
+ *     the OTHER branch's bytecode and the test's own load+jump
+ *     instructions entirely.
+ *   - boolean simplification on IR_AND/IR_OR (ir_optimize_andor, below):
+ *     a non-last constant item that already decides the short-circuit
+ *     outcome truncates the list there (everything after is dead); a
+ *     non-last constant item that doesn't is spliced out (side-effect-
+ *     free, contributes nothing).
  *
  * This is the first Tier 2.1/2.2 transform in this codebase that
  * deliberately produces DIFFERENT bytecode than compile()'s own
@@ -3587,6 +3597,50 @@ bool compiler_ir_self_check(val_t expr) {
  * the same reason (raw val_t, not a tree) and IR_VAR_REF/IR_CONST are
  * leaves -- none of these four kinds get a case below; they fall through
  * to the default `return n` unchanged. */
+
+/* Shared by IR_AND/IR_OR: compacts the items list in place, applying two
+ * safe transforms to each NON-LAST item (after recursively optimizing
+ * it, so an item that itself folds down to a constant -- e.g. a nested
+ * `(if #t 1 2)` -- is caught by the same pass):
+ *
+ *   - a constant whose truthiness already decides the whole expression's
+ *     short-circuit outcome (falsy for AND, truthy for OR) truncates the
+ *     list right there: it becomes the new last item, and every item
+ *     after it is unreachable dead code, discarded.
+ *   - a constant whose truthiness does NOT decide the outcome (truthy
+ *     for AND, falsy for OR) contributes nothing but its own position in
+ *     the sequence, and -- being a literal -- has no side effect either:
+ *     spliced out entirely.
+ *
+ * The last item is never touched by either rule (guarded by `!is_last`):
+ * its VALUE is what the whole expression evaluates to when reached, not
+ * just a truth test, so it's kept (and still recursively optimized)
+ * regardless of its own truthiness. A dropped or truncation-point item
+ * is, by construction, always an IR_CONST -- literals ignore `tail`
+ * entirely in their own codegen, so this never disturbs the one item
+ * (the ORIGINAL last item, when no truncation happens) whose `->tail`
+ * ir_lower_and/or actually set meaningfully for tail-call purposes.
+ * `short_circuits_on_falsy` selects AND's vs OR's roles. */
+static void ir_optimize_andor(IRNode *n, bool short_circuits_on_falsy) {
+    int in_count  = n->as.andor.count;
+    int out_count = 0;
+    for (int i = 0; i < in_count; i++) {
+        bool     is_last = (i == in_count - 1);
+        IRNode  *item    = ir_optimize(n->as.andor.items[i]);
+        if (!is_last && item->kind == IR_CONST) {
+            bool truthy  = item->as.konst.value != V_FALSE;
+            bool ends_it = short_circuits_on_falsy ? !truthy : truthy;
+            if (ends_it) {
+                n->as.andor.items[out_count++] = item;
+                break;  /* truncate: this becomes the new last item */
+            }
+            continue;   /* provably doesn't end it, no side effect: drop */
+        }
+        n->as.andor.items[out_count++] = item;
+    }
+    n->as.andor.count = out_count;
+}
+
 static IRNode *ir_optimize(IRNode *n) {
     switch (n->kind) {
     case IR_IF: {
@@ -3607,11 +3661,8 @@ static IRNode *ir_optimize(IRNode *n) {
     case IR_SET:
         n->as.set.value = ir_optimize(n->as.set.value);
         return n;
-    case IR_AND:
-    case IR_OR:
-        for (int i = 0; i < n->as.andor.count; i++)
-            n->as.andor.items[i] = ir_optimize(n->as.andor.items[i]);
-        return n;
+    case IR_AND: ir_optimize_andor(n, true);  return n;
+    case IR_OR:  ir_optimize_andor(n, false); return n;
     case IR_DEFINE:
         n->as.def.value = ir_optimize(n->as.def.value);
         return n;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -3188,6 +3188,151 @@ static IRNode *ir_lower_call(Compiler *c, val_t head, val_t args, bool tail, int
     return n;
 }
 
+/* Builds an IR_CALL{callee=IR_LAMBDA{...}} node directly (not via
+ * ir_lower_call, which expects a raw val_t callee to lower itself --
+ * here the callee is ALREADY the IR_LAMBDA ir_lower_lambda just built,
+ * no S-expression synthesis needed for it). `head` is V_FALSE: never a
+ * symbol, so IR_CALL's own ir_emit classification always falls through
+ * to its generic (non-self-tail, non-fused-global) branch -- exactly
+ * matching compile_let/compile_let_star/compile_letrec, which always
+ * emit a plain OP_CALL/OP_TAIL_CALL for these desugared forms, never
+ * OP_CALL_GLOBAL. Shared by ir_lower_let/ir_lower_let_star/
+ * ir_lower_letrec below. */
+static IRNode *ir_lower_lambda_call(Compiler *c, IRNode *callee,
+                                     IRNode **args, int argc,
+                                     bool tail, int line) {
+    IRNode *n = ir_node_new(c->ir_arena, IR_CALL, tail, line);
+    n->as.call.head   = V_FALSE;
+    n->as.call.callee = callee;
+    n->as.call.argc   = argc;
+    n->as.call.args   = args;
+    return n;
+}
+
+/* Mirrors compile_let's own PLAIN (non-named) branch exactly: `(let
+ * ((x v) ...) body...)` desugars to `((lambda (x ...) body...) v ...)`.
+ * No new IR node kind needed -- IR_LAMBDA already handles everything a
+ * let's body needs (its own child scope, internal defines, internal
+ * macros -- see IR_LAMBDA's own comment in ir.h), so this is pure
+ * ir_lower-time construction reusing it unchanged. The named-let branch
+ * is NOT handled here -- see ir_lower_named_let, called separately from
+ * ir_lower's own dispatch (it needs ir_emit-time work this can't do). */
+static IRNode *ir_lower_let(Compiler *c, val_t args, bool tail, int line) {
+    val_t bindings = vcar(args);
+    val_t body     = vcdr(args);
+
+    /* Forward-order params list -- same double-reverse compile_let itself
+     * uses (bindings is walked once to reverse, then reversed back). */
+    val_t params = V_NIL;
+    int argc = 0;
+    for (val_t b = bindings; vis_pair(b); b = vcdr(b)) {
+        params = scm_cons(vcar(vcar(b)), params);
+        argc++;
+    }
+    val_t fwd = V_NIL;
+    while (vis_pair(params)) { fwd = scm_cons(vcar(params), fwd); params = vcdr(params); }
+
+    IRNode *callee = ir_lower_lambda(c, fwd, body, c->name, line);
+    IRNode **argv = argc > 0
+        ? (IRNode **)ir_arena_alloc(c->ir_arena, sizeof(IRNode *) * (size_t)argc)
+        : NULL;
+    int i = 0;
+    for (val_t b = bindings; vis_pair(b); b = vcdr(b))
+        argv[i++] = ir_lower(c, vcar(vcdr(vcar(b))), false, line);
+    return ir_lower_lambda_call(c, callee, argv, argc, tail, line);
+}
+
+/* Mirrors compile_let_star exactly, including its base case (empty
+ * bindings compiles the body directly via ir_lower_seq, no lambda
+ * wrapper) and its single-binding-at-a-time nesting: `(let* ((x v)
+ * rest...) body)` -> `((lambda (x) (let* rest... body)) v)`. The
+ * synthesized inner `(let* rest body)` form is embedded as the lambda's
+ * OWN body (via ir_lower_lambda, same as ir_lower_let above) -- it gets
+ * lowered lazily, later, when ir_emit's IR_LAMBDA case walks that body,
+ * re-entering this same function via ir_lower's own S_LET_STAR dispatch
+ * hook. No manual recursion needed here -- IR_LAMBDA's deferred-body
+ * design already gives this the same per-level laziness compile_let_star
+ * itself relies on (each inner let* is only compiled when ITS enclosing
+ * lambda's body is). */
+static IRNode *ir_lower_let_star(Compiler *c, val_t args, bool tail, int line) {
+    val_t bindings = vcar(args);
+    val_t body     = vcdr(args);
+
+    if (vis_nil(bindings))
+        return ir_lower_seq(c, body, tail, line);
+
+    val_t binding = vcar(bindings);
+    val_t name    = vcar(binding);
+    val_t init    = vcar(vcdr(binding));
+    val_t rest    = vcdr(bindings);
+
+    val_t inner_body;
+    if (vis_nil(rest)) {
+        inner_body = body;
+    } else {
+        val_t let_star_sym = sym_intern_cstr("let*");
+        val_t inner_form   = scm_cons(let_star_sym, scm_cons(rest, body));
+        inner_body = scm_cons(inner_form, V_NIL);
+    }
+    val_t params = scm_cons(name, V_NIL);
+
+    IRNode *callee = ir_lower_lambda(c, params, inner_body, c->name, line);
+    IRNode **argv  = (IRNode **)ir_arena_alloc(c->ir_arena, sizeof(IRNode *));
+    argv[0] = ir_lower(c, init, false, line);
+    return ir_lower_lambda_call(c, callee, argv, 1, tail, line);
+}
+
+/* Mirrors compile_letrec exactly (shared by S_LETREC and S_LETREC_STAR,
+ * same as compile_letrec itself -- curry draws no stricter distinction
+ * between them at the compiler level). Rather than replicate
+ * compile_letrec's own bespoke "pre-declare all locals with void
+ * placeholders, then compile+store each init in order" bytecode
+ * sequence, this desugars to `((lambda () (define n1 v1) (define n2 v2)
+ * ... body...)))`  -- lambda_prescan (compiler.c) ALREADY gives ordinary
+ * internal defines this exact same "every name visible from the first
+ * define onward, initialized in sequence" treatment for letrec*
+ * semantics, which is what compile_letrec itself provides for both
+ * letrec and letrec* today, so this produces identical observable
+ * behavior through already-verified machinery instead of a parallel
+ * bespoke implementation. */
+static IRNode *ir_lower_letrec(Compiler *c, val_t args, bool tail, int line) {
+    val_t bindings = vcar(args);
+    val_t body     = vcdr(args);
+
+    /* Build (define name init) forms in reverse, then prepend each (in
+     * that reverse order) onto body -- restores original binding order
+     * at the front, ahead of the original body forms. */
+    val_t rev = V_NIL;
+    for (val_t b = bindings; vis_pair(b); b = vcdr(b)) {
+        val_t name = vcar(vcar(b));
+        val_t init = vcar(vcdr(vcar(b)));
+        val_t def_form = scm_cons(S_DEFINE, scm_cons(name, scm_cons(init, V_NIL)));
+        rev = scm_cons(def_form, rev);
+    }
+    val_t new_body = body;
+    for (val_t p = rev; vis_pair(p); p = vcdr(p))
+        new_body = scm_cons(vcar(p), new_body);
+
+    IRNode *callee = ir_lower_lambda(c, V_NIL, new_body, "<letrec>", line);
+    return ir_lower_lambda_call(c, callee, NULL, 0, tail, line);
+}
+
+/* Named let: `(let loop ((x v) ...) body)` -- see compile_let's own
+ * comment for the full "zero-arg outer wrapper" shape this mirrors.
+ * Unlike every other let / let-star / letrec form above, this ISN'T
+ * pure ir_lower-time desugaring -- see ir.h's comment on IRNode::as.named_let
+ * for why the self-tail-call thread-local arming forces the whole
+ * construction into ir_emit instead. This function only stores the raw
+ * pieces ir_emit's IR_NAMED_LET case needs. */
+static IRNode *ir_lower_named_let(Compiler *c, val_t loop_name, val_t bindings,
+                                   val_t body, bool tail, int line) {
+    IRNode *n = ir_node_new(c->ir_arena, IR_NAMED_LET, tail, line);
+    n->as.named_let.loop_name = loop_name;
+    n->as.named_let.bindings  = bindings;
+    n->as.named_let.body      = body;
+    return n;
+}
+
 static IRNode *ir_lower(Compiler *c, val_t expr, bool tail, int line) {
     if (vis_pair(expr) && as_pair(expr)->hdr.flags)
         line = (int)as_pair(expr)->hdr.flags;
@@ -3249,6 +3394,21 @@ static IRNode *ir_lower(Compiler *c, val_t expr, bool tail, int line) {
     if (head == S_OR)    return ir_lower_or(c, args, tail, line);
     if (head == S_LAMBDA && vis_pair(args))
         return ir_lower_lambda(c, vcar(args), vcdr(args), NULL, line);
+    /* let -- named vs plain distinguished the same way compile_let
+     * itself does (a leading symbol instead of a bindings list). Named
+     * let routes to ir_lower_named_let (IR_NAMED_LET); everything else
+     * routes to ir_lower_let (pure desugaring, see its own comment). */
+    if (head == S_LET && vis_pair(args)) {
+        val_t bindings = vcar(args);
+        if (vis_symbol(bindings)) {
+            val_t let_body = vcdr(args);
+            return ir_lower_named_let(c, bindings, vcar(let_body), vcdr(let_body), tail, line);
+        }
+        return ir_lower_let(c, args, tail, line);
+    }
+    if (head == S_LET_STAR) return ir_lower_let_star(c, args, tail, line);
+    if (head == S_LETREC || head == S_LETREC_STAR)
+        return ir_lower_letrec(c, args, tail, line);
     /* Both `(define sym expr)` and `(define (f params...) body...)`
      * lambda-sugar are natively lowered (the latter via IR_LAMBDA, now
      * that it exists -- see ir_lower_define_lambda_sugar's comment);
@@ -3384,19 +3544,18 @@ static void ir_emit(Compiler *c, IRNode *n) {
          * why this decision (not just the resolution it depends on)
          * happens here, at emit time, rather than during ir_lower.
          *
-         * The self-tail-call sub-branch just below is currently
-         * unreachable via compiler_ir_self_check: c->self_tail_name is
-         * only ever armed by compile_let (for a named-let loop body),
-         * and compile_let only runs on the classic compile() path --
-         * S_LET itself is not natively IR-lowered (classify_head returns
-         * SF_LET, not SF_NONE), so a named-let's loop body is always
-         * inside an IR_FALLBACK leaf that ir_lower never recurses into,
-         * meaning ir_lower_call/this IR_CALL case never even sees it.
-         * Correct by direct mirroring of compile_call, but genuinely
-         * untested until named-let itself gets IR-lowered in a future
-         * landing -- see tests/test_core.c's own comment at the same
-         * spot (an earlier version of that test wrongly claimed this
-         * branch was covered; caught by independent code review). */
+         * The self-tail-call sub-branch just below now has real coverage
+         * (as of the sixth landing, named-let/IR_NAMED_LET below): a
+         * named-let loop's inner lambda body is walked through
+         * ir_lower_lambda+ir_emit (see IR_NAMED_LET's own case), with
+         * c->self_tail_name armed there exactly as compile_let arms it
+         * for the classic path -- so a tail-position self-call inside
+         * that body reaches this branch for real, exercised by
+         * tests/test_core.c's named-let self-tail-call cases. (Earlier
+         * landings, before named-let was IR-lowered, had this branch
+         * correct by inspection only; an earlier version of the test
+         * file wrongly claimed coverage that didn't exist yet -- caught
+         * by independent code review at the time.) */
         val_t head  = n->as.call.head;
         int   argc  = n->as.call.argc;
         bool  ctail = n->tail;
@@ -3483,6 +3642,70 @@ static void ir_emit(Compiler *c, IRNode *n) {
             chunk_emit(c->chunk, child.upvals[i].is_local ? 1 : 0, n->line);
             chunk_emit(c->chunk, (uint8_t)child.upvals[i].index,   n->line);
         }
+        return;
+    }
+    case IR_NAMED_LET: {
+        /* Direct translation of compile_let's own named-let branch -- see
+         * ir.h's comment on IRNode::as.named_let for why this whole
+         * construction (not just the resolution inside it) has to happen
+         * here, at emit time: g_compile_self_tail_name/mutated must be
+         * armed immediately before the inner loop lambda's own child
+         * Compiler is created (init_compiler consumes them), and that
+         * creation now happens via ir_lower_lambda+ir_emit rather than
+         * compile_lambda -- giving IR_CALL's self-tail-call branch (see
+         * its own ir_emit case) its first REAL coverage: a named-let
+         * loop's body is now actually walked through ir_lower/ir_emit,
+         * not left as IR_FALLBACK. */
+        val_t loop_name = n->as.named_let.loop_name;
+        val_t bindings  = n->as.named_let.bindings;
+        val_t body      = n->as.named_let.body;
+
+        int argc = 0;
+        for (val_t b = bindings; vis_pair(b); b = vcdr(b)) argc++;
+
+        /* Forward-order params list -- matches compile_let exactly. */
+        val_t params = V_NIL;
+        for (val_t b = bindings; vis_pair(b); b = vcdr(b))
+            params = scm_cons(vcar(vcar(b)), params);
+        val_t fwd = V_NIL;
+        while (vis_pair(params)) { fwd = scm_cons(vcar(params), fwd); params = vcdr(params); }
+
+        Compiler outer;
+        init_compiler(&outer, c, as_sym(loop_name)->data);
+        outer.chunk->arity = 0;
+
+        /* Slot 0 = loop name (void placeholder) -- matches compile_let. */
+        add_local(&outer, loop_name);
+        mark_initialised(&outer);
+        emit(&outer, OP_VOID, n->line);
+
+        /* Arm the self-tail-call thread-local, consumed by init_compiler
+         * inside ir_lower_lambda+ir_emit's own IR_LAMBDA case below --
+         * body_mentions_set_target scans against `c` (the ENCLOSING
+         * compiler, i.e. this ir_emit call's own parameter), matching
+         * compile_let's identical call exactly (not `outer`: at this
+         * point no inner scope exists yet to check macros against). */
+        g_compile_self_tail_name    = loop_name;
+        g_compile_self_tail_mutated = body_mentions_set_target(c, body, loop_name);
+        IRNode *loop_lambda = ir_lower_lambda(&outer, fwd, body,
+                                               as_sym(loop_name)->data, n->line);
+        ir_emit(&outer, loop_lambda);
+        emit_ab(&outer, OP_STORE_LOCAL, 0, n->line);  /* store closure -> slot 0 */
+        emit_ab(&outer, OP_LOAD_LOCAL,  0, n->line);  /* callee */
+        for (val_t b = bindings; vis_pair(b); b = vcdr(b)) {
+            IRNode *arg = ir_lower(&outer, vcar(vcdr(vcar(b))), false, n->line);
+            ir_emit(&outer, arg);
+        }
+        emit_ab(&outer, OP_TAIL_CALL, (uint8_t)argc, n->line);
+        Chunk *och = end_compiler(&outer);
+
+        int ci = chunk_add_const(c->chunk, (val_t)(uintptr_t)och);
+        emit_ab(c, OP_CLOSURE, (uint8_t)ci, n->line);
+        for (int i = 0; i < outer.upval_count; i++) {
+            chunk_emit(c->chunk, outer.upvals[i].is_local ? 1 : 0, n->line);
+            chunk_emit(c->chunk, (uint8_t)outer.upvals[i].index,   n->line);
+        }
+        emit_ab(c, n->tail ? OP_TAIL_CALL : OP_CALL, 0, n->line);
         return;
     }
     }

--- a/src/ir.h
+++ b/src/ir.h
@@ -71,6 +71,21 @@ typedef enum {
     IR_LAMBDA,      /* widened in the fifth landing -- see this kind's own
                      * `lambda` field comment below for why its body is
                      * stored RAW, not pre-lowered into an IR tree. */
+    IR_NAMED_LET,   /* widened in the sixth landing, ALONGSIDE plain
+                     * let / let-star / letrec / letrec-star -- but those
+                     * four need no new node kind at all: they're pure
+                     * ir_lower-time desugaring into
+                     * IR_CALL{callee=IR_LAMBDA{...}}
+                     * (see ir_lower_let/ir_lower_let_star/
+                     * ir_lower_letrec, compiler.c), reusing IR_LAMBDA's
+                     * already-verified machinery unchanged. Named let is
+                     * the one exception: it needs the self-tail-call
+                     * thread-local side-channel (g_compile_self_tail_
+                     * name/mutated, compiler.c) armed at exactly the
+                     * right moment, an ordering-sensitive side effect
+                     * that -- like every other one in this IR -- can
+                     * only happen at ir_emit time. See this kind's own
+                     * `named_let` field comment below. */
 } IRKind;
 
 typedef struct IRNode IRNode;
@@ -210,6 +225,17 @@ struct IRNode {
          * anonymous (lambda ...), the bound symbol's C string for
          * `(define (f ...) ...)` sugar. */
         struct { val_t params; val_t body; const char *name; } lambda; /* IR_LAMBDA */
+        /* All three fields raw/unprocessed, same reasoning as
+         * IR_LAMBDA's own `lambda` field above -- ir_emit's IR_NAMED_LET
+         * case builds the whole "zero-arg outer wrapper" structure
+         * (compile_let's own comment on its named-let branch,
+         * compiler.c, has the full shape) itself, arming
+         * g_compile_self_tail_name/g_compile_self_tail_mutated
+         * immediately before lowering+emitting the inner loop lambda --
+         * nothing here can be pre-built during ir_lower. `bindings` is
+         * the raw `((x v) ...)` list (not yet split into params/inits);
+         * `body` is the loop's own raw body forms. */
+        struct { val_t loop_name; val_t bindings; val_t body; } named_let; /* IR_NAMED_LET */
     } as;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,15 +2,15 @@ add_executable(curry_test test_core.c)
 target_link_libraries(curry_test PRIVATE curry_core)
 
 add_test(NAME core           COMMAND curry_test)
-add_test(NAME json           COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/json_tests.scm)
-add_test(NAME sqlite         COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sqlite_tests.scm)
-add_test(NAME scheme_r7rs    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/r7rs_tests.scm)
-add_test(NAME scheme_r6rs    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/r6rs_tests.scm)
-add_test(NAME cond_expand    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/cond_expand_tests.scm)
-add_test(NAME srfi_s279_inspect COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s279_inspect_tests.scm)
-add_test(NAME include_relative COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/include_relative_tests.scm)
-add_test(NAME define_library_stack_guard COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/define_library_stack_guard_tests.scm)
-add_test(NAME module_isolation COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/module_isolation_tests.scm)
+add_test(NAME json           COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/json_tests.scm)
+add_test(NAME sqlite         COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sqlite_tests.scm)
+add_test(NAME scheme_r7rs    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/r7rs_tests.scm)
+add_test(NAME scheme_r6rs    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/r6rs_tests.scm)
+add_test(NAME cond_expand    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/cond_expand_tests.scm)
+add_test(NAME srfi_s279_inspect COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s279_inspect_tests.scm)
+add_test(NAME include_relative COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/include_relative_tests.scm)
+add_test(NAME define_library_stack_guard COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/define_library_stack_guard_tests.scm)
+add_test(NAME module_isolation COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/module_isolation_tests.scm)
 set_tests_properties(include_relative PROPERTIES
     ENVIRONMENT "CURRY_MODULE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/fixtures/include_relative")
 
@@ -20,17 +20,17 @@ set_tests_properties(include_relative PROPERTIES
 # directory) differs from the fixture's own directory, exercising the
 # same cwd-independence these fixtures exist to check.
 add_test(NAME load_dir_context_script_relative
-    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/load_dir_context/script_relative_load/main.scm)
+    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/load_dir_context/script_relative_load/main.scm)
 add_test(NAME load_dir_context_exception_safety
-    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/load_dir_context/exception_safety/main.scm)
+    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/load_dir_context/exception_safety/main.scm)
 add_test(NAME load_dir_context_thread_safety
-    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/load_dir_context/thread_safety/main.scm)
-add_test(NAME srfi_1 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_1_tests.scm)
-add_test(NAME srfi_253 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_253_tests.scm)
-add_test(NAME srfi_s26_cut COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s26_cut_tests.scm)
-add_test(NAME srfi_s14_char_sets COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s14_char_sets_tests.scm)
-add_test(NAME numeric_ext    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/numeric_ext_tests.scm)
-add_test(NAME actors         COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/actors_tests.scm)
+    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/load_dir_context/thread_safety/main.scm)
+add_test(NAME srfi_1 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_1_tests.scm)
+add_test(NAME srfi_253 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_253_tests.scm)
+add_test(NAME srfi_s26_cut COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s26_cut_tests.scm)
+add_test(NAME srfi_s14_char_sets COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s14_char_sets_tests.scm)
+add_test(NAME numeric_ext    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/numeric_ext_tests.scm)
+add_test(NAME actors         COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/actors_tests.scm)
 # Rare, non-deterministic hang observed once in CI (Ubuntu Debug, under
 # ctest -j full-suite contention): the 2000-actor spawn/race regression
 # test never returned, but did not reproduce in 9 follow-up attempts
@@ -38,78 +38,78 @@ add_test(NAME actors         COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/actors_te
 # future recurrence into a fast, diagnosable CTest TIMEOUT instead of a
 # silent 15+ minute CI hang.
 set_tests_properties(actors PROPERTIES TIMEOUT 120)
-add_test(NAME dynamic_wind   COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_wind_tests.scm)
-add_test(NAME syntax_rules   COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/syntax_rules_tests.scm)
-add_test(NAME ode            COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/ode_tests.scm)
-add_test(NAME pde_numerical COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/pde_numerical_tests.scm)
-add_test(NAME d_operator    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/d_operator_tests.scm)
-add_test(NAME tuples        COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/tuple_tests.scm)
-add_test(NAME partial       COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/partial_tests.scm)
-add_test(NAME trig              COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/trig_tests.scm)
-add_test(NAME transcendental   COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/transcendental_tests.scm)
-add_test(NAME pde_symbolic     COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/pde_symbolic_tests.scm)
-add_test(NAME sicm              COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sicm_tests.scm)
-add_test(NAME akkadian      COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/akkadian_tests.scm)
-add_test(NAME conditions    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/conditions_tests.scm)
-add_test(NAME numtheory     COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/numtheory_tests.scm)
-add_test(NAME sexagesimal   COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sexagesimal_tests.scm)
-add_test(NAME babylonian_astronomy COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/babylonian_astronomy_tests.scm)
-add_test(NAME sx_rules      COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sx_rules_tests.scm)
-add_test(NAME sx_algebra    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sx_algebra_tests.scm)
-add_test(NAME sx_poly       COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sx_poly_tests.scm)
-add_test(NAME sx_risch      COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sx_risch_tests.scm)
-add_test(NAME logic        COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/logic_tests.scm)
-add_test(NAME aviation_weather COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/aviation_weather_tests.scm)
-add_test(NAME naips COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/naips_tests.scm)
-add_test(NAME base64 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/base64_tests.scm)
-add_test(NAME random       COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/random_tests.scm)
-add_test(NAME sets         COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/set_tests.scm)
-add_test(NAME sets_module  COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sets_module_tests.scm)
-add_test(NAME oop          COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/oop_tests.scm)
-add_test(NAME yaml         COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/yaml_tests.scm)
-add_test(NAME toml         COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/toml_tests.scm)
-add_test(NAME matchable    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/matchable_tests.scm)
-add_test(NAME csv          COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/csv_tests.scm)
-add_test(NAME schematic    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/schematic_tests.scm)
-add_test(NAME graphviz     COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/graphviz_tests.scm)
-add_test(NAME xml          COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/xml_tests.scm)
-add_test(NAME rss          COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/rss_tests.scm)
-add_test(NAME atom         COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/atom_tests.scm)
-add_test(NAME dot_locking  COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/dot_locking_tests.scm)
-add_test(NAME zeromq       COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/zeromq_tests.scm)
-add_test(NAME tts          COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/tts_tests.scm)
+add_test(NAME dynamic_wind   COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_wind_tests.scm)
+add_test(NAME syntax_rules   COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/syntax_rules_tests.scm)
+add_test(NAME ode            COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/ode_tests.scm)
+add_test(NAME pde_numerical COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/pde_numerical_tests.scm)
+add_test(NAME d_operator    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/d_operator_tests.scm)
+add_test(NAME tuples        COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/tuple_tests.scm)
+add_test(NAME partial       COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/partial_tests.scm)
+add_test(NAME trig              COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/trig_tests.scm)
+add_test(NAME transcendental   COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/transcendental_tests.scm)
+add_test(NAME pde_symbolic     COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/pde_symbolic_tests.scm)
+add_test(NAME sicm              COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sicm_tests.scm)
+add_test(NAME akkadian      COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/akkadian_tests.scm)
+add_test(NAME conditions    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/conditions_tests.scm)
+add_test(NAME numtheory     COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/numtheory_tests.scm)
+add_test(NAME sexagesimal   COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sexagesimal_tests.scm)
+add_test(NAME babylonian_astronomy COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/babylonian_astronomy_tests.scm)
+add_test(NAME sx_rules      COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sx_rules_tests.scm)
+add_test(NAME sx_algebra    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sx_algebra_tests.scm)
+add_test(NAME sx_poly       COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sx_poly_tests.scm)
+add_test(NAME sx_risch      COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sx_risch_tests.scm)
+add_test(NAME logic        COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/logic_tests.scm)
+add_test(NAME aviation_weather COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/aviation_weather_tests.scm)
+add_test(NAME naips COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/naips_tests.scm)
+add_test(NAME base64 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/base64_tests.scm)
+add_test(NAME random       COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/random_tests.scm)
+add_test(NAME sets         COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/set_tests.scm)
+add_test(NAME sets_module  COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sets_module_tests.scm)
+add_test(NAME oop          COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/oop_tests.scm)
+add_test(NAME yaml         COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/yaml_tests.scm)
+add_test(NAME toml         COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/toml_tests.scm)
+add_test(NAME matchable    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/matchable_tests.scm)
+add_test(NAME csv          COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/csv_tests.scm)
+add_test(NAME schematic    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/schematic_tests.scm)
+add_test(NAME graphviz     COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/graphviz_tests.scm)
+add_test(NAME xml          COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/xml_tests.scm)
+add_test(NAME rss          COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/rss_tests.scm)
+add_test(NAME atom         COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/atom_tests.scm)
+add_test(NAME dot_locking  COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/dot_locking_tests.scm)
+add_test(NAME zeromq       COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/zeromq_tests.scm)
+add_test(NAME tts          COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/tts_tests.scm)
 if(BUILD_FFI)
   # (curry sql) unconditionally imports (curry mariadb)/(curry postgres),
   # both of which import (curry ffi) -- all three tests need BUILD_FFI=ON
   # to even import, regardless of whether a live MariaDB/PostgreSQL
   # server is reachable (mariadb_tests.scm/postgres_tests.scm test what's
   # possible without one -- see their own headers).
-  add_test(NAME sql          COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/sql_tests.scm)
-  add_test(NAME mariadb      COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/mariadb_tests.scm)
-  add_test(NAME postgres     COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/postgres_tests.scm)
+  add_test(NAME sql          COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sql_tests.scm)
+  add_test(NAME mariadb      COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/mariadb_tests.scm)
+  add_test(NAME postgres     COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/postgres_tests.scm)
 endif()
-add_test(NAME hash_tables_srfi COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/hash_tables_srfi_tests.scm)
-add_test(NAME timespec COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/timespec_tests.scm)
-add_test(NAME srfi_receive_assume_optional COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_receive_assume_optional_tests.scm)
-add_test(NAME srfi_comparators COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_comparators_tests.scm)
-add_test(NAME srfi_hash_tables_125_126 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_hash_tables_125_126_tests.scm)
-add_test(NAME srfi_sorting_vectors COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_sorting_vectors_tests.scm)
-add_test(NAME srfi_sets_bags COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_sets_bags_tests.scm)
-add_test(NAME srfi_generators COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_generators_tests.scm)
-add_test(NAME srfi_threads COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_threads_tests.scm)
-add_test(NAME srfi_misc COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_misc_tests.scm)
-add_test(NAME srfi_numbered_shims COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_numbered_shims_tests.scm)
-add_test(NAME srfi_numbered_shim_hash_family COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_numbered_shim_hash_family_tests.scm)
-add_test(NAME srfi_numbered_shim_comparator_hash COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_numbered_shim_comparator_hash_tests.scm)
-add_test(NAME srfi_srfi_prefixed_shims COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_srfi_prefixed_shims_tests.scm)
-add_test(NAME srfi_s263_prototype_objects COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s263_prototype_objects_tests.scm)
-add_test(NAME srfi_s111_s195_boxes COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s111_s195_boxes_tests.scm)
-add_test(NAME srfi_s252_property_testing COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s252_property_testing_tests.scm)
-add_test(NAME srfi_s209_enums COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s209_enums_tests.scm)
-add_test(NAME srfi_s210_multiple_values COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s210_multiple_values_tests.scm)
-add_test(NAME srfi_s54_cat COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s54_cat_tests.scm)
+add_test(NAME hash_tables_srfi COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/hash_tables_srfi_tests.scm)
+add_test(NAME timespec COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/timespec_tests.scm)
+add_test(NAME srfi_receive_assume_optional COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_receive_assume_optional_tests.scm)
+add_test(NAME srfi_comparators COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_comparators_tests.scm)
+add_test(NAME srfi_hash_tables_125_126 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_hash_tables_125_126_tests.scm)
+add_test(NAME srfi_sorting_vectors COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_sorting_vectors_tests.scm)
+add_test(NAME srfi_sets_bags COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_sets_bags_tests.scm)
+add_test(NAME srfi_generators COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_generators_tests.scm)
+add_test(NAME srfi_threads COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_threads_tests.scm)
+add_test(NAME srfi_misc COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_misc_tests.scm)
+add_test(NAME srfi_numbered_shims COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_numbered_shims_tests.scm)
+add_test(NAME srfi_numbered_shim_hash_family COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_numbered_shim_hash_family_tests.scm)
+add_test(NAME srfi_numbered_shim_comparator_hash COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_numbered_shim_comparator_hash_tests.scm)
+add_test(NAME srfi_srfi_prefixed_shims COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_srfi_prefixed_shims_tests.scm)
+add_test(NAME srfi_s263_prototype_objects COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s263_prototype_objects_tests.scm)
+add_test(NAME srfi_s111_s195_boxes COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s111_s195_boxes_tests.scm)
+add_test(NAME srfi_s252_property_testing COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s252_property_testing_tests.scm)
+add_test(NAME srfi_s209_enums COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s209_enums_tests.scm)
+add_test(NAME srfi_s210_multiple_values COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s210_multiple_values_tests.scm)
+add_test(NAME srfi_s54_cat COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s54_cat_tests.scm)
 if(BUILD_MPFR)
-  add_test(NAME mpfr COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/mpfr_tests.scm)
+  add_test(NAME mpfr COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/mpfr_tests.scm)
 endif()
 add_test(NAME cli
     COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cli.sh
@@ -126,13 +126,13 @@ set_tests_properties(numeric_ext actors ode pde_numerical d_operator tuples part
     ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 
 if(BUILD_MODULE_GIT AND TARGET curry_git)
-    add_test(NAME git COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/test_git.scm)
+    add_test(NAME git COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/test_git.scm)
     set_tests_properties(git PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
 if(TARGET curry_plplot)
-    add_test(NAME plplot COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/test_plplot.scm)
+    add_test(NAME plplot COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/test_plplot.scm)
     set_tests_properties(plplot PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
@@ -166,11 +166,11 @@ if(BUILD_MODULE_LSP AND TARGET curry_lsp)
 endif()
 
 if(BUILD_LLVM)
-    add_test(NAME jit COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/jit_tests.scm)
+    add_test(NAME jit COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/jit_tests.scm)
 endif()
 
 if(BUILD_MODULE_NETWORK AND TARGET curry_network)
-    add_test(NAME network COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/network_tests.scm)
+    add_test(NAME network COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/network_tests.scm)
     set_tests_properties(network PROPERTIES ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
@@ -180,7 +180,7 @@ endif()
 # (s3_tests.scm's own live round-trip section skips cleanly unless
 # CURRY_S3_TEST_ENDPOINT/BUCKET/ACCESS_KEY/SECRET_KEY are all set).
 if(BUILD_MODULE_CRYPTO AND TARGET curry_crypto AND BUILD_MODULE_HTTP AND TARGET curry_http)
-    add_test(NAME s3 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/s3_tests.scm)
+    add_test(NAME s3 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/s3_tests.scm)
     set_tests_properties(s3 PROPERTIES ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
@@ -188,34 +188,34 @@ endif()
 # wrapper (requires BUILD_FFI=ON to compile; libhdf5 itself is a
 # runtime-only dlopen dependency, so hdf5_tests.scm skips cleanly if it's
 # not installed rather than needing a build-time gate here).
-add_test(NAME fits    COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/fits_tests.scm)
-add_test(NAME netcdf  COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/netcdf_tests.scm)
+add_test(NAME fits    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/fits_tests.scm)
+add_test(NAME netcdf  COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/netcdf_tests.scm)
 if(BUILD_FFI)
-    add_test(NAME hdf5 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/hdf5_tests.scm)
+    add_test(NAME hdf5 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/hdf5_tests.scm)
     # (curry ncurses) is the same pure-Scheme-+-FFI shape as hdf5 above:
     # requires BUILD_FFI=ON to compile, dlopens the system ncurses at
     # runtime. ncurses_tests.scm only checks import/constants — no
     # initscr()/newwin(), which need a real controlling terminal.
-    add_test(NAME ncurses COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/ncurses_tests.scm)
+    add_test(NAME ncurses COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/ncurses_tests.scm)
 endif()
 
 if(BUILD_MODULE_PROFILING AND TARGET curry_profiling)
-    add_test(NAME profiling COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/profiling_tests.scm)
+    add_test(NAME profiling COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/profiling_tests.scm)
     set_tests_properties(profiling PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
 if(BUILD_MODULE_POSIX AND TARGET curry_posix)
-    add_test(NAME posix COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/posix_tests.scm)
+    add_test(NAME posix COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/posix_tests.scm)
     set_tests_properties(posix PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
     # (srfi s19 time) imports (curry posix) for current-time.
-    add_test(NAME time_srfi COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/time_srfi_tests.scm)
+    add_test(NAME time_srfi COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/time_srfi_tests.scm)
     set_tests_properties(time_srfi PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
     # (curry okf) imports (curry posix) for directory walking and (srfi 19)
     # for staleness/log timestamps.
-    add_test(NAME okf COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/okf_tests.scm)
+    add_test(NAME okf COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/okf_tests.scm)
     set_tests_properties(okf PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 
@@ -225,36 +225,36 @@ if(BUILD_MODULE_POSIX AND TARGET curry_posix)
     # isolated fixture cache before importing the module, so it never
     # touches the network or the real user cache.
     if(BUILD_MODULE_HTTP AND TARGET curry_http)
-        add_test(NAME airports COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/airports_tests.scm)
+        add_test(NAME airports COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/airports_tests.scm)
         set_tests_properties(airports PROPERTIES
             ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
     endif()
 endif()
 
 if(BUILD_MODULE_CODESETS AND TARGET curry_codesets)
-    add_test(NAME codesets COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/codesets_tests.scm)
+    add_test(NAME codesets COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/codesets_tests.scm)
     set_tests_properties(codesets PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
 if(BUILD_MODULE_RPI AND TARGET curry_rpi)
     # rpi_tests.scm: hardware-free simulation tests + API surface check (Linux)
-    add_test(NAME rpi COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/rpi_tests.scm)
+    add_test(NAME rpi COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/rpi_tests.scm)
     set_tests_properties(rpi PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
     # test_rpi.scm: smoke tests that open real device nodes (skipped if absent)
-    add_test(NAME rpi_hw COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/test_rpi.scm)
+    add_test(NAME rpi_hw COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/test_rpi.scm)
     set_tests_properties(rpi_hw PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
 if(BUILD_MODULE_TYPEDVEC AND TARGET curry_typedvec AND BUILD_MODULE_F64VECTOR AND TARGET curry_f64vector)
     # (srfi 4) imports both (curry typedvec) and (curry f64vector).
-    add_test(NAME typedvec COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/typedvec_tests.scm)
+    add_test(NAME typedvec COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/typedvec_tests.scm)
     set_tests_properties(typedvec PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
     # (srfi 160) builds on (srfi 4) in pure Scheme -- same module dependency.
-    add_test(NAME srfi_160 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/srfi_160_tests.scm)
+    add_test(NAME srfi_160 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_160_tests.scm)
     set_tests_properties(srfi_160 PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
@@ -263,7 +263,7 @@ if(BUILD_MODULE_QT6 AND TARGET curry_qt6)
     # Phase 1 (widget creation) runs immediately; Phase 2 (painter / text
     # metrics) triggers an offscreen render via canvas-save-png!.
     # QT_QPA_PLATFORM=offscreen lets this run in CI without a display.
-    add_test(NAME qt6 COMMAND curry ${CMAKE_CURRENT_SOURCE_DIR}/test_qt6_new.scm)
+    add_test(NAME qt6 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/test_qt6_new.scm)
     set_tests_properties(qt6 PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH};QT_QPA_PLATFORM=offscreen"
         TIMEOUT 30)

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -476,6 +476,32 @@ static void test_ir_optimize_check(void) {
         "(and #t (if #f 1 2))",
         "(or #f (if #t 1 2))",
         "(define x (if #t 10 20))",
+        /* and/or boolean simplification (ir_optimize_andor). */
+        "(and 1 2 3)",
+        "(and #f 1 2)",
+        "(and 1 #f 2)",
+        "(and 1 2 #f)",
+        "(and 1 2 3 'last)",
+        "(or 1 2 3)",
+        "(or #f 1 2)",
+        "(or #f #f 1)",
+        "(or 1 2 3 'last)",
+        "(and #t #t #t)",
+        "(or #f #f #f)",
+        /* a non-last item that only becomes constant AFTER its own
+         * nested fold -- ir_optimize_andor must re-check post-recursion,
+         * not just the item's shape before optimizing it. */
+        "(and (if #t 1 2) 3)",
+        "(or (if #f 1 2) 3)",
+        /* mixed with calls -- the dropped/truncated items are always
+         * literals, but a surviving non-constant item (a call) must
+         * still be reachable and correctly emitted. */
+        "(and 1 (+ 2 3))",
+        "(or #f (+ 2 3))",
+        /* nested and/or -- the outer pass must recurse into an inner
+         * and/or that itself simplifies. */
+        "(and (and 1 2) 3)",
+        "(or (or #f #f) 3)",
     };
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
         val_t port = port_open_input_string(cases[i], (uint32_t)strlen(cases[i]));

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -287,26 +287,32 @@ static void test_ir_self_check(void) {
         "(f 1 2 3)",
         "(+ 1 (* 2 3))",
         "((lambda (x) x) 5)",
-        /* No self-tail-call case here: `let`/named-let (S_LET) is itself
-         * not natively IR-lowered -- classify_head returns SF_LET, not
-         * SF_NONE, so ir_lower wraps the WHOLE named-let form (loop body
-         * included) as one IR_FALLBACK leaf and never recurses into it.
-         * self_tail_name is only ever armed by compile_let, which only
-         * runs on the classic compile() path that IR_FALLBACK's own
-         * ir_emit case delegates to -- ir_lower/ir_lower_call never see
-         * that body at all. IR_CALL's self-tail-call branch in ir_emit
-         * (mirrors compile_call's own guard exactly) is therefore
-         * correct-by-inspection but genuinely UNREACHABLE via this
-         * differential self-check today, and any attempt to write a
-         * named-let test case here would silently test nothing (an
-         * earlier version of this test did exactly that -- caught by
-         * independent code review). Real coverage arrives once named-let
-         * itself gets IR-lowered in a future landing. Manually verified
-         * against the live compile() path instead: `curry -e '(display
-         * (let loop ((i 0) (acc 0)) (if (= i 100000) acc (loop (+ i 1)
-         * (+ acc i)))))'` runs the classic self-tail-call path
-         * correctly (unaffected by this landing, since ir_lower/ir_emit
-         * are still never called from compile()). */
+        /* let / let-star / letrec / letrec-star / named-let -- widened
+         * in the sixth landing. Plain let/let-star/letrec are pure
+         * ir_lower-time desugaring into IR_CALL{callee=IR_LAMBDA{...}}
+         * (see ir_lower_let/ir_lower_let_star/ir_lower_letrec's own
+         * comments); named-let is the one genuinely new IR_NAMED_LET
+         * node kind, and the first thing to give IR_CALL's self-tail-
+         * call branch REAL coverage (previously correct-by-inspection
+         * but unreachable -- an earlier version of this test wrongly
+         * claimed a named-let case tested it, when named-let itself
+         * wasn't IR-lowered yet; caught by independent code review). */
+        "(let ((a 1) (b 2)) (+ a b))",
+        "(let () 42)",
+        "(let* ((a 1) (b (+ a 1)) (c (+ b 1))) c)",
+        "(let* () 'empty)",
+        "(letrec ((even? (lambda (n) (if (= n 0) #t (odd? (- n 1))))) (odd?  (lambda (n) (if (= n 0) #f (even? (- n 1)))))) (even? 10))",
+        "(letrec* ((a 1) (b (+ a 1))) b)",
+        /* named-let: self-tail-call in tail position -- exercises
+         * IR_CALL's OP_SELF_TAIL_CALL branch for real. */
+        "(let loop ((i 0) (acc 0)) (if (= i 5) acc (loop (+ i 1) (+ acc i))))",
+        /* a non-tail self-reference must NOT take the self-tail-call
+         * path (matches compile_call's own `tail &&` guard). */
+        "(let loop ((i 0)) (+ 1 (if (< i 3) (loop (+ i 1)) i)))",
+        /* named-let nested inside a call/if -- mixed with other already-
+         * lowered forms, the exact shape that caught real ordering bugs
+         * in earlier landings. */
+        "(+ 1 (let loop ((i 0)) (if (= i 3) i (loop (+ i 1)))))",
         /* receive/call-with-values with the "wrong" shape for the special
          * form fall through to an ordinary call (classify_head's shaped
          * checks) -- see compile()'s own SF_RECEIVE/SF_CALL_WITH_VALUES

--- a/tests/test_mqtt.sh
+++ b/tests/test_mqtt.sh
@@ -87,7 +87,7 @@ fi
 # observe the disconnect event.  Everything else goes through as normal output.
 
 CURRY_MODULE_PATH="$MOD_PATH" \
-    "$CURRY" "$SCRIPT_DIR/mqtt_tests.scm" \
+    "$CURRY" --clear-cache "$SCRIPT_DIR/mqtt_tests.scm" \
     "$PLAIN_PORT" "$TLS_PORT" "$TLS_CA" "$DISCO_ACTUAL" \
 | while IFS= read -r line; do
     if [ "$line" = "READY" ]; then

--- a/tests/test_redis.sh
+++ b/tests/test_redis.sh
@@ -70,5 +70,5 @@ fi
 
 # ---- Run tests ----
 CURRY_MODULE_PATH="$MOD_PATH" \
-    "$CURRY" "$SCRIPT_DIR/redis_tests.scm" \
+    "$CURRY" --clear-cache "$SCRIPT_DIR/redis_tests.scm" \
     "$PLAIN_PORT" "$TLS_PORT" "$TLS_CA"


### PR DESCRIPTION
## Summary

Follow-up to #63 (merged) — three more commits on `tier2-ir-widen-1`:

- **Tier 2.2: `and`/`or` boolean simplification** (`ir_optimize_andor`) — alongside the already-merged `IR_IF` dead-branch elimination. A non-last constant item that already decides the short-circuit outcome truncates the list there; a non-last constant item that doesn't is spliced out (side-effect-free literal). Confirmed real bytecode shrinkage (e.g. `(or 1 2 3)`: 16→3 bytes), verified via `compiler_ir_optimize_check`.
- **`.scc` cache staleness fix** — found while verifying the `classify_head` refactor (merged in #63) actually held up: `ctest` had been silently validating against pre-session cached bytecode for every Scheme-file test suite (`curry --timings tests/r7rs_tests.scm` showed `cache HIT`), since the `.scc` cache is keyed on source content hash, not compiler version. Fixed by adding `--clear-cache` to all 102 `ctest` `add_test()` invocations plus `test_redis.sh`/`test_mqtt.sh`, and documented the rule in `CLAUDE.md`'s Tests section.
- **Sixth IR landing: `let`/`let*`/`letrec`/`letrec*`/named-let.** Plain let/let*/letrec need no new IR node kind — pure `ir_lower`-time desugaring into the already-verified `IR_CALL{callee=IR_LAMBDA{...}}` shape (letrec reuses `lambda_prescan`'s existing internal-define handling unchanged). Named-let needed one new node, `IR_NAMED_LET`, since its self-tail-call optimization depends on a thread-local side-channel armed at exactly the right moment — giving `IR_CALL`'s self-tail-call branch its first real test coverage (previously correct-by-inspection but unreachable, since named-let fell back whole to `IR_FALLBACK`).

`ir_lower`/`ir_emit`/`ir_optimize` are still **not wired into `compile()`'s live dispatch** — test-only, via `compiler_ir_self_check`/`compiler_ir_optimize_check`.

## Test plan

- [x] Full build clean, no new warnings
- [x] `ctest` — 99/99 passing (now genuinely fresh, not cache-masked)
- [x] `curry_test` — 165/165 assertions (up from 139 in #63), including mutual-recursion `letrec`, both tail/non-tail named-let self-reference cases, and 17 new `and`/`or` optimize-check cases
- [x] Manual smoke tests: 1M-iteration named-let loop, mutual recursion, `let*`
- [x] Independent code review + security review on every landing in this PR (3 separate review passes, one real finding caught and fixed: a stale "unreachable" comment on `IR_CALL`'s self-tail-call branch, now contradicted by named-let's own landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
