### PR TITLE
fix(builtins): force fully flattens delay-force chains of any depth

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2112,21 +2112,56 @@ static val_t prim_fold_right(int ac, val_t *av, void *ud) {
     return apply(proc, scm_cons(vcar(lst), scm_cons(rest, V_NIL)));
 }
 static val_t prim_not(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(vis_false(av[0]));}
+/* Iterative (not recursive) delay-force trampoline -- R7RS 4.2.5 requires
+ * `force` to fully flatten a delay-force chain of ANY depth, not just one
+ * level. The previous version unwrapped exactly one indirection (apply
+ * p's thunk, and if THAT returned a still-lazy delay-force promise q,
+ * collapse p onto q's own thunk and apply ONCE more, returning whatever
+ * that produced -- without checking whether THAT result was itself
+ * another still-lazy delay-force promise). For a chain 3+ levels deep
+ * (p1 -> p2 -> p3 -> value) this returned p3 itself (an unforced
+ * promise) instead of p3's eventual value (confirmed via repro; GitHub
+ * issue #51). Fixed by looping instead of returning after one collapse:
+ * each iteration re-applies p's (possibly just-collapsed) thunk and
+ * re-checks the result, continuing for as many delay-force indirections
+ * as the chain actually has.
+ *
+ * `p->hdr.flags` is copied from `q` on each collapse (not just `p->val`):
+ * once p is standing in for q, whether the NEXT apply's result should
+ * itself be chased as a delay-force indirection depends on whether q was
+ * a delay-force promise, not on p's original flags -- a chain that mixes
+ * delay-force with plain delay would otherwise wrongly keep chasing (or
+ * wrongly stop chasing) past a plain-delay link.
+ *
+ * Checks `p->state == PROMISE_FORCED` after every apply, not just once
+ * up front: a self-referential promise's own thunk can force `p` itself
+ * during evaluation (the classic memoized-lazy-stream pattern) -- if
+ * that happened, respect the memoized value instead of overwriting it
+ * with whatever this call's own apply produced. */
 static val_t prim_force(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
     if (!vis_promise(av[0])) return av[0];
     Promise *p = as_promise(av[0]);
-    if (p->state == PROMISE_FORCED) return p->val;
-    val_t r = apply(p->val, V_NIL);
-    if (p->hdr.flags & 1) { /* delay-force: r should be a promise */
-        if (vis_promise(r)) {
+    while (p->state != PROMISE_FORCED) {
+        val_t r = apply(p->val, V_NIL);
+        if (p->state == PROMISE_FORCED) break;  /* forced during apply */
+        if ((p->hdr.flags & 1) && vis_promise(r)) {
             Promise *q = as_promise(r);
-            if (q->state == PROMISE_FORCED) r = q->val;
-            else { gc_wb_slot(&p->val, q->val); return apply(p->val, V_NIL); }
+            if (q->state == PROMISE_FORCED) {
+                gc_wb_slot(&p->val, q->val);
+                p->state = PROMISE_FORCED;
+                break;
+            }
+            /* q is itself a lazy promise -- collapse p onto q's own
+             * thunk/flags and loop again instead of returning early. */
+            gc_wb_slot(&p->val, q->val);
+            p->hdr.flags = q->hdr.flags;
+            continue;
         }
+        /* r is a final, non-promise (or non-delay-force) value. */
+        gc_wb_slot(&p->val, r);
+        p->state = PROMISE_FORCED;
     }
-    gc_wb_slot(&p->val, r);
-    p->state = PROMISE_FORCED;
     return p->val;
 }
 static val_t prim_make_promise(int ac, val_t *av, void *ud) {

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -888,6 +888,46 @@
 (define p-lazy (make-promise (+ 1 2)))
 (check "force promise" (force p-lazy) 3)
 
+;;; delay-force chains -- GitHub issue #51: force only flattened one
+;;; level of delay-force indirection, leaving a chain 3+ levels deep as
+;;; an unforced inner promise instead of its final value.
+(define dfp3 (delay 42))
+(define dfp2 (delay-force dfp3))
+(define dfp1 (delay-force dfp2))
+(check "delay-force chain, 3 levels" (force dfp1) 42)
+
+(define dfp6 (delay 100))
+(define dfp5 (delay-force dfp6))
+(define dfp4 (delay-force dfp5))
+(define dfp3b (delay-force dfp4))
+(define dfp2b (delay-force dfp3b))
+(define dfp1b (delay-force dfp2b))
+(check "delay-force chain, 6 levels" (force dfp1b) 100)
+(check "delay-force chain memoized on second force" (force dfp1b) 100)
+
+;;; mixed plain delay / delay-force chain
+(define dfq2 (delay 7))
+(define dfq1 (delay-force dfq2))
+(check "mixed delay/delay-force chain" (force dfq1) 7)
+
+;;; the classic delay-force use case: a recursive stream filter, which
+;;; chains delay-force arbitrarily deep as it skips non-matching elements
+(define (df-stream-filter pred s)
+  (delay-force
+    (if (null? (force s))
+        (delay '())
+        (let ((h (car (force s))) (t (cdr (force s))))
+          (if (pred h)
+              (delay (cons h (df-stream-filter pred t)))
+              (df-stream-filter pred t))))))
+(define (df-stream-from n) (delay (cons n (df-stream-from (+ n 1)))))
+(define (df-stream-take s n)
+  (if (= n 0) '()
+      (cons (car (force s)) (df-stream-take (cdr (force s)) (- n 1)))))
+(check "delay-force recursive stream filter"
+  (df-stream-take (df-stream-filter even? (df-stream-from 1)) 5)
+  '(2 4 6 8 10))
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")


### PR DESCRIPTION
Fixes #51.

## Summary

`prim_force`'s `delay-force` trampoline only ever unwrapped one level of indirection: apply the promise's thunk, and if the result was itself a still-lazy `delay-force` promise, collapse onto its thunk and apply once more — returning whatever that produced *directly*, without checking whether it was itself another unforced promise. For a chain 3+ levels deep (`p1 -> p2 -> p3 -> value`), `force` returned `p3` itself (an unforced promise object) instead of chasing through to the final value.

Rewritten as a loop instead of a single conditional collapse-and-return: each iteration applies the promise's (possibly just-collapsed) thunk and re-checks the result, continuing for as many `delay-force` indirections as the chain actually has. Two correctness details fall out of doing this properly rather than just wrapping the old logic in a loop:

- `p`'s `hdr.flags` (the delay-force bit) is copied from the promise being collapsed onto, not left as `p`'s original value — once `p` is standing in for that promise, whether the *next* apply's result should be chased further depends on whether *that* promise was itself delay-force, not on where the chain started. A chain mixing `delay-force` with plain `delay` would otherwise chase (or stop chasing) at the wrong point.
- `p->state` is checked after every apply, not just once up front, so a self-referential promise that memoizes itself during its own thunk's evaluation (the classic lazy-stream pattern) isn't clobbered by this call's own stale result.

## Test plan

- [x] Verified the exact 3-level repro from the issue
- [x] 6-level chain, memoization on repeat `force`, mixed plain-delay/delay-force chain
- [x] The R7RS reference stream-filter pattern that motivated `delay-force` in the first place
- [x] All of the above now in `tests/r7rs_tests.scm` — `delay-force` had zero test coverage before this
- [x] Full test suite passes (99/99 ctest)
- [x] Independent code review + security review (both clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
