### PR TITLE
fix(eval,builtins): call/cc leaks GC shadow stack, gc_inhibit_count, JIT depth

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2269,11 +2269,21 @@ static val_t prim_call_cc(int ac, val_t *av, void *ud) {
     int saved_fc   = vm->frame_count;
     val_t *saved_sp = vm->sp;
     Upvalue *saved_uv = vm->open_upvalues;
+    /* Mirrors SCM_PROTECT's own save/restore triple (eval.h) and
+     * eval_call_cc's identical fix (eval.c) -- see that comment for the
+     * full explanation of why all three (shadow stack, gc_inhibit_count,
+     * g_jit_call_depth) need saving here, not just the shadow stack. */
+    void *saved_shadow = gc_shadow_save();
+    int   saved_inhibit = gc_inhibit_save();
+    int   saved_jit_depth = jit_depth_save();
     if (setjmp(*(jmp_buf *)cont->jmpbuf) != 0) {
         /* Continuation was invoked — restore VM state and return captured value.
          * Volatile cast: clang (ARM64 -O2) folds cont->result to V_VOID without
          * it, because cont->result was V_VOID at setjmp time.  See eval_call_cc
          * comment for the full explanation. */
+        gc_shadow_restore(saved_shadow);
+        gc_inhibit_restore(saved_inhibit);
+        jit_depth_restore(saved_jit_depth);
         vm->frame_count   = saved_fc;
         vm->sp            = saved_sp;
         vm->open_upvalues = saved_uv;

--- a/src/eval.c
+++ b/src/eval.c
@@ -107,7 +107,30 @@ static val_t eval_call_cc(val_t proc) {
     int saved_fc   = vm ? vm->frame_count : 0;
     val_t *saved_sp = vm ? vm->sp : NULL;
     Upvalue *saved_uv = vm ? vm->open_upvalues : NULL;
+    /* Mirrors SCM_PROTECT's own save/restore triple (eval.h) -- a longjmp
+     * back into this frame bypasses every normal-return cleanup between
+     * here and the jump's origin (longjmp restores registers/PC directly,
+     * it doesn't run cleanup attributes or fall through pending restores),
+     * which would otherwise leave all three of these permanently
+     * unbalanced: gc_shadow_stack pointing at expired C stack frames
+     * (matters only under --gc generational), gc_inhibit_count stuck
+     * incremented if the jump crosses a gc_inhibit_minor()/gc_resume_minor()
+     * bracket (e.g. invoking a captured continuation from inside a
+     * primitive like for-each's own C-side dispatch) -- permanently
+     * blocking minor GC on this thread, an unbounded nursery leak, not
+     * just a missed optimization -- and g_jit_call_depth stuck incremented
+     * if the jump crosses a JIT call boundary, permanently downgrading
+     * this closure to the bytecode interpreter for the rest of the
+     * process. Found missing here (only gc_shadow was originally added)
+     * by independent code review after the shadow-stack part of this fix
+     * landed. */
+    void *saved_shadow = gc_shadow_save();
+    int   saved_inhibit = gc_inhibit_save();
+    int   saved_jit_depth = jit_depth_save();
     if (setjmp(*(jmp_buf *)cont->jmpbuf) != 0) {
+        gc_shadow_restore(saved_shadow);
+        gc_inhibit_restore(saved_inhibit);
+        jit_depth_restore(saved_jit_depth);
         if (vm) {
             vm->frame_count   = saved_fc;
             vm->sp            = saved_sp;

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -229,6 +229,45 @@ static void test_continuations(void) {
     CHECK(vis_fixnum(r) && vunfix(r) == 42, "call/cc escape");
 }
 
+/* Regression test for a real gap found by independent code review of the
+ * gc_shadow_save/restore fix (eval_call_cc/prim_call_cc, eval.c/builtins.c):
+ * SCM_PROTECT saves/restores THREE things around its own setjmp/longjmp --
+ * the GC shadow stack, gc_inhibit_count, and g_jit_call_depth -- but the
+ * call/cc capture sites only originally gained the first one. Invoking a
+ * captured continuation from inside a primitive's own gc_inhibit_minor()/
+ * gc_resume_minor() bracket (for-each's C-side dispatch is exactly this
+ * shape) longjmps straight past the pending gc_resume_minor(), permanently
+ * leaking gc_inhibit_count -- under --gc generational this blocks minor GC
+ * on the thread forever (see src/compiler.c's own comment on this exact
+ * failure class for a different call site). Covers both execution paths
+ * that have their own independent call/cc implementation: eval_call_cc
+ * (tree-walker, exercised via run()) and prim_call_cc (compiled VM,
+ * exercised via run_vm()). */
+static void test_call_cc_inhibit_count_balanced(void) {
+    {
+        int before = gc_inhibit_save();
+        val_t r = run(
+            "(call/cc (lambda (k) "
+            " (for-each (lambda (x) (if (= x 3) (k 'done))) (list 1 2 3 4 5))))");
+        int after = gc_inhibit_save();
+        CHECK(r == sym_intern_cstr("done"),
+              "call/cc (tree-walker): escape from inside for-each returns correctly");
+        CHECK(before == after,
+              "call/cc (tree-walker): gc_inhibit_count balanced after escaping from inside for-each");
+    }
+    {
+        int before = gc_inhibit_save();
+        val_t r = run_vm(
+            "(call/cc (lambda (k) "
+            " (for-each (lambda (x) (if (= x 3) (k 'done))) (list 1 2 3 4 5))))");
+        int after = gc_inhibit_save();
+        CHECK(r == sym_intern_cstr("done"),
+              "call/cc (compiled VM): escape from inside for-each returns correctly");
+        CHECK(before == after,
+              "call/cc (compiled VM): gc_inhibit_count balanced after escaping from inside for-each");
+    }
+}
+
 static void test_sets(void) {
     run("(define s (make-set))");
     run("(set-add! s 1) (set-add! s 2) (set-add! s 3)");
@@ -1501,6 +1540,7 @@ int main(void) {
     RUN_TEST(test_tail_calls);
     RUN_TEST(test_closures);
     RUN_TEST(test_continuations);
+    RUN_TEST(test_call_cc_inhibit_count_balanced);
     RUN_TEST(test_sets);
     RUN_TEST(test_hash_tables);
     RUN_TEST(test_records);


### PR DESCRIPTION
## Summary
- Triggered by CodeQL alert #23 (`cpp/using-expired-stack-address`): an independent audit found the specific alert is a false positive (`SCM_PROTECT` already saves/restores the GC shadow stack around its own setjmp/longjmp), but surfaced a real, structurally identical gap on a different path -- `call/cc`.
- Neither `eval_call_cc` (tree-walker) nor `prim_call_cc` (compiled VM) saved/restored the GC shadow stack, `gc_inhibit_count`, or `g_jit_call_depth` around their own `setjmp`. A captured continuation's `longjmp` bypasses `GC_AUTOFRAME`'s cleanup-attribute auto-pop and any pending `gc_resume_minor()`/`jit_depth_pop()` between the capture and invocation sites, permanently leaking all three.
- Confirmed one of these is a real, reachable bug, not just theoretical: temporarily reverting the `gc_inhibit_count` part of the fix made a new regression test fail on the compiled-VM path (invoking a captured continuation from inside `for-each`'s inhibit-bracketed C-side dispatch leaks the inhibit counter forever).
- Fixed by mirroring `SCM_PROTECT`'s existing full save/restore triple in both `call/cc` capture sites.
- Real-world impact is currently limited: the GC shadow stack is only read under the experimental `--gc generational` backend; `gc_inhibit_count` leaking blocks minor GC on the affected thread under that same backend. Matters more once that backend graduates past experimental.

## Test plan
- [x] `ctest --test-dir build` -- 107/107 suites pass, fresh `--clear-cache` run
- [x] `./build/tests/curry_test` -- 332/332 C unit tests pass, including new `test_call_cc_inhibit_count_balanced`
- [x] Manually verified the new test fails without the `gc_inhibit_count` restore (confirms the test is meaningful, not a false-positive-always-passes check)
- [x] Manual stress test: `call/cc` escaping from a loop allocating heavily under `--gc generational --gc-nursery-size 64K` (forces many minor collections between capture and invocation) -- correct result, no crash
- [x] `tests/dynamic_wind_tests.scm` (16 call/cc + dynamic-wind assertions) run under `--gc generational` -- all pass
- [x] Independent code-review and security-review subagent passes on the final diff
