### PR TITLE
feat(compiler): Tier 2.6 Phase A -- interleaved-lowering session API

### DIFF
--- a/docs/thoughts/tier2-6-llvm-ir-retargeting-plan-2026-08-25.md
+++ b/docs/thoughts/tier2-6-llvm-ir-retargeting-plan-2026-08-25.md
@@ -211,4 +211,42 @@ project, not required for the item's own original ask (retarget
   scope-tracking that never needed VM-specific eager resolution, and (b)
   `compiler_ir_lower_for_jit`'s existing one-shot contract is the right
   template for a repeated-call version, not something needing replacement.
-  Not yet started: Phase A implementation.
+
+- **2026-08-25 (same day, later)**: first concrete Phase A step landed
+  (PR #72, branch `tier2-6-ir-session-api`): `compiler_ir_session_new_root`/
+  `new_child`/`lower_next` (`compiler.h`/`compiler.c`), the interleaved
+  lower-then-consume API "Open question 2" above asked for. `Compiler` is
+  now an opaque type in `compiler.h`. Verified concretely (not just by
+  reading comments) that lowering never touches a Compiler's
+  `locals[]`/`upvals[]`/`known[]` — confirmed by independent code review
+  grepping the whole `ir_lower_*` family for those field accesses (zero
+  hits) — so "Open question 1" above is resolved for real: the session
+  reuses the full `Compiler` struct without populating those fields at
+  all, and it's provably safe to do so, not just assumed safe. "Open
+  question 2" (exception-safety across a multi-call session) is also
+  resolved: each `lower_next` call brackets its own
+  `gc_inhibit_minor`/`gc_resume_minor` pair independently rather than
+  holding it open across the session, specifically to avoid the exact
+  leak class PR #71's `call/cc` fix found (an unbalanced inhibit/resume
+  across multiple external calls permanently blocking minor GC). One real
+  bug found by code review and fixed before merge: the session's `name`
+  parameter had no documented lifetime contract despite being embedded in
+  a persisted `IR_LAMBDA` node for named-let forms — now documented
+  matching `compiler_set_source_name`'s existing "must outlive" contract.
+
+  **Still not started**: the actual Phase A table (the `codegen.cpp` side
+  — an `ir_emit`-shaped LLVM dispatcher consuming what this session API
+  produces). "Open question 3" (skip curry's own cp0/wrapper-elision
+  inliner for the LLVM path, let LLVM's own inliner handle it) remains
+  open, unresolved by this landing. Also unstarted, separately: as a
+  side quest this same day, `compiler.c` (5874 lines before any of the
+  above) is being split into `compiler.c`/`compiler_classic.c`/
+  `ir_lower.c`/`ir_emit.c`/`compiler_ir_checks.c` + a new
+  `compiler_internal.h`, purely for readability (matching the existing
+  `eval.c`/`runtime.c`/`runtime_internal.h` precedent) — a separate,
+  parallel effort, not a Tier 2.6 prerequisite per se, but relevant to
+  anyone picking up the actual `codegen.cpp` dispatcher table next: check
+  whether that split landed first and adjust file paths in this plan
+  accordingly (`ir_lower.c`/`ir_emit.c` are where the `ir_lower_*`/
+  `ir_emit` functions this plan keeps referencing by `compiler.c` line
+  number will have moved to, if so).

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5368,6 +5368,124 @@ IRNode *compiler_ir_lower_for_jit(val_t expr, IRArena **out_arena) {
     return result;
 }
 
+/* Tier 2.6 (docs/thoughts/tier2-6-llvm-ir-retargeting-plan-2026-08-25.md,
+ * "Phase A"): compiler_ir_lower_for_jit above lowers exactly one top-level
+ * expression per call, against a throwaway Compiler that never survives
+ * past that single call -- fine for a JIT-eligible chunk's own top-level
+ * src_lambda, but not enough for a consumer (an LLVM codegen dispatcher)
+ * that needs to lower a WHOLE function body, one form at a time,
+ * interleaved with its own per-form consumption -- the same "lower this
+ * form, consume it immediately, THEN lower the next one" contract
+ * ir_emit's own IR_SEQ/IR_LAMBDA cases already rely on (see ir.h's own
+ * comments on IRNode::as.seq and IRNode::as.lambda for why: an internal
+ * define-syntax registered by form i must be visible when form i+1 is
+ * classified, which only holds if lowering happens interleaved with
+ * consumption, never as one eager batch upfront).
+ *
+ * This is genuinely new territory: every other Compiler in this file
+ * lives on one C function's own stack frame for the duration of a single,
+ * synchronous compile call. A session Compiler instead needs to survive
+ * across multiple, separate calls INTO this file from external (C++)
+ * code, so it must be heap-allocated -- gc_alloc_pinned, not GC_MALLOC or
+ * a plain malloc, since Compiler holds live val_t references (chunk,
+ * syntax_locals[].name/transformer, self_tail_name) that need to stay
+ * reachable to Boehm's collector for as long as this session lives, the
+ * same way every other long-lived, GC-participating struct in this
+ * codebase is allocated (see e.g. chunk_new's own gc_alloc_pinned call).
+ * A plain stack Compiler would only be traced by Boehm's conservative
+ * stack scan for the lifetime of ONE C stack frame -- wrong here, since
+ * the session outlives the call that created it. */
+Compiler *compiler_ir_session_new_root(const char *name, IRArena **out_arena) {
+    Compiler *c = CURRY_NEW_PINNED(Compiler);
+    init_compiler(c, NULL, name);
+    *out_arena = c->ir_arena;
+    return c;
+}
+
+/* Child session for a nested lambda body -- mirrors ir_emit's own
+ * IR_LAMBDA case creating a child Compiler for the body it's about to
+ * walk. Shares the parent's arena (init_compiler's own enc != NULL
+ * branch); needs no separate `out_arena` parameter since it's always the
+ * same arena the root session already returned. `enclosing` linkage is
+ * the one thing that actually matters for correctness here even though
+ * this session never populates real locals[]/upvals[] (nothing during
+ * LOWERING reads those -- see this function's own header note below) --
+ * resolve_syntax_local walks ->enclosing to find a macro registered in
+ * an outer scope, so a nested lambda's own body must chain to its
+ * parent's session Compiler to see macros defined above it. */
+Compiler *compiler_ir_session_new_child(Compiler *parent, const char *name) {
+    Compiler *c = CURRY_NEW_PINNED(Compiler);
+    init_compiler(c, parent, name);
+    return c;
+}
+
+/* Lowers ONE form against this session's Compiler, immediately -- the
+ * interleaved half of the "lower this form, consume it immediately" loop
+ * a caller (e.g. an LLVM codegen dispatcher walking IR_SEQ/IR_LAMBDA
+ * bodies) needs to drive itself. `tail` marks whether this form is in
+ * tail position (the last form of a body); `line` is the caller's own
+ * source-line tracking for this form (this function does not read
+ * g_reader_last_line the way compiler_ir_lower_for_jit does, since a
+ * session's forms don't necessarily come from an active read -- an
+ * LLVM-JIT-triggered recompile walks an ALREADY-read val_t body list, see
+ * Chunk's own per-statement line tracking for the shape a caller should
+ * mirror).
+ *
+ * Verified during this landing that lowering itself never actually reads
+ * this Compiler's locals[]/known[]/upvals[]/local_count/chunk fields --
+ * only ->enclosing (macro visibility, resolve_syntax_local) and
+ * ->syntax_locals[] (macro registration/lookup) are ever touched by
+ * ir_lower's own dispatch (classify_head checks resolve_syntax_local,
+ * never resolve_local/resolve_upvalue -- variable/call-site resolution
+ * is entirely an ir_emit-time concern, deferred by design, see ir.h's own
+ * comments on IR_VAR_REF/IR_CALL). This session API deliberately does
+ * NOT populate real locals/upvals for that reason: an LLVM consumer's own
+ * resolution (its own scope-tracking, entirely separate from this
+ * Compiler) is what actually resolves an IR_VAR_REF/IR_CALL once it
+ * consumes the node this function returns, exactly mirroring how
+ * ir_emit's own resolve_local/resolve_upvalue calls are what resolve
+ * those nodes for the VM bytecode backend -- two independent consumers,
+ * two independent resolutions, one shared lowering pass.
+ *
+ * Returns NULL if lowering raises a catchable Scheme condition (malformed
+ * special-form syntax, etc.) -- caught here via SCM_PROTECT so it can
+ * never cross into a C++ caller as a raw longjmp (the same hazard
+ * compiler_ir_lower_for_jit's own header comment describes), converted to
+ * a plain NULL instead, mirroring curry_llvm_jit_compile's existing
+ * "silent failure, fall back to bytecode" philosophy. On NULL, the caller
+ * must abort the whole in-progress session (this function does NOT free
+ * the arena itself on a raise -- earlier forms already lowered through
+ * this same session may still be referenced by the caller, and a session
+ * may have live children sharing the one arena, so freeing here could
+ * invalidate state the caller hasn't finished inspecting yet; the caller
+ * owns exactly when to call ir_arena_free on the arena
+ * compiler_ir_session_new_root returned, same single-owner contract every
+ * other IRArena in this codebase already has). Each call brackets its own
+ * gc_inhibit_minor/gc_resume_minor pair independently, rather than
+ * leaving that bracketing to the caller to hold open across the whole
+ * session -- deliberately, after PR #71's call/cc fix found exactly this
+ * class of bug (a paired inhibit/resume left unbalanced across multiple
+ * external calls into this codebase permanently blocks minor GC on the
+ * thread); a self-contained bracket per call cannot leak that way. */
+IRNode *compiler_ir_session_lower_next(Compiler *c, val_t form, bool tail, int line) {
+    gc_inhibit_minor();
+
+    IRNode *result = NULL;
+    bool    raised = false;
+
+    ExnHandler h;
+    SCM_PROTECT(h, {
+        IRNode *ir = ir_lower(c, form, tail, line);
+        result = ir_optimize(ir);
+    }, {
+        raised = true;
+    });
+
+    gc_resume_minor();
+
+    return raised ? NULL : result;
+}
+
 bool compiler_ir_self_check(val_t expr) {
     gc_inhibit_minor();
 

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -6,6 +6,14 @@
 #include "vm.h"
 #include "ir.h"
 
+/* Opaque -- struct body is private to compiler.c. Exposed only so an
+ * external (e.g. C++ LLVM codegen) caller can hold a session handle
+ * across multiple compiler_ir_session_lower_next calls; see that
+ * function's own comment for the full contract. Never dereferenced
+ * outside compiler.c -- the incomplete type here makes that a compile
+ * error anywhere else, same as any other opaque-pointer C API. */
+typedef struct Compiler Compiler;
+
 /*
  * Compiler — AST (val_t) → bytecode (Chunk / Closure)
  *
@@ -126,5 +134,46 @@ bool compiler_ir_inline_fired_check(val_t expr);
  * lifetime contract every other IRArena in this codebase already has,
  * see ir.h's own header comment). */
 IRNode *compiler_ir_lower_for_jit(val_t expr, IRArena **out_arena);
+
+/* Tier 2.6 Phase A (docs/thoughts/tier2-6-llvm-ir-retargeting-plan-
+ * 2026-08-25.md): an interleaved-lowering session for a caller (an LLVM
+ * codegen dispatcher) that needs to lower a WHOLE function body one form
+ * at a time, immediately consuming each form's IR before lowering the
+ * next -- unlike compiler_ir_lower_for_jit above, which only ever lowers
+ * one single top-level expression per call. See
+ * compiler_ir_session_lower_next's own comment (compiler.c) for the full
+ * contract, including why lowering never needs this session's
+ * locals/upvals to be real, and why each lowering call brackets its own
+ * GC-inhibit pair rather than leaving that open across the session.
+ *
+ *   IRArena *arena;
+ *   Compiler *root = compiler_ir_session_new_root("<jit-fn>", &arena);
+ *   for each top-level form in the function body, in order:
+ *     IRNode *n = compiler_ir_session_lower_next(root, form, is_last, line);
+ *     if (!n) { ir_arena_free(arena); abort this JIT attempt; }
+ *     ... consume `n` immediately (LLVM-emit it) before lowering the next
+ *         form -- required for internal define-syntax registration
+ *         ordering, see compiler_ir_session_lower_next's own comment ...
+ *   // for a nested (lambda ...) form encountered while consuming:
+ *   Compiler *child = compiler_ir_session_new_child(root, "<nested>");
+ *   // ... lower/consume the nested body against `child`, same loop shape ...
+ *   ir_arena_free(arena);  // once the WHOLE top-level function is done,
+ *                          // success or abort -- single owner, same as
+ *                          // every other IRArena in this codebase.
+ *
+ * `name` lifetime (found missing from an earlier version of this comment
+ * by independent code review): stored UNOWNED on the session's Compiler,
+ * exactly the same contract compiler_set_source_name's own comment above
+ * already documents for that similar case -- the string must outlive the
+ * session, since a named-let form lowered through it embeds this same
+ * pointer into a persisted IR_LAMBDA node kept alive in the session's
+ * arena (ir_lower_let/ir_lower_let_star -> ir_lower_lambda). Pass a
+ * literal or a buffer with process lifetime, never a transient stack
+ * buffer or a temporary std::string's c_str() that won't outlive the
+ * call that created it.
+ */
+Compiler *compiler_ir_session_new_root(const char *name, IRArena **out_arena);
+Compiler *compiler_ir_session_new_child(Compiler *parent, const char *name);
+IRNode   *compiler_ir_session_lower_next(Compiler *c, val_t form, bool tail, int line);
 
 #endif /* CURRY_COMPILER_H */

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -1474,6 +1474,97 @@ static void test_compiler_ir_lower_for_jit(void) {
     }
 }
 
+/* Tier 2.6 Phase A groundwork (docs/thoughts/tier2-6-llvm-ir-retargeting-
+ * plan-2026-08-25.md): compiler_ir_session_new_root/new_child/lower_next,
+ * the interleaved-lowering API a future LLVM codegen dispatcher will
+ * drive to lower a whole function body one form at a time. Covers what's
+ * observable from outside compiler.c -- Compiler is now an opaque type
+ * (compiler.h), so this can't reach in and inspect syntax_locals/locals
+ * directly; the one invariant that actually needs ir_emit's own
+ * (private, VM-bytecode-specific) side effects to observe -- an internal
+ * define-syntax registered by form i being visible when form i+1 is
+ * lowered -- is deliberately NOT tested here. It becomes testable once
+ * Phase A's real consumer (codegen.cpp) exists and can be driven
+ * end-to-end through actual JIT compilation of a script with an internal
+ * macro used before... er, after its own definition in the same body. */
+static void test_compiler_ir_session(void) {
+    IRArena *arena = NULL;
+    Compiler *root = compiler_ir_session_new_root("<test-session>", &arena);
+    CHECK(root != NULL, "session: new_root returns a session handle");
+    CHECK(arena != NULL, "session: new_root returns a shared arena");
+
+    /* Sequential lowering of several distinct forms in ONE session --
+     * proves the API supports repeated calls without corrupting shared
+     * state, and that each call's result is independently sane. */
+    {
+        val_t port = port_open_input_string("(+ 1 2)", 7);
+        val_t expr = scm_read(port);
+        int before = gc_inhibit_save();
+        IRNode *ir = compiler_ir_session_lower_next(root, expr, false, 1);
+        int after = gc_inhibit_save();
+        CHECK(ir != NULL, "session: lower_next returns a tree for ordinary input");
+        CHECK(ir && ir->kind == IR_CALL, "session: (+ 1 2) lowers to IR_CALL");
+        CHECK(before == after, "session: gc_inhibit_count balanced after an ordinary lower_next call");
+    }
+    {
+        /* Not (if #t 1 2): ir_optimize's own dead-branch elimination on a
+         * constant test (see ir_optimize's IR_IF case) would fold that
+         * down to a bare IR_CONST before this function returns -- correct
+         * behavior (this session API runs the same lower-then-optimize
+         * pipeline compiler_ir_lower_for_jit does), just not what this
+         * check wants to observe. A non-constant test keeps IR_IF intact. */
+        val_t port = port_open_input_string("(if x 1 2)", 10);
+        val_t expr = scm_read(port);
+        IRNode *ir = compiler_ir_session_lower_next(root, expr, false, 2);
+        CHECK(ir != NULL, "session: second lower_next call in the same session still works");
+        CHECK(ir && ir->kind == IR_IF, "session: (if x 1 2) lowers to IR_IF");
+    }
+    {
+        val_t port = port_open_input_string("(lambda (x) x)", 14);
+        val_t expr = scm_read(port);
+        IRNode *ir = compiler_ir_session_lower_next(root, expr, true, 3);
+        CHECK(ir != NULL, "session: third lower_next call (tail position) still works");
+        CHECK(ir && ir->kind == IR_LAMBDA, "session: (lambda (x) x) lowers to IR_LAMBDA");
+    }
+
+    /* Child session -- mirrors ir_emit's own IR_LAMBDA case creating a
+     * child Compiler for a nested body. Just needs to not crash and
+     * produce sane IR; cross-scope macro visibility isn't observable
+     * from here (see this test's own header comment). */
+    {
+        Compiler *child = compiler_ir_session_new_child(root, "<test-child>");
+        CHECK(child != NULL, "session: new_child returns a session handle");
+        val_t port = port_open_input_string("(* x x)", 7);
+        val_t expr = scm_read(port);
+        IRNode *ir = compiler_ir_session_lower_next(child, expr, false, 4);
+        CHECK(ir != NULL, "session: lower_next works against a child session");
+        CHECK(ir && ir->kind == IR_CALL, "session: (* x x) in a child session lowers to IR_CALL");
+    }
+
+    /* Malformed input mid-session: NULL, gc_inhibit_count still balanced,
+     * and (unlike compiler_ir_lower_for_jit's own one-shot contract) the
+     * arena is NOT freed here -- earlier forms already lowered through
+     * this session may still be referenced by the caller. Verified by
+     * successfully lowering one more well-formed form through the SAME
+     * session afterward. */
+    {
+        val_t port = port_open_input_string("(if)", 4);
+        val_t expr = scm_read(port);
+        int before = gc_inhibit_save();
+        IRNode *ir = compiler_ir_session_lower_next(root, expr, false, 5);
+        int after = gc_inhibit_save();
+        CHECK(ir == NULL, "session: malformed input returns NULL, not a longjmp");
+        CHECK(before == after, "session: gc_inhibit_count balanced after a raise mid-session");
+
+        val_t port2 = port_open_input_string("(- 5 1)", 7);
+        val_t expr2 = scm_read(port2);
+        IRNode *ir2 = compiler_ir_session_lower_next(root, expr2, false, 6);
+        CHECK(ir2 != NULL, "session: the session and its arena survive a raise, still usable afterward");
+    }
+
+    ir_arena_free(arena);
+}
+
 /* Regression test for a real, confirmed, WIDESPREAD bug found by
  * independent code review while landing Tier 2.6 step 1 (not something
  * that landing introduced -- confirmed present on `main` too): every
@@ -1559,6 +1650,7 @@ int main(void) {
     RUN_TEST(test_open_coding_preserves_tco);
     RUN_TEST(test_arithmetic_open_coding);
     RUN_TEST(test_compiler_ir_lower_for_jit);
+    RUN_TEST(test_compiler_ir_session);
     RUN_TEST(test_special_form_arity_crashes);
 
     printf("\n%d passed, %d failed\n", pass, fail);


### PR DESCRIPTION
## Summary
- Tier 2.6 Phase A groundwork (see `docs/thoughts/tier2-6-llvm-ir-retargeting-plan-2026-08-25.md` for the full multi-session plan this is the first concrete step of).
- Adds `compiler_ir_session_new_root`/`new_child`/`lower_next`: an interleaved-lowering API for a future consumer (an LLVM codegen dispatcher) that needs to lower a whole function body one form at a time, immediately consuming each form's IR before lowering the next -- unlike the existing `compiler_ir_lower_for_jit`, which only lowers a single top-level expression per call.
- `Compiler` becomes an opaque type in `compiler.h` (forward-declared only) so this new API can hand out session handles without exposing internal fields to callers outside `compiler.c`.
- Verified lowering itself never reads a session's `locals[]`/`upvals[]`/`known[]` (only `->enclosing` and `->syntax_locals[]` matter for macro visibility) -- variable/call-site resolution is an `ir_emit`-time concern by design, so a future LLVM consumer does its own separate resolution, exactly mirroring how the VM backend's `ir_emit` does its own.
- Each `lower_next` call brackets its own `gc_inhibit_minor`/`gc_resume_minor` pair independently, deliberately avoiding the exact class of bug PR #71 just fixed for `call/cc` (an unbalanced inhibit/resume across multiple external calls permanently blocking minor GC).
- Independent code review found and fixed one real gap: the `name` parameter's lifetime wasn't documented, even though a named-let form lowered through a session embeds that same raw pointer into a persisted IR node -- now documented with the same "literal or process-lifetime buffer" contract `compiler_set_source_name` already uses for the same class of parameter.

## Test plan
- [x] `ctest --test-dir build` -- 107/107 suites pass, fresh `--clear-cache` run
- [x] `./build/tests/curry_test` -- 347/347 C unit tests pass, including new `test_compiler_ir_session`
- [x] Independent code-review and security-review subagent passes on the final diff (one real finding from code review, fixed and re-verified)
