### PR TITLE
feat(network): implement SRFI 106 (Basic Socket Interface)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,10 @@ if(BUILD_MODULE_NETWORK)
   # compiles into the same curry_network.so target.
   target_sources(curry_network PRIVATE modules/network/tls.c)
   target_link_libraries(curry_network PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+  # SRFI 106 (Basic Socket Interface) native primitives -- same
+  # one-file-per-concern pattern as tls.c above, no extra link deps
+  # (plain POSIX sockets only).
+  target_sources(curry_network PRIVATE modules/network/srfi106.c)
 endif()
 
 if(BUILD_MODULE_CRYPTO)

--- a/docs/reference/srfi/index.md
+++ b/docs/reference/srfi/index.md
@@ -43,6 +43,7 @@ The same import-collision caveat as `(srfi N)` above applies identically here (i
 | [`(srfi s69 hash-tables)`](s69-s90.md) | [SRFI-69](https://srfi.schemers.org/srfi-69/) | Basic hash tables — full API, wrapping curry's built-in hash table with corrected `hash-table-ref` semantics |
 | [`(srfi s90 hash-tables)`](s69-s90.md) | [SRFI-90](https://srfi.schemers.org/srfi-90/srfi-90.html) | `make-table`, a keyword-argument hash-table constructor layered on `(srfi s69 hash-tables)` |
 | [`(srfi s98 os-environment-variables)`](s98.md) | [SRFI-98](https://srfi.schemers.org/srfi-98/) | `get-environment-variable(s)` — thin re-export of native builtins |
+| [`(srfi s106 sockets)`](s106.md) | [SRFI-106](https://srfi.schemers.org/srfi-106/) | Basic Socket Interface — native primitives in `(curry network)` (`modules/network/srfi106.c`), requires `-DBUILD_MODULE_NETWORK=ON` (default, always-on) |
 | [`(srfi s111 boxes)`](s111.md) | [SRFI-111](https://srfi.schemers.org/srfi-111/) | Single-slot mutable box — `box`/`box?`/`unbox`/`set-box!` |
 | [`(srfi s112 environment-inquiry)`](s112.md) | [SRFI-112](https://srfi.schemers.org/srfi-112/) | Implementation/OS/machine identity queries — thin re-export of `(curry posix)`, requires `-DBUILD_MODULE_POSIX=ON` (default) |
 | [`(srfi s113 sets-and-bags)`](s113.md) | [SRFI-113](https://srfi.schemers.org/srfi-113/) | Sets — comparator-adapter wrapper over curry's native set; bags — pure-Scheme multiset on a comparator-adapted hash table |

--- a/docs/reference/srfi/s106.md
+++ b/docs/reference/srfi/s106.md
@@ -1,0 +1,71 @@
+# `(srfi s106 sockets)` — SRFI-106
+
+```scheme
+(import (srfi s106 sockets))   ; or (srfi 106) / (srfi srfi-106)
+```
+
+[SRFI-106](https://srfi.schemers.org/srfi-106/): a portable Basic Socket Interface — TCP and UDP, blocking, no TLS. Curry already had a richer, curry-specific networking API (`(curry network)`: `tcp-connect`/`tcp-listen`/`tcp-accept`, `udp-socket`/`-bind`/`-send`/`-recv`, non-blocking mode, and TLS) before this library existed; SRFI-106 support was added as a portability layer for code written against the standard interface, not to replace curry's own richer API — use whichever fits.
+
+The native primitives (all of `make-client-socket` through `socket-output-port`, plus the plain-fixnum named constants) live directly in `modules/network/srfi106.c`, compiled into the same `curry_network` module target as the rest of `(curry network)` — same convention `(curry posix)`/SRFI-170 already uses: the C module defines the spec's own procedure names directly, this library just re-exports them. `address-family`/`address-info`/`socket-domain`/`ip-protocol`/`message-type`/`shutdown-method` and `socket-merge-flags`/`socket-purge-flags` are pure Scheme (`syntax-rules` macros for the six name→constant lookups, ordinary procedures for the two flag combinators).
+
+## Sockets
+
+```scheme
+(make-client-socket node service [family [socktype [ai-flags [protocol]]]])
+(make-server-socket service [family [socktype [protocol]]])
+(socket? obj)
+(socket-accept socket)
+(socket-send socket bv [flags])       ; -> bytes sent
+(socket-recv socket size [flags])     ; -> bytevector
+(socket-shutdown socket how)
+(socket-close socket)
+(socket-input-port socket)
+(socket-output-port socket)
+(call-with-socket socket proc)        ; closes socket on return or error
+```
+
+`service` accepts either a string (service name or numeric port string, passed straight to `getaddrinfo`) or an exact integer (a port number) — SRFI-106 leaves the representation implementation-defined; both are accepted since real portable code in the wild uses either.
+
+```scheme
+(define srv (make-server-socket 8080 (address-family inet) (socket-domain stream)))
+(define client (make-client-socket "127.0.0.1" 8080 (address-family inet) (socket-domain stream)))
+(define conn (socket-accept srv))
+(socket-send client (string->utf8 "hello"))
+(utf8->string (socket-recv conn 16))    ; => "hello"
+```
+
+`socket-input-port`/`socket-output-port` dup the underlying fd, so the original socket handle stays independently usable for `socket-send`/`socket-recv`/`socket-close` after taking a port from it — and the resulting ports interoperate with ordinary port procedures (`read-line`, `write-string`, etc.):
+
+```scheme
+(define out (socket-output-port conn))
+(write-string "a line\n" out)
+(close-port out)   ; NOT socket-close -- see the note below
+```
+
+`socket-close` only accepts a raw socket handle, not a port — closing a port's underlying fd through the wrong primitive would leave that port's own open/closed bookkeeping inconsistent. Close a `socket-input-port`/`socket-output-port` result with `close-port`, same as any other curry port.
+
+## Name → constant macros
+
+```scheme
+(address-family inet)                ; -> *af-inet*
+(socket-domain stream)                ; -> *sock-stream*
+(ip-protocol tcp)                     ; -> *ipproto-tcp*
+(address-info v4mapped all)           ; -> combines independent AI_* bits
+(message-type peek oob)               ; -> combines independent MSG_* bits
+(shutdown-method read write)          ; -> *shut-rdwr*
+```
+
+`address-family`/`socket-domain`/`ip-protocol` each take exactly one name (the underlying value is a single selector, never combined). `address-info`/`message-type` take one or more names and OR them together — safe, since `AI_*`/`MSG_*` are genuinely independent bits on every platform.
+
+`shutdown-method` is the one category that is **not** plain bitwise-or over raw platform values: real POSIX `SHUT_RD`/`SHUT_WR`/`SHUT_RDWR` are `0`/`1`/`2` on every platform checked — not independent bits, so `SHUT_RD | SHUT_WR` (`0 | 1 = 1`) would silently collide with plain `SHUT_WR` instead of producing `SHUT_RDWR` (`2`). `*shut-rd*`/`*shut-wr*`/`*shut-rdwr*` are instead a clean, always-combinable `1`/`2`/`3` encoding, translated back to the real platform constant inside `socket-shutdown` itself.
+
+## Flag combinators
+
+```scheme
+(socket-merge-flags flag ...)              ; bitwise-or all of them
+(socket-purge-flags base-flag flag ...)    ; remove the given bits from base-flag
+```
+
+## Named constants
+
+`*af-unspec*` `*af-inet*` `*af-inet6*` — `*sock-stream*` `*sock-dgram*` — `*ai-canonname*` `*ai-numerichost*` `*ai-v4mapped*` `*ai-all*` `*ai-addrconfig*` — `*ipproto-ip*` `*ipproto-tcp*` `*ipproto-udp*` — `*msg-peek*` `*msg-oob*` `*msg-waitall*` — `*shut-rd*` `*shut-wr*` `*shut-rdwr*`

--- a/lib/curry/modules/srfi/106.scm
+++ b/lib/curry/modules/srfi/106.scm
@@ -1,0 +1,14 @@
+(define-library (srfi 106)
+  (import (srfi s106 sockets))
+  (export
+    make-client-socket make-server-socket socket? socket-accept
+    socket-send socket-recv socket-shutdown socket-close
+    socket-input-port socket-output-port call-with-socket
+    address-family address-info socket-domain ip-protocol
+    message-type shutdown-method socket-merge-flags socket-purge-flags
+    *af-unspec* *af-inet* *af-inet6*
+    *sock-stream* *sock-dgram*
+    *ai-canonname* *ai-numerichost* *ai-v4mapped* *ai-all* *ai-addrconfig*
+    *ipproto-ip* *ipproto-tcp* *ipproto-udp*
+    *msg-peek* *msg-oob* *msg-waitall*
+    *shut-rd* *shut-wr* *shut-rdwr*))

--- a/lib/curry/modules/srfi/s106/sockets.scm
+++ b/lib/curry/modules/srfi/s106/sockets.scm
@@ -1,0 +1,122 @@
+;;; (srfi s106 sockets) -- SRFI 106: Basic Socket Interface
+;;;
+;;; The native primitives (make-client-socket, make-server-socket, socket?,
+;;; socket-accept, socket-send, socket-recv, socket-shutdown, socket-close,
+;;; socket-input-port, socket-output-port) and the plain fixnum constants
+;;; live in modules/network/srfi106.c, registered directly under these
+;;; exact SRFI-106 names -- same convention (curry posix)/SRFI 170 already
+;;; uses (see lib/curry/modules/srfi/s170/posix.scm): the C module defines
+;;; the spec's own procedure names directly, this file just re-exports
+;;; them plus adds the pieces that only make sense as Scheme: call-with-
+;;; socket (a thin dynamic-wind wrapper) and the six name->constant macros
+;;; the spec itself defines (address-family, address-info, socket-domain,
+;;; ip-protocol, message-type, shutdown-method) plus socket-merge-flags/
+;;; socket-purge-flags.
+;;;
+;;; The six macros are pure compile-time symbol->constant lookups with no
+;;; runtime behavior -- syntax-rules with literal identifiers, not a C
+;;; primitive (curry's C module API has no macro-registration story).
+;;; address-family/socket-domain/ip-protocol take exactly one name each
+;;; (the underlying platform value is a single selector, never combined);
+;;; address-info/message-type/shutdown-method take one or more names and
+;;; combine them -- see shutdown-method's own comment below for why that
+;;; combination is NOT simply bitwise-or for every category.
+
+(define-library (srfi s106 sockets)
+  (import (curry network) (scheme base))
+  (export
+    make-client-socket make-server-socket socket? socket-accept
+    socket-send socket-recv socket-shutdown socket-close
+    socket-input-port socket-output-port call-with-socket
+    address-family address-info socket-domain ip-protocol
+    message-type shutdown-method socket-merge-flags socket-purge-flags
+    *af-unspec* *af-inet* *af-inet6*
+    *sock-stream* *sock-dgram*
+    *ai-canonname* *ai-numerichost* *ai-v4mapped* *ai-all* *ai-addrconfig*
+    *ipproto-ip* *ipproto-tcp* *ipproto-udp*
+    *msg-peek* *msg-oob* *msg-waitall*
+    *shut-rd* *shut-wr* *shut-rdwr*)
+  (begin
+
+    ;; Closes `socket` after `proc` returns OR raises -- dynamic-wind's
+    ;; after-thunk runs on both paths, matching call-with-port's own
+    ;; close-on-either-path contract (prim_call_with_port, builtins.c).
+    (define (call-with-socket socket proc)
+      (dynamic-wind
+        (lambda () #f)
+        (lambda () (proc socket))
+        (lambda () (socket-close socket))))
+
+    (define-syntax address-family
+      (syntax-rules (inet inet6 unspec)
+        ((_ inet)   *af-inet*)
+        ((_ inet6)  *af-inet6*)
+        ((_ unspec) *af-unspec*)))
+
+    (define-syntax socket-domain
+      (syntax-rules (stream datagram)
+        ((_ stream)   *sock-stream*)
+        ((_ datagram) *sock-dgram*)))
+
+    (define-syntax ip-protocol
+      (syntax-rules (ip tcp udp)
+        ((_ ip)  *ipproto-ip*)
+        ((_ tcp) *ipproto-tcp*)
+        ((_ udp) *ipproto-udp*)))
+
+    ;; address-info names are genuinely independent getaddrinfo(3) AI_*
+    ;; bits on every platform -- safe to combine with plain bitwise-or.
+    (define-syntax %address-info-1
+      (syntax-rules (canonname numerichost v4mapped all addrconfig)
+        ((_ canonname)   *ai-canonname*)
+        ((_ numerichost) *ai-numerichost*)
+        ((_ v4mapped)    *ai-v4mapped*)
+        ((_ all)         *ai-all*)
+        ((_ addrconfig)  *ai-addrconfig*)))
+    (define-syntax address-info
+      (syntax-rules ()
+        ((_ name)          (%address-info-1 name))
+        ((_ name name* ...) (bitwise-or (%address-info-1 name)
+                                         (address-info name* ...)))))
+
+    ;; message-type names are genuinely independent MSG_* bits too.
+    ;; `none` (0) is SRFI 106's own explicit "no flags" name -- there is
+    ;; no MSG_NONE in POSIX, 0 already means exactly that to send/recv.
+    (define-syntax %message-type-1
+      (syntax-rules (none peek oob wait-all)
+        ((_ none)     0)
+        ((_ peek)     *msg-peek*)
+        ((_ oob)      *msg-oob*)
+        ((_ wait-all) *msg-waitall*)))
+    (define-syntax message-type
+      (syntax-rules ()
+        ((_ name)          (%message-type-1 name))
+        ((_ name name* ...) (bitwise-or (%message-type-1 name)
+                                         (message-type name* ...)))))
+
+    ;; shutdown-method is the one category that is NOT plain bitwise-or
+    ;; over real platform values -- see *shut-rd*/*shut-wr*/*shut-rdwr*'s
+    ;; own comment in srfi106.c (fn_socket_shutdown) for the full
+    ;; reasoning: raw POSIX SHUT_RD/SHUT_WR/SHUT_RDWR (0/1/2 on every
+    ;; platform checked) are not independent bits, so combining them the
+    ;; same way address-info/message-type do would silently produce the
+    ;; wrong value ((shutdown-method read write) via SHUT_RD|SHUT_WR =
+    ;; 0|1 = 1, indistinguishable from plain SHUT_WR). *shut-rd*/*shut-
+    ;; wr*/*shut-rdwr* are instead a clean 2-bit encoding (1/2/3) that DOES
+    ;; combine correctly with bitwise-or, translated back to the real
+    ;; platform constant inside socket-shutdown's own C implementation.
+    (define-syntax %shutdown-method-1
+      (syntax-rules (read write)
+        ((_ read)  *shut-rd*)
+        ((_ write) *shut-wr*)))
+    (define-syntax shutdown-method
+      (syntax-rules ()
+        ((_ name)          (%shutdown-method-1 name))
+        ((_ name name* ...) (bitwise-or (%shutdown-method-1 name)
+                                         (shutdown-method name* ...)))))
+
+    (define (socket-merge-flags . flags)
+      (apply bitwise-or 0 flags))
+
+    (define (socket-purge-flags base-flag . flags)
+      (bitwise-and base-flag (bitwise-not (apply bitwise-or 0 flags))))))

--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -31,9 +31,6 @@
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
 #  pragma comment(lib, "ws2_32.lib")
-typedef SOCKET sock_t;
-#  define SOCK_INVALID INVALID_SOCKET
-#  define sock_close closesocket
 #else
 #  include <sys/socket.h>
 #  include <netinet/in.h>
@@ -42,26 +39,18 @@ typedef SOCKET sock_t;
 #  include <arpa/inet.h>
 #  include <fcntl.h>
 #  include <sys/select.h>
-typedef int sock_t;
-#  define SOCK_INVALID (-1)
-#  define sock_close close
 #endif
 
-static curry_val sock_to_val(sock_t fd) {
-    /* Pack fd into a bytevector */
-    curry_val bv = curry_make_bytevector(sizeof(sock_t), 0);
-    for (size_t i = 0; i < sizeof(sock_t); i++)
-        curry_bytevector_set(bv, (uint32_t)i, ((uint8_t *)&fd)[i]);
-    return curry_make_pair(curry_make_symbol("socket"), bv);
-}
-
-static sock_t val_to_sock(curry_val v) {
-    curry_val bv = curry_cdr(v);
-    sock_t fd;
-    for (size_t i = 0; i < sizeof(sock_t); i++)
-        ((uint8_t *)&fd)[i] = curry_bytevector_ref(bv, (uint32_t)i);
-    return fd;
-}
+/* sock_t/SOCK_INVALID/sock_close and the raw-socket-handle pack/unpack
+ * helpers (net_sock_to_val/net_val_to_sock/net_is_raw_socket_handle/
+ * net_extract_fd) now live in network_internal.h, shared with srfi106.c
+ * (the SRFI-106 socket interface, added alongside it) -- see that
+ * header's own comment. Local aliases kept here (rather than rewriting
+ * every call site below) purely to minimize this diff; srfi106.c uses
+ * the net_-prefixed names directly. */
+#include "network_internal.h"
+#define sock_to_val net_sock_to_val
+#define val_to_sock net_val_to_sock
 
 static curry_val fn_tcp_connect(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
@@ -89,10 +78,26 @@ static curry_val fn_tcp_connect(int ac, curry_val *av, void *ud) {
      * `-> port-pair (in-port . out-port)` contract. */
     int wfd = dup((int)fd);
     if (wfd < 0) { sock_close(fd); curry_error("tcp-connect: dup failed"); }
-    curry_val in_port  = curry_make_port_from_fd((int)fd, false, false);
+    /* curry_make_port_from_fd takes ownership of its fd ONLY on success;
+     * on fdopen failure it returns a falsy value without taking
+     * ownership at all (curry.h's own documented contract), so each of
+     * these must close its own fd explicitly on failure rather than
+     * leaking it -- found missing here by independent code review of
+     * the identical pattern in srfi106.c's socket-input-port/-output-
+     * port. Once in_port has been successfully created it owns `fd`
+     * (its own finalizer/close-port will close it), so a later out_port
+     * failure must only close `wfd`, never `fd` again. */
+    curry_val in_port = curry_make_port_from_fd((int)fd, false, false);
+    if (!curry_is_true(in_port)) {
+        sock_close(fd);
+        sock_close(wfd);
+        curry_error("tcp-connect: fdopen failed (in-port)");
+    }
     curry_val out_port = curry_make_port_from_fd(wfd, true, false);
-    if (!curry_is_true(in_port) || !curry_is_true(out_port))
-        curry_error("tcp-connect: fdopen failed");
+    if (!curry_is_true(out_port)) {
+        sock_close(wfd);
+        curry_error("tcp-connect: fdopen failed (out-port)");
+    }
     return curry_make_pair(in_port, out_port);
 }
 
@@ -131,13 +136,21 @@ static curry_val fn_tcp_accept(int ac, curry_val *av, void *ud) {
     sock_t client = accept((int)server, (struct sockaddr *)&addr, &addrlen);
     if (client == SOCK_INVALID) curry_error("tcp-accept: accept failed");
 
-    /* Port pair, same rationale as fn_tcp_connect. */
+    /* Port pair, same rationale (and same fd-leak-on-fdopen-failure fix)
+     * as fn_tcp_connect above. */
     int wfd = dup((int)client);
     if (wfd < 0) { sock_close(client); curry_error("tcp-accept: dup failed"); }
-    curry_val in_port  = curry_make_port_from_fd((int)client, false, false);
+    curry_val in_port = curry_make_port_from_fd((int)client, false, false);
+    if (!curry_is_true(in_port)) {
+        sock_close(client);
+        sock_close(wfd);
+        curry_error("tcp-accept: fdopen failed (in-port)");
+    }
     curry_val out_port = curry_make_port_from_fd(wfd, true, false);
-    if (!curry_is_true(in_port) || !curry_is_true(out_port))
-        curry_error("tcp-accept: fdopen failed");
+    if (!curry_is_true(out_port)) {
+        sock_close(wfd);
+        curry_error("tcp-accept: fdopen failed (out-port)");
+    }
     return curry_make_pair(in_port, out_port);
 }
 
@@ -227,19 +240,10 @@ static curry_val fn_udp_recv(int ac, curry_val *av, void *ud) {
 }
 
 /* socket-ready?/socket-set-nonblocking! accept either a raw socket handle
- * (tcp-listen's/udp-socket's return) or a port (tcp-connect's/tcp-accept's
- * in-port or out-port) -- extract_fd dispatches on which it got. */
-static bool is_raw_socket_handle(curry_val v) {
-    return curry_is_pair(v) && curry_is_symbol(curry_car(v)) &&
-           strcmp(curry_symbol(curry_car(v)), "socket") == 0;
-}
-
-static int extract_fd(curry_val v, const char *who) {
-    if (is_raw_socket_handle(v)) return (int)val_to_sock(v);
-    int fd = curry_port_fd(v);
-    if (fd < 0) curry_error("%s: not a socket handle or file-backed port", who);
-    return fd;
-}
+ * (tcp-listen's/udp-socket's/SRFI-106 socket's return) or a port
+ * (tcp-connect's/tcp-accept's in-port or out-port) -- net_extract_fd
+ * (network_internal.h) dispatches on which it got. */
+#define extract_fd net_extract_fd
 
 static curry_val fn_socket_set_nonblocking(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
@@ -274,6 +278,14 @@ static curry_val fn_socket_ready_p(int ac, curry_val *av, void *ud) {
  * TLS code's OpenSSL includes/link stay isolated in their own file. */
 void curry_tls_module_init(CurryVM *vm);
 
+/* Defined in srfi106.c, compiled into this same module target -- SRFI 106
+ * (Basic Socket Interface) native primitives, built on the exact same
+ * raw-socket-handle representation this file uses (network_internal.h).
+ * Same "separate file, own init function" pattern as curry_tls_module_init
+ * above, for the same reason: keeps the larger, more self-contained
+ * SRFI-106 surface out of this file. */
+void curry_srfi106_module_init(CurryVM *vm);
+
 void curry_module_init(CurryVM *vm) {
     curry_define_fn(vm, "tcp-connect", fn_tcp_connect, 2, 2, NULL);
     curry_define_fn(vm, "tcp-listen",  fn_tcp_listen,  1, 2, NULL);
@@ -286,4 +298,5 @@ void curry_module_init(CurryVM *vm) {
     curry_define_fn(vm, "socket-set-nonblocking!", fn_socket_set_nonblocking, 1, 1, NULL);
     curry_define_fn(vm, "socket-ready?", fn_socket_ready_p, 1, 2, NULL);
     curry_tls_module_init(vm);
+    curry_srfi106_module_init(vm);
 }

--- a/modules/network/network_internal.h
+++ b/modules/network/network_internal.h
@@ -1,0 +1,68 @@
+/*
+ * network_internal.h — shared "raw socket handle" representation for the
+ * curry_network module target (network.c, srfi106.c; NOT tls.c, which
+ * never touches raw handles directly).
+ *
+ * A raw socket handle (as opposed to a port -- see tcp-connect's own
+ * comment in network.c) is `(socket . bytevector-packed-fd)`: the fd is
+ * packed byte-for-byte into a bytevector rather than exposed as a
+ * fixnum, so it can never be mistaken for -- or forged as -- an ordinary
+ * integer at the Scheme level. Moved here (out of network.c, where these
+ * were originally static/file-private) so srfi106.c can share the exact
+ * same pack/unpack logic instead of duplicating it -- header-only
+ * `static inline` rather than a shared .c translation unit, since these
+ * are all one-liners and this avoids any new link-time surface for a
+ * module that's otherwise a flat set of independent .c files compiled
+ * into one target.
+ */
+
+#ifndef CURRY_NETWORK_INTERNAL_H
+#define CURRY_NETWORK_INTERNAL_H
+
+#include <curry.h>
+#include <string.h>
+
+#ifdef _WIN32
+#  include <winsock2.h>
+typedef SOCKET sock_t;
+#  define SOCK_INVALID INVALID_SOCKET
+#  define sock_close closesocket
+#else
+#  include <unistd.h>
+typedef int sock_t;
+#  define SOCK_INVALID (-1)
+#  define sock_close close
+#endif
+
+static inline curry_val net_sock_to_val(sock_t fd) {
+    curry_val bv = curry_make_bytevector(sizeof(sock_t), 0);
+    for (size_t i = 0; i < sizeof(sock_t); i++)
+        curry_bytevector_set(bv, (uint32_t)i, ((uint8_t *)&fd)[i]);
+    return curry_make_pair(curry_make_symbol("socket"), bv);
+}
+
+static inline sock_t net_val_to_sock(curry_val v) {
+    curry_val bv = curry_cdr(v);
+    sock_t fd;
+    for (size_t i = 0; i < sizeof(sock_t); i++)
+        ((uint8_t *)&fd)[i] = curry_bytevector_ref(bv, (uint32_t)i);
+    return fd;
+}
+
+static inline bool net_is_raw_socket_handle(curry_val v) {
+    return curry_is_pair(v) && curry_is_symbol(curry_car(v)) &&
+           strcmp(curry_symbol(curry_car(v)), "socket") == 0;
+}
+
+/* Accepts either a raw socket handle (tcp-listen's/udp-socket's/SRFI-106
+ * make-client-socket's/make-server-socket's/socket-accept's return) or a
+ * port (tcp-connect's/tcp-accept's in-port or out-port) -- extract_fd
+ * dispatches on which it got. */
+static inline int net_extract_fd(curry_val v, const char *who) {
+    if (net_is_raw_socket_handle(v)) return (int)net_val_to_sock(v);
+    int fd = curry_port_fd(v);
+    if (fd < 0) curry_error("%s: not a socket handle or file-backed port", who);
+    return fd;
+}
+
+#endif /* CURRY_NETWORK_INTERNAL_H */

--- a/modules/network/srfi106.c
+++ b/modules/network/srfi106.c
@@ -1,0 +1,342 @@
+/*
+ * srfi106.c — SRFI 106 (Basic Socket Interface) native primitives.
+ *
+ * Compiled into the same curry_network.so target as network.c/tls.c (see
+ * network.c's own curry_srfi106_module_init comment) -- built on the
+ * exact same raw-socket-handle representation network.c already
+ * established (network_internal.h): `(socket . bytevector-packed-fd)`.
+ *
+ * Scheme API (registered directly under these SRFI-106-spec names, same
+ * convention (curry posix)/SRFI-170 already uses -- the C module defines
+ * the spec's own names directly; the (srfi s106 sockets)/(srfi 106)
+ * library files just import-and-re-export, no renaming layer needed):
+ *
+ *   (make-client-socket node service [family [socktype [ai-flags [protocol]]]])
+ *     -> socket
+ *   (make-server-socket service [family [socktype [protocol]]]) -> socket
+ *   (socket? obj) -> bool
+ *   (socket-accept socket) -> socket
+ *   (socket-send socket bv [flags]) -> bytes-sent (fixnum)
+ *   (socket-recv socket size [flags]) -> bytevector
+ *   (socket-shutdown socket how) -> void
+ *   (socket-close socket) -> void
+ *   (socket-input-port socket) -> port
+ *   (socket-output-port socket) -> port
+ *
+ * `service` (make-client-socket/make-server-socket) accepts either a
+ * string (a service name or numeric port string, passed straight to
+ * getaddrinfo) or a fixnum (a port number, converted to its decimal
+ * string form first) -- SRFI 106 leaves the representation
+ * implementation-defined; supporting both matches what real portable
+ * code in the wild actually passes (chibi/gauche both accept a fixnum
+ * port too, not just a string).
+ *
+ * `how` (socket-shutdown) is NOT a raw platform SHUT_RD/SHUT_WR/
+ * SHUT_RDWR value -- see the shutdown-method constants below for why.
+ *
+ * The (address-family ...)/(address-info ...)/(socket-domain ...)/
+ * (ip-protocol ...)/(message-type ...)/(shutdown-method ...) macros
+ * SRFI 106 itself specifies live in the Scheme shim (srfi/s106/sockets.scm),
+ * not here -- they're pure compile-time name->constant lookups with no
+ * runtime behavior of their own, syntax-rules is the natural fit, and
+ * curry's C module API has no macro-registration story (DEF-registered
+ * primitives are always ordinary procedures).
+ */
+
+#include <curry.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#ifdef _WIN32
+/* struct addrinfo/getaddrinfo/freeaddrinfo/AI_* /IPPROTO_* /etc. below are
+ * declared in ws2tcpip.h, not winsock2.h (network_internal.h's own
+ * _WIN32 branch only pulls in the latter, for sock_t/SOCK_INVALID/
+ * sock_close) -- mirrors network.c's own identical include, which needs
+ * the exact same symbols for its own getaddrinfo calls. */
+#  include <ws2tcpip.h>
+#else
+#  include <sys/socket.h>
+#  include <netinet/in.h>
+#  include <netdb.h>
+#  include <unistd.h>
+#  include <arpa/inet.h>
+#endif
+
+#include "network_internal.h"
+
+/* 20 digits (the largest magnitude a signed 64-bit long can print) + 1
+ * sign + 1 NUL, rounded up. See service_to_cstr's own comment for why
+ * this needs to cover more than just a 16-bit port number. */
+#define SERVICE_BUF_SIZE 24
+
+/* service: fixnum port number or a string (service name / numeric port
+ * string) -- normalizes to the C string getaddrinfo wants. `buf` must be
+ * at least SERVICE_BUF_SIZE bytes -- curry_fixnum is a signed ~61-bit
+ * value (val_t's 2-bit tag leaves that much magnitude, see value.h), not
+ * a 32-bit int, so its decimal form needs up to 20 digits plus a sign and
+ * NUL; a 16-byte buffer (an earlier version of this function, found
+ * undersized by independent code review) silently truncated the most
+ * extreme fixnum values instead of overflowing -- snprintf itself never
+ * writes past `buflen`, so this was never a memory-safety bug, but a
+ * truncated port number is still a real correctness bug: getaddrinfo
+ * would reject the truncated string as an unresolvable service, an
+ * opaque failure with no hint that the real cause was a buffer that was
+ * simply too small. Returns a pointer to either `buf` or the original
+ * Scheme string's own GC-heap bytes (curry_string's usual "pointer into
+ * the GC heap" contract -- valid as long as the underlying curry_val
+ * stays reachable, which it does for the duration of this call, all on
+ * the C stack). */
+static const char *service_to_cstr(curry_val service, char *buf, size_t buflen) {
+    if (curry_is_fixnum(service)) {
+        snprintf(buf, buflen, "%ld", (long)curry_fixnum(service));
+        return buf;
+    }
+    if (curry_is_string(service)) return curry_string(service);
+    curry_error("service must be a string or an exact integer");
+    return NULL; /* unreachable -- curry_error longjmps */
+}
+
+static curry_val fn_make_client_socket(int ac, curry_val *av, void *ud) {
+    (void)ud;
+    const char *node = curry_string(av[0]);
+    char service_buf[SERVICE_BUF_SIZE];
+    const char *service = service_to_cstr(av[1], service_buf, sizeof(service_buf));
+
+    struct addrinfo hints = {0}, *res;
+    hints.ai_family   = ac > 2 ? (int)curry_fixnum(av[2]) : AF_UNSPEC;
+    hints.ai_socktype = ac > 3 ? (int)curry_fixnum(av[3]) : SOCK_STREAM;
+    hints.ai_flags    = ac > 4 ? (int)curry_fixnum(av[4]) : 0;
+    hints.ai_protocol = ac > 5 ? (int)curry_fixnum(av[5]) : 0;
+
+    if (getaddrinfo(node, service, &hints, &res) != 0)
+        curry_error("make-client-socket: could not resolve %s", node);
+
+    sock_t fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (fd == SOCK_INVALID) {
+        freeaddrinfo(res);
+        curry_error("make-client-socket: socket failed");
+    }
+    if (connect((int)fd, res->ai_addr, (socklen_t)res->ai_addrlen) != 0) {
+        sock_close(fd);
+        freeaddrinfo(res);
+        curry_error("make-client-socket: connect failed");
+    }
+    freeaddrinfo(res);
+    return net_sock_to_val(fd);
+}
+
+static curry_val fn_make_server_socket(int ac, curry_val *av, void *ud) {
+    (void)ud;
+    char service_buf[SERVICE_BUF_SIZE];
+    const char *service = service_to_cstr(av[0], service_buf, sizeof(service_buf));
+
+    struct addrinfo hints = {0}, *res;
+    hints.ai_family   = ac > 1 ? (int)curry_fixnum(av[1]) : AF_UNSPEC;
+    hints.ai_socktype = ac > 2 ? (int)curry_fixnum(av[2]) : SOCK_STREAM;
+    hints.ai_flags    = AI_PASSIVE;
+    hints.ai_protocol = ac > 3 ? (int)curry_fixnum(av[3]) : 0;
+
+    if (getaddrinfo(NULL, service, &hints, &res) != 0)
+        curry_error("make-server-socket: could not resolve service %s", service);
+
+    sock_t fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (fd == SOCK_INVALID) {
+        freeaddrinfo(res);
+        curry_error("make-server-socket: socket failed");
+    }
+    int optval = 1;
+    setsockopt((int)fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+    if (bind((int)fd, res->ai_addr, (socklen_t)res->ai_addrlen) != 0) {
+        sock_close(fd);
+        freeaddrinfo(res);
+        curry_error("make-server-socket: bind failed");
+    }
+    /* Only a stream socket is listen()able -- a datagram server socket is
+     * ready to recv immediately after bind. */
+    if (hints.ai_socktype == SOCK_STREAM && listen((int)fd, 128) != 0) {
+        sock_close(fd);
+        freeaddrinfo(res);
+        curry_error("make-server-socket: listen failed");
+    }
+    freeaddrinfo(res);
+    return net_sock_to_val(fd);
+}
+
+static curry_val fn_socket_p(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    return curry_make_bool(net_is_raw_socket_handle(av[0]));
+}
+
+static curry_val fn_socket_accept(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    int server = net_extract_fd(av[0], "socket-accept");
+    struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
+    sock_t client = accept(server, (struct sockaddr *)&addr, &addrlen);
+    if (client == SOCK_INVALID) curry_error("socket-accept: accept failed");
+    return net_sock_to_val(client);
+}
+
+static curry_val fn_socket_send(int ac, curry_val *av, void *ud) {
+    (void)ud;
+    int fd = net_extract_fd(av[0], "socket-send");
+    uint32_t len = curry_bytevector_length(av[1]);
+    const uint8_t *data = curry_bytevector_data(av[1]);
+    int flags = ac > 2 ? (int)curry_fixnum(av[2]) : 0;
+    ssize_t sent = send(fd, data, len, flags);
+    if (sent < 0) curry_error("socket-send: send failed: %s", strerror(errno));
+    return curry_make_fixnum(sent);
+}
+
+static curry_val fn_socket_recv(int ac, curry_val *av, void *ud) {
+    (void)ud;
+    int fd = net_extract_fd(av[0], "socket-recv");
+    intptr_t size = curry_fixnum(av[1]);
+    if (size <= 0) curry_error("socket-recv: size must be a positive exact integer");
+    int flags = ac > 2 ? (int)curry_fixnum(av[2]) : 0;
+
+    uint8_t *buf = malloc((size_t)size);
+    if (!buf) curry_error("socket-recv: out of memory");
+    ssize_t n = recv(fd, buf, (size_t)size, flags);
+    if (n < 0) { free(buf); curry_error("socket-recv: recv failed: %s", strerror(errno)); }
+
+    curry_val bv = curry_make_bytevector((uint32_t)n, 0);
+    for (ssize_t i = 0; i < n; i++) curry_bytevector_set(bv, (uint32_t)i, buf[i]);
+    free(buf);
+    return bv;
+}
+
+/* `how` is a synthetic bitmask (1 = read, 2 = write, 3 = both -- see the
+ * *shut-rd* / *shut-wr* / *shut-rdwr* constants below), NOT a raw platform
+ * SHUT_RD/SHUT_WR/SHUT_RDWR value. Real POSIX SHUT_* values (0, 1, 2 on
+ * every platform checked) are NOT independent bits -- SHUT_RD | SHUT_WR
+ * (0 | 1 = 1) would silently collide with plain SHUT_WR instead of
+ * producing SHUT_RDWR (2), which is exactly the shape SRFI 106's own
+ * `(shutdown-method read write)` needs to combine cleanly the same way
+ * `(message-type peek oob)` already does for genuinely independent MSG_*
+ * bits. Translating a clean, always-combinable 2-bit encoding into the
+ * real platform constant here (rather than exposing raw SHUT_* values to
+ * Scheme and hoping the merge macro's plain bitwise-or never gets used
+ * against them) keeps the combining logic uniform across all of SRFI
+ * 106's flag categories instead of carving out a silent special case for
+ * this one. */
+static curry_val fn_socket_shutdown(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    int fd = net_extract_fd(av[0], "socket-shutdown");
+    intptr_t how = curry_fixnum(av[1]);
+    int real_how;
+    switch (how) {
+        case 1: real_how = SHUT_RD;   break;
+        case 2: real_how = SHUT_WR;   break;
+        case 3: real_how = SHUT_RDWR; break;
+        default:
+            curry_error("socket-shutdown: how must be *shut-rd*, *shut-wr*, or *shut-rdwr*");
+            return curry_void(); /* unreachable */
+    }
+    if (shutdown(fd, real_how) != 0)
+        curry_error("socket-shutdown: shutdown failed: %s", strerror(errno));
+    return curry_void();
+}
+
+static curry_val fn_socket_close(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    /* Only meaningful for a raw handle -- a socket obtained via
+     * socket-input-port/-output-port is an ordinary port and should be
+     * closed with close-port instead, same as tcp-connect's own port
+     * pairs (see network.c's header comment). Mirrors extract_fd's own
+     * "accepts either shape" flexibility elsewhere in this module, but
+     * closing a port's underlying fd out from under it here (rather than
+     * through close-port) would leave that port's own internal
+     * open/closed bookkeeping wrong -- so this one deliberately does NOT
+     * accept a port, only a raw handle. */
+    if (!net_is_raw_socket_handle(av[0]))
+        curry_error("socket-close: not a socket (did you mean close-port, for a socket-input-port/socket-output-port result?)");
+    sock_close(net_val_to_sock(av[0]));
+    return curry_void();
+}
+
+/* Duplicates the fd for each port (same rationale as tcp-connect's own
+ * in-port/out-port pair, network.c: two independent FILE* streams over
+ * dup()'d fds, not one bidirectional stream, since a Curry port is
+ * one-directional) -- so socket-input-port and socket-output-port can
+ * both be called on the same socket and used independently, and the
+ * original socket handle is left untouched (still valid for socket-send/
+ * socket-recv/socket-close) rather than consumed by either call. */
+static curry_val fn_socket_input_port(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    int fd = net_extract_fd(av[0], "socket-input-port");
+    int dfd = dup(fd);
+    if (dfd < 0) curry_error("socket-input-port: dup failed");
+    curry_val port = curry_make_port_from_fd(dfd, false, false);
+    /* curry_make_port_from_fd takes ownership of dfd ONLY on success
+     * (closing it via fclose when the port is later closed/finalized);
+     * on fdopen failure it returns a falsy value without having taken
+     * ownership at all, per its own documented contract (curry.h) --
+     * found missing here by independent code review: without this
+     * explicit close, dfd (a real, just-dup()'d fd) leaked on every
+     * fdopen failure, worsening the exact fd-exhaustion condition most
+     * likely to CAUSE that failure in the first place. */
+    if (!curry_is_true(port)) {
+        sock_close((sock_t)dfd);
+        curry_error("socket-input-port: fdopen failed");
+    }
+    return port;
+}
+
+static curry_val fn_socket_output_port(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    int fd = net_extract_fd(av[0], "socket-output-port");
+    int dfd = dup(fd);
+    if (dfd < 0) curry_error("socket-output-port: dup failed");
+    curry_val port = curry_make_port_from_fd(dfd, true, false);
+    /* See fn_socket_input_port's own comment on this exact check. */
+    if (!curry_is_true(port)) {
+        sock_close((sock_t)dfd);
+        curry_error("socket-output-port: fdopen failed");
+    }
+    return port;
+}
+
+void curry_srfi106_module_init(CurryVM *vm) {
+    curry_define_fn(vm, "make-client-socket", fn_make_client_socket, 2, 6, NULL);
+    curry_define_fn(vm, "make-server-socket", fn_make_server_socket, 1, 4, NULL);
+    curry_define_fn(vm, "socket?",             fn_socket_p,          1, 1, NULL);
+    curry_define_fn(vm, "socket-accept",       fn_socket_accept,     1, 1, NULL);
+    curry_define_fn(vm, "socket-send",         fn_socket_send,       2, 3, NULL);
+    curry_define_fn(vm, "socket-recv",         fn_socket_recv,       2, 3, NULL);
+    curry_define_fn(vm, "socket-shutdown",     fn_socket_shutdown,   2, 2, NULL);
+    curry_define_fn(vm, "socket-close",        fn_socket_close,      1, 1, NULL);
+    curry_define_fn(vm, "socket-input-port",   fn_socket_input_port, 1, 1, NULL);
+    curry_define_fn(vm, "socket-output-port",  fn_socket_output_port,1, 1, NULL);
+
+    /* Named constants (SRFI 106's own *earmuffs* naming). Plain fixnums
+     * wrapping the real platform values, EXCEPT *shut-rd* / *shut-wr* /
+     * *shut-rdwr* -- see fn_socket_shutdown's own comment for why those
+     * three are a synthetic, always-combinable encoding instead. */
+    curry_define_val(vm, "*af-unspec*", curry_make_fixnum(AF_UNSPEC));
+    curry_define_val(vm, "*af-inet*",   curry_make_fixnum(AF_INET));
+    curry_define_val(vm, "*af-inet6*",  curry_make_fixnum(AF_INET6));
+
+    curry_define_val(vm, "*sock-stream*", curry_make_fixnum(SOCK_STREAM));
+    curry_define_val(vm, "*sock-dgram*",  curry_make_fixnum(SOCK_DGRAM));
+
+    curry_define_val(vm, "*ai-canonname*",  curry_make_fixnum(AI_CANONNAME));
+    curry_define_val(vm, "*ai-numerichost*", curry_make_fixnum(AI_NUMERICHOST));
+    curry_define_val(vm, "*ai-v4mapped*",   curry_make_fixnum(AI_V4MAPPED));
+    curry_define_val(vm, "*ai-all*",        curry_make_fixnum(AI_ALL));
+    curry_define_val(vm, "*ai-addrconfig*", curry_make_fixnum(AI_ADDRCONFIG));
+
+    curry_define_val(vm, "*ipproto-ip*",  curry_make_fixnum(IPPROTO_IP));
+    curry_define_val(vm, "*ipproto-tcp*", curry_make_fixnum(IPPROTO_TCP));
+    curry_define_val(vm, "*ipproto-udp*", curry_make_fixnum(IPPROTO_UDP));
+
+    curry_define_val(vm, "*msg-peek*",    curry_make_fixnum(MSG_PEEK));
+    curry_define_val(vm, "*msg-oob*",     curry_make_fixnum(MSG_OOB));
+    curry_define_val(vm, "*msg-waitall*", curry_make_fixnum(MSG_WAITALL));
+
+    curry_define_val(vm, "*shut-rd*",   curry_make_fixnum(1));
+    curry_define_val(vm, "*shut-wr*",   curry_make_fixnum(2));
+    curry_define_val(vm, "*shut-rdwr*", curry_make_fixnum(3));
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,6 +173,8 @@ endif()
 if(BUILD_MODULE_NETWORK AND TARGET curry_network)
     add_test(NAME network COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/network_tests.scm)
     set_tests_properties(network PROPERTIES ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+    add_test(NAME srfi_106 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_106_tests.scm)
+    set_tests_properties(srfi_106 PROPERTIES ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
 # (curry s3) imports (curry crypto) for HMAC-SHA256/SHA-256 and

--- a/tests/srfi_106_tests.scm
+++ b/tests/srfi_106_tests.scm
@@ -1,0 +1,222 @@
+;;; Tests for (srfi 106) -- Basic Socket Interface.
+;;;
+;;; Native primitives live in modules/network/srfi106.c, built on the
+;;; same raw-socket-handle representation (curry network) already uses
+;;; for tcp-listen/udp-socket (network_internal.h). Covers: real TCP
+;;; round trips (both raw socket-send/recv AND port-based socket-input-
+;;; port/socket-output-port), UDP via make-client-socket/make-server-
+;;; socket with (socket-domain datagram), the six name->constant macros
+;;; (address-family/address-info/socket-domain/ip-protocol/message-type/
+;;; shutdown-method), socket-merge-flags/socket-purge-flags, and
+;;; call-with-socket's close-on-error guarantee.
+;;;
+;;; shutdown-method gets its own dedicated correctness check (not just a
+;;; smoke test) because it's the one flag category that is NOT plain
+;;; bitwise-or over raw platform values -- see srfi106.c's own comment
+;;; on *shut-rd*/*shut-wr*/*shut-rdwr* for why combining raw POSIX
+;;; SHUT_RD/SHUT_WR (0/1 on every platform checked, not independent
+;;; bits) the same way address-info/message-type combine their own
+;;; genuinely-independent AI_*/MSG_* bits would silently produce the
+;;; wrong value.
+
+(import (srfi 106) (scheme base) (scheme write))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label result expected)
+  (if (equal? result expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " got ") (write result)
+             (display " expected ") (write expected)
+             (newline)
+             (set! fail (+ fail 1)))))
+
+(define (check-true label result)
+  (check label (if result #t #f) #t))
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 1  name->constant macros
+;;; ════════════════════════════════════════════════════════════
+
+(check "address-family inet"  (address-family inet)  *af-inet*)
+(check "address-family inet6" (address-family inet6) *af-inet6*)
+(check "address-family unspec" (address-family unspec) *af-unspec*)
+
+(check "socket-domain stream"   (socket-domain stream)   *sock-stream*)
+(check "socket-domain datagram" (socket-domain datagram) *sock-dgram*)
+
+(check "ip-protocol tcp" (ip-protocol tcp) *ipproto-tcp*)
+(check "ip-protocol udp" (ip-protocol udp) *ipproto-udp*)
+
+(check "address-info single name" (address-info canonname) *ai-canonname*)
+(check "address-info combines independent bits"
+  (address-info v4mapped all)
+  (bitwise-or *ai-v4mapped* *ai-all*))
+
+(check "message-type none is zero" (message-type none) 0)
+(check "message-type combines independent bits"
+  (message-type peek oob)
+  (bitwise-or *msg-peek* *msg-oob*))
+
+;;; The correctness-critical case: read+write must equal *shut-rdwr*
+;;; exactly, NOT (bitwise-or *shut-rd* *shut-wr*) computed against raw
+;;; platform SHUT_RD/SHUT_WR values, which would silently collide.
+(check "shutdown-method read alone"  (shutdown-method read)  *shut-rd*)
+(check "shutdown-method write alone" (shutdown-method write) *shut-wr*)
+(check "shutdown-method read+write is genuinely *shut-rdwr*, not a collision"
+  (shutdown-method read write)
+  *shut-rdwr*)
+(check "shutdown-method read+write distinct from write alone"
+  (not (= (shutdown-method read write) (shutdown-method write)))
+  #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 2  socket-merge-flags / socket-purge-flags
+;;; ════════════════════════════════════════════════════════════
+
+(check "merge-flags ors independent flags"
+  (socket-merge-flags *msg-peek* *msg-oob*)
+  (bitwise-or *msg-peek* *msg-oob*))
+(check "merge-flags of one flag is itself"
+  (socket-merge-flags *msg-peek*)
+  *msg-peek*)
+(check "purge-flags removes exactly the given bits"
+  (socket-purge-flags (socket-merge-flags *msg-peek* *msg-oob*) *msg-oob*)
+  *msg-peek*)
+(check "purge-flags is a no-op when the flag wasn't present"
+  (socket-purge-flags *msg-peek* *msg-oob*)
+  *msg-peek*)
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 3  socket? predicate
+;;; ════════════════════════════════════════════════════════════
+
+(check "socket? false for non-socket values" (socket? 42) #f)
+(check "socket? false for an ordinary string" (socket? "not a socket") #f)
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 4  TCP round trip -- raw socket-send/socket-recv
+;;; ════════════════════════════════════════════════════════════
+
+(define tcp-port 18601)
+(define srv (make-server-socket tcp-port (address-family inet) (socket-domain stream)))
+(check-true "make-server-socket returns a socket" (socket? srv))
+
+(define client (make-client-socket "127.0.0.1" tcp-port
+                                    (address-family inet) (socket-domain stream)))
+(check-true "make-client-socket returns a socket" (socket? client))
+
+(define conn (socket-accept srv))
+(check-true "socket-accept returns a socket" (socket? conn))
+
+(define sent (socket-send client (string->utf8 "hello")))
+(check "socket-send returns the byte count sent" sent 5)
+(check "socket-recv receives exactly what was sent"
+  (utf8->string (socket-recv conn 16))
+  "hello")
+
+;;; Reply the other direction on the same connection.
+(socket-send conn (string->utf8 "world"))
+(check "socket-recv works in both directions on the same connection"
+  (utf8->string (socket-recv client 16))
+  "world")
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 5  TCP round trip -- port-based I/O via socket-input-port/
+;;; socket-output-port (must interoperate with ordinary port procedures)
+;;; ════════════════════════════════════════════════════════════
+
+(define conn-out (socket-output-port conn))
+(write-string "line one\n" conn-out)
+(close-port conn-out)
+
+(define client-in (socket-input-port client))
+(check "socket-input-port interoperates with read-line"
+  (read-line client-in)
+  "line one")
+(close-port client-in)
+
+;;; The underlying socket handle itself must still be independently
+;;; usable after taking a port from it -- socket-input-port/
+;;; socket-output-port dup the fd rather than consuming the handle.
+(socket-send conn (string->utf8 "still alive"))
+(check "the socket handle is still usable after socket-input-port"
+  (utf8->string (socket-recv client 32))
+  "still alive")
+
+(socket-shutdown conn (shutdown-method read write))
+(socket-close conn)
+(socket-close client)
+(socket-close srv)
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 6  UDP round trip -- (socket-domain datagram)
+;;; ════════════════════════════════════════════════════════════
+
+(define udp-port 18602)
+(define udp-srv (make-server-socket udp-port (address-family inet) (socket-domain datagram)))
+(define udp-client (make-client-socket "127.0.0.1" udp-port
+                                        (address-family inet) (socket-domain datagram)))
+(socket-send udp-client (string->utf8 "udp ping"))
+(check "UDP round trip via make-client-socket/make-server-socket"
+  (utf8->string (socket-recv udp-srv 32))
+  "udp ping")
+(socket-close udp-client)
+(socket-close udp-srv)
+
+;;; ════════════════════════════════════════════════════════════
+;;; § 7  call-with-socket -- closes on normal return AND on error
+;;; ════════════════════════════════════════════════════════════
+
+(define cws-port 18603)
+(define cws-srv (make-server-socket cws-port (address-family inet) (socket-domain stream)))
+
+(define normal-result
+  (call-with-socket
+    (make-client-socket "127.0.0.1" cws-port (address-family inet) (socket-domain stream))
+    (lambda (s) (socket-send s (string->utf8 "x")) 'normal-return)))
+(check "call-with-socket returns the thunk's own value" normal-result 'normal-return)
+
+(define accepted1 (socket-accept cws-srv))
+(socket-recv accepted1 16)
+(socket-close accepted1)
+
+;;; The socket call-with-socket closed above must now be genuinely
+;;; unusable -- socket-send on an already-closed fd raises rather than
+;;; silently succeeding.
+(define error-raised #f)
+(define cws-client2
+  (make-client-socket "127.0.0.1" cws-port (address-family inet) (socket-domain stream)))
+(guard (e (#t (set! error-raised #t)))
+  (call-with-socket cws-client2
+    (lambda (s) (error "deliberate error inside call-with-socket"))))
+(check "call-with-socket's thunk error propagates" error-raised #t)
+
+;;; And the socket must have been closed by the after-thunk despite the
+;;; error -- socket-send on an already-closed fd must now fail, proving
+;;; close-on-error actually ran. (NOT a second socket-close: this
+;;; codebase's own tcp-close, same convention socket-close follows,
+;;; never checks close()'s return value either, so double-close is not
+;;; guaranteed to raise -- POSIX close() on an already-closed fd is
+;;; EBADF on most platforms but that's not a contract this module makes
+;;; anywhere else, so asserting on it here would test an incidental
+;;; platform detail instead of the actual guarantee that matters.)
+(define send-after-close-raised #f)
+(guard (e (#t (set! send-after-close-raised #t)))
+  (socket-send cws-client2 (string->utf8 "should fail, socket is closed")))
+(check "call-with-socket closed the socket even though the thunk raised"
+  send-after-close-raised #t)
+
+(define accepted2 (socket-accept cws-srv))
+(socket-close accepted2)
+(socket-close cws-srv)
+
+;;; Summary
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary
- Implements SRFI 106 (Basic Socket Interface) as a portability layer on top of curry's existing, richer `(curry network)` module (which already covers TCP/UDP/TLS/non-blocking -- a strict superset of SRFI 106's blocking-only TCP/UDP scope).
- Native primitives (`make-client-socket`, `make-server-socket`, `socket-accept`, `socket-send`/`-recv`, `socket-shutdown`, `socket-close`, `socket-input-port`/`-output-port`) live in a new `modules/network/srfi106.c`, sharing the existing raw-socket-handle representation via a new `modules/network/network_internal.h` (extracted from `network.c`, which previously kept these helpers as file-private statics).
- The six SRFI-specified name->constant macros (`address-family`, `address-info`, `socket-domain`, `ip-protocol`, `message-type`, `shutdown-method`) and the two flag combinators (`socket-merge-flags`, `socket-purge-flags`) live in the Scheme shim (`lib/curry/modules/srfi/s106/sockets.scm`).
- `shutdown-method` needed real design attention: raw POSIX `SHUT_RD`/`SHUT_WR`/`SHUT_RDWR` (`0`/`1`/`2`) are not independent bits, so combining them the way `address-info`/`message-type` combine their own genuinely-independent flags would silently produce the wrong value. Uses a clean `1`/`2`/`3` encoding instead, translated to the real platform constant inside `socket-shutdown`'s own C code -- with a dedicated regression test.
- Independent code review found and fixed three real bugs: an fd leak on `fdopen` failure in `socket-input-port`/`-output-port` (same pre-existing gap found and fixed in `network.c`'s own `tcp-connect`/`tcp-accept` too), an undersized buffer in the port-number-to-string helper (truncated curry's actual ~61-bit fixnum range, not just 32-bit), and a missing Windows include that would have broken cross-platform compilation.

## Test plan
- [x] `ctest --test-dir build` -- 108/108 suites pass, fresh `--clear-cache` run (new `srfi_106` suite: 33 assertions)
- [x] `./build/tests/curry_test` -- 347/347 C unit tests pass (unchanged)
- [x] Manual end-to-end smoke tests: TCP round trip via raw `socket-send`/`socket-recv`, TCP round trip via `socket-input-port`/`socket-output-port` interoperating with `read-line`/`write-string`, UDP round trip via `(socket-domain datagram)`
- [x] Independent code-review and security-review subagent passes on the final diff (three findings from code review, all fixed and re-verified; security review found no new attack surface)
