### PR TITLE
feat(gillespie): add (curry gillespie) stochastic cell-biochemistry module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Documentation is split into two directories:
 - [macOS app bundler](docs/guides/make-macos-app.md) — bundle any Curry script as a `.app` with Qt frameworks embedded
 - [Monitoring guide](docs/guides/guide-monitoring.md) — using `(gc-stats)`, running the Grafana stack (Docker and Apple Containers), customizing dashboards, publishing custom metrics
 - [Text-to-speech with Piper](docs/guides/tts-piper.md) — building `libpiper` and curry against it on macOS/Linux, speaking/saving audio via `(curry tts)`, sourcing and adding voice models
+- [Simulating cell biochemistry with Gillespie](docs/guides/gillespie-cells.md) — stochastic reaction networks, composable temperature/pH/nutrient-sensitive rate laws, multi-cell simulation via actors
 - [Benchmarking reference](docs/reference/benchmarking.md) — bench suites, MQTT event schema, all GC stat fields
 - [Profiling reference](docs/reference/profiling.md) — `**eval-profiler**`, `(curry profiling)` API, `,profile` REPL command, timing workflows
 

--- a/docs/guides/gillespie-cells.md
+++ b/docs/guides/gillespie-cells.md
@@ -1,0 +1,172 @@
+# Simulating cell biochemistry with the Gillespie algorithm
+
+This guide walks through `(curry gillespie)` by building up a real toy
+example — a gene that flips on and off — from nothing, then makes it
+sensitive to temperature, then runs several of them at once as competing
+curry actors.
+
+For the field-level reference — every procedure, every combinator — see
+[`docs/reference/module-gillespie.md`](../reference/module-gillespie.md).
+This guide is the narrative version.
+
+---
+
+## Why not just solve an ODE?
+
+If you've done any chemical-kinetics modeling before, your instinct is
+probably a system of ODEs: `d[A]/dt = k₁ − k₂[A]`. That's the right tool
+when molecule counts are large enough that concentration is meaningfully
+continuous. Inside a real cell, a gene often has a handful of mRNA copies,
+sometimes zero, sometimes three — "concentration" isn't a continuous
+quantity there, it's a small integer that jumps around randomly. The
+Gillespie algorithm simulates those individual random jumps directly,
+rather than averaging them into a smooth curve that hides the noise —
+noise that's often the actual biologically interesting part (this is
+literally why real gene expression looks "bursty" under a microscope).
+
+## Part 1: A birth-death process
+
+The simplest possible example: molecules of `A` are produced at a constant
+rate, and each existing molecule of `A` independently degrades at some
+rate. This is the "hello world" of stochastic simulation, and it has a
+known analytical answer to check your simulation against: at steady state,
+the expected count is `(production rate) / (degradation rate per molecule)`.
+
+```scheme
+(import (curry gillespie))
+
+(define birth (make-reaction "birth" '() (list (cons 'A 1))
+                              (mass-action 5.0 '())))
+(define death (make-reaction "death" (list (cons 'A 1)) '()
+                              (mass-action 0.1 (list (cons 'A 1)))))
+
+(define env  (make-environment 310.0 7.0 0))
+(define cell (make-cell (make-species (list (cons 'A 0))) (list birth death) env 0))
+
+(gillespie-run! cell 200.0)
+(species-count (cell-species cell) 'A)
+; => somewhere around 50 (= 5.0 / 0.1), different every run
+```
+
+Run this a few times — you'll get a different number each time, scattered
+around 50. That's the point: this is a genuine random process, not a
+deterministic calculation with noise sprinkled on top.
+
+`make-reaction` takes reactants and products as `(species . stoichiometry)`
+alists — `'()` for "nothing consumed"/"nothing produced" (a zero-order
+birth reaction, or a pure degradation with no product). `mass-action`
+builds the standard rate law: `k` times the reactant count (or the
+combinatorial term `C(n, stoichiometry)` for a reaction that needs more
+than one molecule of the same species).
+
+## Part 2: A gene that flips on and off
+
+A slightly more interesting toy: a gene switches between an "off" state
+and an "on" state, and only produces protein while on.
+
+```scheme
+(define switch-on  (make-reaction "switch-on"  (list (cons 'gene-off 1)) (list (cons 'gene-on 1))
+                                   (mass-action 0.1 (list (cons 'gene-off 1)))))
+(define switch-off (make-reaction "switch-off" (list (cons 'gene-on 1))  (list (cons 'gene-off 1))
+                                   (mass-action 0.1 (list (cons 'gene-on 1)))))
+(define transcribe  (make-reaction "transcribe" (list (cons 'gene-on 1)) (list (cons 'gene-on 1) (cons 'protein 1))
+                                    (mass-action 2.0 (list (cons 'gene-on 1)))))
+(define degrade      (make-reaction "degrade" (list (cons 'protein 1)) '()
+                                     (mass-action 0.05 (list (cons 'protein 1)))))
+
+(define species (make-species (list (cons 'gene-off 1) (cons 'gene-on 0) (cons 'protein 0))))
+(define cell (make-cell species (list switch-on switch-off transcribe degrade)
+                         (make-environment 310.0 7.0 0) 0))
+
+(define trajectory (cell-trajectory cell 500.0 5.0))
+```
+
+`transcribe` is written so the gene isn't consumed by producing protein —
+`gene-on` appears in both its reactants and its products (stoichiometry 1
+on each side), which is exactly how you represent "this reaction needs `X`
+to be present as a catalyst/enabling condition, but doesn't use it up."
+
+`cell-trajectory` runs the simulation and records a full snapshot of every
+species every 5 time units, returning a list of
+`(time . ((species . count) ...))` — feed that straight to a plotting
+routine, or (see Part 4) a live Qt canvas.
+
+## Part 3: Making it temperature-sensitive
+
+Real transcription rates depend on temperature. Wrap the `transcribe`
+reaction's rate law with `arrhenius`, and compose it with `mass-action`
+via `rate*`:
+
+```scheme
+(define transcribe-hot
+  (make-reaction "transcribe" (list (cons 'gene-on 1)) (list (cons 'gene-on 1) (cons 'protein 1))
+                 (rate* (mass-action 2.0 (list (cons 'gene-on 1)))
+                        (arrhenius 1.0 5000.0))))
+```
+
+Now the exact same reaction slows down as you cool the environment:
+
+```scheme
+(define env (make-environment 310.0 7.0 0))
+((reaction-propensity transcribe-hot) species env)          ; warmer
+(set-environment-temperature! env 250.0)
+((reaction-propensity transcribe-hot) species env)          ; noticeably slower
+```
+
+This is the whole composability story: `rate*` just multiplies whatever
+propensity procedures you give it together. Want it pH-sensitive too? Add
+`(hill environment-ph 7.0 1.0)` to the `rate*` call. Want it to saturate
+as a shared nutrient pool depletes? Add `(michaelis-menten vmax km
+'glucose)`. None of these interact specially with each other — they're
+just numbers being multiplied.
+
+## Part 4: Several cells at once, as actors
+
+`(curry gillespie)` has no separate "multi-cell" API, because curry
+already has one: actors.
+
+```scheme
+(define (run-one-cell reporter)
+  (let* ((species (make-species (list (cons 'gene-off 1) (cons 'gene-on 0) (cons 'protein 0))))
+         (cell (make-cell species (list switch-on switch-off transcribe degrade)
+                           (make-environment 310.0 7.0 0) 0)))
+    (gillespie-run! cell 500.0)
+    (send! reporter (species-count (cell-species cell) 'protein))))
+
+(define reporter (self))
+(for-each (lambda (_) (spawn run-one-cell reporter)) (iota 20))
+
+(let loop ((i 0) (results '()))
+  (if (= i 20)
+      results
+      (loop (+ i 1) (cons (receive) results))))
+```
+
+Twenty independent cells, each running its own Gillespie simulation on its
+own OS thread, reporting back through an ordinary actor mailbox — no new
+concurrency primitive, no locking code you had to write yourself.
+
+If those cells need to **share** something — one common nutrient pool they
+all compete for — don't mutate a shared `<environment>` directly from
+multiple actors; that's an unprotected data race the same as it would be
+in any language. Wrap the shared mutable state in curry's software
+transactional memory (`(curry stm)`) instead, so a cell's uptake reaction
+decrements the pool atomically:
+
+```scheme
+(import (curry stm))
+;; sketch -- see docs/reference/concurrency.md for the full STM API
+(define shared-nutrients (make-tvar 1000))
+```
+
+## Where to go from here
+
+- The [reference doc](../reference/module-gillespie.md) covers every
+  procedure and combinator in full, including the exact combinatorial
+  formula `mass-action` uses for multi-molecule reactions.
+- [`docs/thoughts/gillespie-cell-model.md`](../thoughts/gillespie-cell-model.md)
+  sketches importing real published models from
+  [BioModels](https://www.ebi.ac.uk/biomodels/) via SBML, and composing
+  this module with a toy population-genetics model where a cell's genome
+  *is* its own vector of reaction rate constants — evolution as literally
+  "which rate-constant vectors survive."

--- a/docs/reference/module-gillespie.md
+++ b/docs/reference/module-gillespie.md
@@ -1,0 +1,238 @@
+# Module: (curry gillespie)
+
+*unreleased*
+
+Stochastic simulation of cell biochemistry via the Gillespie algorithm (SSA):
+a set of chemical species undergoing reactions, modeled as a continuous-time
+Markov chain rather than a system of smooth ODEs. This matters because real
+gene expression is noisy at low molecule counts — a handful of mRNA copies,
+not a continuous concentration — and the Gillespie algorithm simulates
+individual random reaction events instead of averaging them away.
+
+Pure Scheme, no C extension. See
+[`docs/thoughts/gillespie-cell-model.md`](../thoughts/gillespie-cell-model.md)
+for the design rationale, an SBML-import idea, and how this composes with a
+(currently unimplemented) toy population-genetics model.
+
+## Import
+
+```scheme
+(import (curry gillespie))
+```
+
+## The core mechanism
+
+Each reaction has a *propensity*: a probability-per-unit-time that it fires
+next, given the current state. At each simulation step:
+
+1. Sum every reaction's current propensity → `a0`
+2. Draw an exponentially-distributed waiting time, `τ = -ln(random-real)/a0`
+3. Pick which reaction fires, weighted by its own share of `a0`
+4. Apply it (decrement reactant counts, increment product counts), advance
+   time by `τ`, repeat
+
+A propensity is just an ordinary procedure `(species environment) ->
+nonnegative-real` — there's no separate mini-language for reaction kinetics.
+That's also the entire mechanism behind environment sensitivity: temperature,
+pH, and nutrient level aren't bolted on afterward, they're ordinary inputs a
+propensity procedure is free to read.
+
+## Reactions
+
+### `(make-reaction name reactants products propensity)` → reaction
+
+- `reactants`, `products` — alists of `(species-symbol . stoichiometry)`,
+  e.g. `(list (cons 'A 2))` for two molecules of `A`
+- `propensity` — a procedure `(species environment) -> nonnegative-real`,
+  typically built from the combinators below rather than written by hand
+
+### `(reaction? v)`, `(reaction-name r)`, `(reaction-reactants r)`, `(reaction-products r)`, `(reaction-propensity r)`
+
+Accessors.
+
+## Environment
+
+### `(make-environment temperature ph nutrients)` → environment
+
+Three fields: `temperature` (Kelvin), `ph` (dimensionless), `nutrients` (a
+plain number — meant to double as an extra pool a reaction's propensity
+reads and an uptake reaction depletes, the same way any other species would
+be, just kept separate from the species table for convenience). Want more
+environment axes? Fold them into the species table itself instead (e.g.
+"oxygen" as an ordinary species) rather than extending this record.
+
+### `(environment-temperature e)`, `(set-environment-temperature! e v)`
+### `(environment-ph e)`, `(set-environment-ph! e v)`
+### `(environment-nutrients e)`, `(set-environment-nutrients! e v)`
+
+Accessors/mutators. Mutating an environment shared by multiple cells (see
+[Notes](#notes)) affects every cell reading it on their next propensity
+evaluation — there's no snapshot/versioning, it's a plain mutable record.
+
+## Species tables
+
+A species table is a plain hash-table (`symbol -> count`); these helpers
+just wrap `hash-table-ref`/`hash-table-set!` with a `0` default so a species
+that's never been touched reads as absent-but-zero rather than an error.
+
+### `(make-species alist)` → species table
+
+```scheme
+(make-species (list (cons 'A 10) (cons 'B 0)))
+```
+
+### `(species-count species key)` → integer
+
+Defaults to `0` for a key that was never set.
+
+### `(set-species-count! species key n)`
+### `(adjust-species! species key delta)`
+
+`adjust-species!` is `set-species-count!` composed with a `+`; used
+internally by reaction application, exported since it's equally useful for
+setting up a simulation's initial perturbations by hand.
+
+## Cells
+
+### `(make-cell species reactions environment time)` → cell
+
+`species` a species table, `reactions` a list of `<reaction>`, `environment`
+an `<environment>`, `time` the starting simulation time (almost always `0`).
+
+### `(cell? v)`, `(cell-species c)`, `(cell-reactions c)`, `(cell-environment c)`, `(cell-time c)`, `(set-cell-time! c t)`
+
+Accessors. `cell-species` returns the live, mutable hash-table — reactions
+mutate it in place as the simulation runs.
+
+## Composable rate-law combinators
+
+Every combinator returns a propensity procedure `(species environment) ->
+nonnegative-real`. There's no combinator algebra beyond "these are plain
+procedures" — build a richer propensity by composing smaller ones with
+`rate*`, or by writing an ordinary `lambda` that calls a few of them itself.
+
+### `(mass-action k reactants)` → propensity procedure
+
+The standard elementary-reaction rate law: `k` times the combinatorial term
+for each reactant. A reactant with stoichiometry 1 contributes its raw
+count; stoichiometry `n` contributes `C(count, n)` (the binomial
+coefficient) — e.g. `2A → B` has propensity `k·C(nₐ,2) = k·nₐ(nₐ−1)/2`, not
+`k·nₐ²`, since two molecules of the same species must be drawn without
+replacement. Correctly evaluates to `0` (not an error, and not a nonzero
+value from an unmultiplied accumulator — see the note in the source on the
+bug this used to have) whenever any reactant's count is below its required
+stoichiometry.
+
+```scheme
+(mass-action 5.0 '())                    ; zero-order: propensity is a flat 5.0
+(mass-action 2.0 (list (cons 'A 1)))     ; first-order: 2.0 * n_A
+(mass-action 1.0 (list (cons 'A 2)))     ; second-order, same species: C(n_A, 2)
+```
+
+### `(arrhenius A Ea)` → propensity procedure
+
+Temperature-dependent rate constant, `k(T) = A · exp(−Ea / (R·T))` (R =
+8.314 J/(mol·K)). Returns `0` for `temperature = 0` rather than dividing by
+zero — the physically correct limit as `T → 0⁺` for `Ea > 0`, not an
+arbitrary guard value. Meant to be combined with `mass-action` via `rate*`
+to make a reaction temperature-sensitive:
+
+```scheme
+(rate* (mass-action 1.0 reactants) (arrhenius 1e13 50000.0))
+```
+
+### `(michaelis-menten vmax km substrate-key)` → propensity procedure
+
+Saturating enzyme/uptake kinetics: `vmax·S / (km+S)`, where `S` is
+`(species-count species substrate-key)`. Approaches `vmax` as substrate
+grows large, approaches `0` as it's depleted — half of `vmax` exactly when
+`S = km`.
+
+### `(hill env-reader optimal width)` → propensity procedure
+
+A bell-curve multiplier peaking at `1.0` when `(env-reader environment)`
+equals `optimal`, falling off symmetrically over `width`. `width = 0` returns
+the curve's own limit — a delta function, `1.0` exactly at `optimal` and `0`
+everywhere else — rather than dividing by zero. The general shape behind
+"this reaction has an optimal pH" (or any other environment axis with an
+optimum rather than a monotonic scaling):
+
+```scheme
+(hill environment-ph 7.0 1.0)          ; peaks at pH 7, roughly e^-2 by pH 9
+(hill environment-temperature 310.0 5.0) ; an enzyme with an optimal temperature
+```
+
+### `(rate* proc ...)` → propensity procedure
+
+Multiplies any number of propensity procedures' outputs together — the
+actual composability mechanism. A temperature-sensitive, pH-sensitive,
+nutrient-saturating reaction is:
+
+```scheme
+(rate* (mass-action k reactants)
+       (arrhenius A Ea)
+       (hill environment-ph 7.0 1.0)
+       (michaelis-menten vmax km 'glucose))
+```
+
+## Simulation
+
+### `(gillespie-step! cell)` → boolean
+
+Runs one step of the algorithm above, mutating `cell` in place. Returns `#f`
+(and changes nothing at all — not even the time) when every reaction's
+propensity is currently `0`, e.g. a nutrient pool has run out and nothing
+can react any more. A caller can treat "the cell went quiescent" as an
+ordinary checkable outcome rather than an error or an infinite loop.
+
+### `(gillespie-run! cell t-max)` → real (the final time reached)
+
+Steps until `(cell-time cell)` reaches `t-max` or the cell goes quiescent.
+The return value is `< t-max` exactly when the run ended by quiescence
+rather than reaching `t-max` — check it if you need to distinguish the two.
+
+### `(cell-trajectory cell t-max dt)` → list of `(time . ((species . count) ...))`
+
+Runs the simulation to `t-max`, recording a full species snapshot every `dt`
+time units — not every reaction event, which for a fast network could be
+thousands of points per unit of biological time. `dt` must be positive; a
+zero or negative `dt` raises immediately rather than looping forever.
+Sample times are computed as `i·dt` for an integer step count, not by
+repeatedly adding `dt` to itself, so the sample count is exact even for a
+`dt` that isn't an exact binary fraction (e.g. `0.1`). Returned oldest-first,
+directly usable as a plotting data series (a Qt canvas timer callback, a CSV
+writer, whatever). Mutates `cell` in place, same as `gillespie-run!`. Once
+the cell goes quiescent, remaining samples reuse one cached snapshot rather
+than recomputing every reaction's propensity for no new information.
+
+## Notes
+
+- **Multi-cell simulation** isn't a separate API here — spawn one curry actor
+  per cell, each running its own `gillespie-step!`/`gillespie-run!` loop, and
+  use `send!`/`receive` for intercellular signaling. If cells share a single
+  `<environment>` (competing for one nutrient pool), protect concurrent
+  mutation of it with `(curry stm)` rather than mutating it unprotected from
+  multiple actor threads.
+- **This is a real stochastic process** — two calls to `gillespie-run!` with
+  identical starting conditions will not produce identical trajectories
+  unless you explicitly reseed with `random-source-pseudo-randomize!`
+  beforehand (see `(curry random)`'s underlying SRFI-27 primitives).
+  Statistical properties (steady-state means, variance) are reproducible
+  across many replicates; individual trajectories are not, by design.
+- **No built-in unit conversion or validation** — species counts, rate
+  constants, and environment values are plain numbers with whatever units
+  you decide on; nothing here checks that an `Ea` is in the right unit
+  system for the `R` used internally, for instance. Get your units
+  consistent before wiring reactions together.
+
+## See also
+
+- [`gillespie-cell-model.md`](../thoughts/gillespie-cell-model.md) — design
+  rationale, the SBML-import idea, and how this composes with a
+  population-genetics model
+- [`module-random.md`](module-random.md) — the SRFI-27 primitives
+  (`random-real`, `random-source-pseudo-randomize!`) this module's waiting-time
+  draw builds on directly
+- [`concurrency.md`](concurrency.md) — actors, STM, and `(curry stm)`'s
+  `or-else`/`select` sugar, for protecting a shared `<environment>` across
+  multiple cell-actors

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -60,6 +60,7 @@ The full list of `(curry ...)` modules. Optional modules that need an external l
 | [mariadb](module-mariadb.md) | `(curry mariadb)` | MariaDB/MySQL client *(pure Scheme + FFI, no build step)* | `libmariadb`/`libmysqlclient` installed at runtime (`-DBUILD_FFI=ON`) |
 | [postgres](module-postgres.md) | `(curry postgres)` | PostgreSQL client *(pure Scheme + FFI, no build step)* | `libpq` installed at runtime (`-DBUILD_FFI=ON`) |
 | [tts](module-tts.md) | `(curry tts)` | Cross-backend text-to-speech — macOS (`say`) and Linux (`espeak-ng`/`espeak`) *(pure Scheme, no build step)* | `(curry posix)`, `(curry conditions)`; `say` or `espeak-ng`/`espeak` installed at runtime |
+| [gillespie](module-gillespie.md) | `(curry gillespie)` | Stochastic simulation of cell biochemistry (Gillespie/SSA): composable rate laws, temperature/pH/nutrient sensitivity *(pure Scheme, no build step)* | — |
 | [typedvec](module-typedvec.md) | `(curry typedvec)` | SRFI-4 core typed numeric vectors: u8/s8/u16/s16/u32/s32/u64/s64vector | — |
 
 ## See also

--- a/docs/thoughts/anarchists-cookbook.md
+++ b/docs/thoughts/anarchists-cookbook.md
@@ -144,6 +144,79 @@ Zipf distribution; recursive structure of natural language in six lines.
 
 ---
 
+---
+
+## Chapter: Watch a Cell Think — Stochastic Biochemistry with the Gillespie Algorithm
+
+*Full module in `(curry gillespie)`, design doc in
+`docs/thoughts/gillespie-cell-model.md`.*
+
+The pitch: real gene expression is noisy. A cell doesn't have "5.3 copies of a
+protein," it has 4, then 6, then 3 — a small integer jumping around at random,
+because chemistry at low molecule counts genuinely is a stochastic process,
+not a smooth curve with noise sprinkled on afterward. The Gillespie algorithm
+simulates that directly: draw a random waiting time, pick which reaction
+fires, repeat. Composable rate-law combinators (`mass-action`, `arrhenius`,
+`michaelis-menten`, `hill`, all glued together with `rate*`) mean temperature,
+pH, and nutrient sensitivity aren't special features — they're just more
+functions being multiplied into a propensity, so a reader who understands
+`rate*` can build essentially arbitrary biochemistry from four small pieces.
+
+This is exactly the kind of thing an eager nerdy reader can just... play
+with. Change one number, rerun, watch the population statistics shift. Cool
+the environment down and watch a whole reaction network visibly slow to a
+crawl. Starve a cell of glucose and watch it go quiescent mid-simulation with
+no crash, no special-cased error path — just an ordinary `#f` from
+`gillespie-step!` because every propensity in the network genuinely reached
+zero.
+
+### Recipe ideas
+
+**The birth-death "hello world"** — one production reaction, one
+degradation reaction, and a known analytical answer (`λ/μ`) to check your
+simulation against. The right first thing to run, and a good sanity check
+whenever you write a new reaction network: does the steady state land near
+where the math says it should?
+
+**A genetic toggle switch** — the classic synthetic-biology circuit: two
+genes that mutually repress each other, so the system settles into one of
+two stable states essentially at random depending on early noise. Build it
+with four reactions (transcribe-A, transcribe-B, degrade-A, degrade-B, each
+gated by the other's current level) and watch fifty independent cells split
+roughly in half between the two states — a beautiful, tiny demonstration of
+how stochastic noise can create genuine bistability from a symmetric system.
+
+**A population under thermal stress** — spawn N cell-actors (see
+`docs/reference/concurrency.md`), each running the same reaction network,
+sharing one `<environment>` whose temperature you ramp up over the course
+of the simulation via `set-environment-temperature!`. Watch the population's
+average protein output curve bend as an Arrhenius-scaled reaction crosses
+its effective activation threshold.
+
+**Starve it and watch it stop** — a network with one nutrient-uptake
+reaction (`michaelis-menten`) feeding everything else. Run to depletion and
+plot the trajectory: watch every downstream reaction's activity taper off
+in lockstep as the shared substrate runs out, then confirm the cell has
+gone genuinely quiescent (`gillespie-run!`'s return value `<` the requested
+`t-max`) rather than just "slow."
+
+**Live in Qt** — wire `cell-trajectory`'s output (or a live per-tick
+`gillespie-step!` loop) into a `(curry qt6)` canvas: cells as colored
+circles, color channels driven by species counts, so gene-expression noise
+is something you *watch flicker* rather than a number in a table.
+
+### Connecting thread for the chapter
+
+Every recipe above is the same four moving parts — a species table, a
+reaction list built from `mass-action`/`arrhenius`/`michaelis-menten`/`hill`
+composed with `rate*`, an environment, and either `gillespie-run!` for a
+single endpoint or `cell-trajectory` for the full time series. A reader who
+builds the birth-death toy and the toggle switch has already seen everything
+needed for the population and starvation recipes; scaling up to many cells
+is "wrap it in `spawn`," not a new concept.
+
+---
+
 ## Other chapter seeds (unrelated to v1.4)
 
 *(Drop ideas for other chapters here as they come up)*

--- a/docs/thoughts/gillespie-cell-model.md
+++ b/docs/thoughts/gillespie-cell-model.md
@@ -1,0 +1,205 @@
+# `(curry gillespie)` — stochastic simulation of cell biochemistry
+## Composable rate laws, environment sensitivity, multi-cell via actors, and SBML import
+
+*Drafted 2026-08-27. Status: pre-implementation design sketch (base module is
+being implemented alongside this doc).*
+
+---
+
+## What it is
+
+The Gillespie stochastic simulation algorithm (SSA) models a set of chemical
+species undergoing reactions as a continuous-time Markov chain: instead of
+solving smooth ODEs for concentrations, it simulates individual random
+reaction events (production, degradation, binding), which matters
+biologically because real gene expression is noisy at low molecule counts —
+a handful of mRNA copies, not a continuous concentration.
+
+The core mechanism: each reaction has a *propensity* (a probability-per-unit-
+time that it fires next, given the current state). At each step, draw an
+exponentially-distributed waiting time from the sum of all propensities,
+pick which reaction fires weighted by its own share of that sum, update
+species counts, repeat.
+
+## Why environment sensitivity falls out for free
+
+A propensity is just a function of current state, so temperature, pH, and
+nutrient level aren't bolted on afterward — they're ordinary inputs to the
+exact mechanism that already decides which reaction fires when:
+
+- **Temperature** — Arrhenius scaling, `k(T) = A · exp(−Ea / (R·T))`
+- **pH** — a bell-curve enzyme-activity multiplier evaluated at current pH
+- **Nutrients** — modeled as just another species (external glucose,
+  consumed by uptake reactions); propensities naturally drop to zero when
+  it's depleted, and the cell's metabolism visibly stalls with no special
+  casing needed
+
+## Core data model
+
+```scheme
+;; A reaction: propensity is a function of (species-state environment)
+(define-record-type <reaction>
+  (make-reaction name reactants products propensity)
+  reaction?
+  (name        reaction-name)
+  (reactants   reaction-reactants)   ; ((species . stoich) ...) consumed
+  (products    reaction-products)    ; ((species . stoich) ...) produced
+  (propensity  reaction-propensity)) ; (lambda (species env) -> nonneg-real)
+
+(define-record-type <environment>
+  (make-environment temperature ph nutrients)
+  environment?
+  (temperature environment-temperature set-environment-temperature!)
+  (ph          environment-ph)
+  (nutrients   environment-nutrients set-environment-nutrients!))
+
+(define-record-type <cell>
+  (make-cell species reactions environment time)
+  cell?
+  (species     cell-species)      ; hash-table: symbol -> count
+  (reactions   cell-reactions)
+  (environment cell-environment)
+  (time        cell-time set-cell-time!))
+
+(define (gillespie-step! cell)
+  (let* ((props (map (lambda (r) ((reaction-propensity r)
+                                   (cell-species cell) (cell-environment cell)))
+                      (cell-reactions cell)))
+         (a0 (apply + props)))
+    (and (positive? a0)
+         (let ((tau (/ (- (log (random-real))) a0))
+               (r   (%pick-weighted (cell-reactions cell) props a0)))
+           (set-cell-time! cell (+ (cell-time cell) tau))
+           (%apply-reaction! cell r)
+           #t))))
+```
+
+## Composable rate-law combinators
+
+The point of making this composable: a propensity function is just a plain
+closure `(species env) -> real`, so building richer behavior is ordinary
+function composition, not a special mini-language:
+
+```scheme
+(define (mass-action k)
+  (lambda (species env) (* k (%reactant-product species))))
+
+(define (arrhenius base-rate-fn A Ea)
+  (lambda (species env)
+    (* (base-rate-fn species env)
+       A (exp (- (/ Ea (* 8.314 (environment-temperature env))))))))
+
+(define (michaelis-menten vmax km substrate-key)
+  (lambda (species env)
+    (let ((s (hash-table-ref species substrate-key 0)))
+      (/ (* vmax s) (+ km s)))))
+
+;; compose: a temperature-sensitive, nutrient-saturating uptake reaction
+(define uptake-propensity
+  (arrhenius (michaelis-menten 10.0 5.0 'glucose) 1e13 50000))
+```
+
+## Multi-cell: actors + STM, not new machinery
+
+Curry already has real actor concurrency (`spawn`, `send!`, `receive`) and
+software transactional memory (`(curry stm)`, `T_TVAR`). A "cell" maps onto
+one actor running its own `gillespie-step!` loop; a shared `<environment>`
+(when cells compete for a common nutrient pool) is protected by STM, so a
+cell's nutrient-uptake reaction does an atomic transaction against the
+shared pool instead of racing other cells. Intercellular signaling (quorum
+sensing, diffusible ligands) is just `send!` between cell actors. No new
+concurrency primitive needed — this is exactly what the existing actor/STM
+system is for.
+
+## Visualizing it in Qt
+
+`(curry qt6)`'s canvas + timer already covers what's needed: each simulation
+tick runs a batch of `gillespie-step!` calls per cell, then redraws — cells
+as circles colored/sized from their own species counts (protein-A → red
+channel, protein-B → green channel, so gene-expression noise is visible as
+flickering color), the shared nutrient pool as a background heatmap, and
+temperature/pH as live slider widgets mutating the `<environment>` record in
+real time.
+
+---
+
+## SBML interoperability
+
+[SBML](https://sbml.org) (Systems Biology Markup Language) is the standard
+XML exchange format for exactly this kind of model — species, compartments,
+reactions with stoichiometry, and kinetic laws — used by essentially every
+systems-biology tool (COPASI, VCell, libSBML-based pipelines) and by
+[BioModels](https://www.ebi.ac.uk/biomodels/), a public repository of
+several thousand curated, published, peer-reviewed model definitions
+(glycolysis, the cell cycle, MAPK signaling cascades, circadian clocks, and
+so on).
+
+The reason this is worth a paragraph rather than dismissing it as "too big":
+**curry already has the two pieces an SBML importer would actually need.**
+
+1. **XML parsing** — `(curry xml)` already exists (`xml-parse`, `xml-find`,
+   `xml-find-all`, `xml-attr`), used today by the atom/rss/s3/naips modules.
+   SBML's core structure (`<model>` → `<listOfSpecies>`/`<listOfReactions>`,
+   each `<species>`/`<reaction>` carrying attributes and nested
+   `<listOfReactants>`/`<listOfProducts>` elements) is a plain nested-element
+   tree with attributes — exactly the shape `xml-find-all`/`xml-attr` are
+   already built to walk. No new XML infrastructure needed.
+
+2. **Symbolic math** — SBML kinetic laws embed the actual rate expression as
+   **MathML**, a nested-element XML encoding of an expression tree (`<apply>
+   <times/> <ci>k</ci> <ci>S</ci> </apply>` for `k*S`, etc.). Curry's own
+   `(curry symbolic)` CAS already has a full expression-tree representation
+   (`sym-var`, `symbolic`, `simplify`, and general expression construction)
+   plus the evaluator to turn a symbolic expression into a numeric result
+   given variable bindings. A MathML→symbolic-expression translator is a
+   structural walk (MathML's operator tags map close to 1:1 onto CAS node
+   constructors) — small, and it means an imported kinetic law becomes a
+   genuine curry symbolic expression, not an opaque string, so it can be
+   *differentiated, simplified, or inspected* the same as anything else built
+   with `∂`/`simplify`, not just evaluated as a black box.
+
+Sketch of the resulting pipeline:
+
+```scheme
+(import (curry xml) (curry symbolic) (curry gillespie))
+
+(define (sbml->cell path environment)
+  (let* ((doc     (xml-load-file path))
+         (model   (xml-find doc "model"))
+         (species (sbml-parse-species model))       ; -> hash-table
+         (reactions (map sbml-reaction->reaction
+                         (xml-find-all model "reaction"))))
+    (make-cell species reactions environment 0)))
+
+;; each <reaction>'s <kineticLaw><math>...</math></kineticLaw> becomes a
+;; real symbolic expression, then a propensity closure over it
+(define (sbml-reaction->reaction el)
+  (make-reaction (xml-attr el "id")
+                 (sbml-parse-species-refs (xml-find el "listOfReactants"))
+                 (sbml-parse-species-refs (xml-find el "listOfProducts"))
+                 (mathml->propensity (xml-find (xml-find el "kineticLaw") "math"))))
+```
+
+This would let a curry script load a real, published cell-cycle or
+glycolysis model straight from BioModels and run it under the stochastic
+Gillespie engine with zero manual re-entry of the reaction network — turning
+`(curry gillespie)` from "a toy you hand-build small networks for" into
+something that can also reproduce (and then perturb, re-parameterize, or
+feed into the evolution model) genuine published systems-biology results.
+
+Scope note: a full SBML importer (all of SBML core, plus the optional
+`comp`/`fbc`/etc. packages) is a real undertaking. A *useful* first cut —
+species, reactions, stoichiometry, and mass-action/Michaelis-Menten kinetic
+laws specifically (the common case in the simpler BioModels entries) — is a
+much smaller, bounded piece of work, comparable in size to the base
+Gillespie module itself. Full MathML coverage (every operator, piecewise
+functions, etc.) is where the scope could balloon, so worth explicitly
+capping to a useful operator subset rather than aiming for completeness.
+
+## See also
+
+- `docs/thoughts/toy-evolution-model.md` — the population-genetics model
+  that composes with this one (genome = a cell's own rate-constant vector)
+- `docs/reference/module-random.md` — the distribution/sampling primitives
+  the Gillespie waiting-time draw and mutation-operator allele generators
+  both build on

--- a/docs/thoughts/toy-evolution-model.md
+++ b/docs/thoughts/toy-evolution-model.md
@@ -1,0 +1,205 @@
+# `(curry evolution)` — a toy population-genetics model
+## Composing with `(curry gillespie)` to get evolving digital cells
+
+*Drafted 2026-08-27. Status: pre-implementation design sketch — parked for later,
+written up so the idea (and especially the composition with Gillespie) doesn't
+get lost.*
+
+---
+
+## The goal
+
+A hyper-simplified genetic model with real inheritance, several distinct modes of
+gene transfer, and mutation that visibly changes simple life forms — small enough
+to build in an afternoon, not a research-grant-sized undertaking.
+
+## Prior art worth knowing about, not worth porting
+
+- **Avida** (Michigan State's Digital Evolution Lab) — self-replicating digital
+  organisms with genuine mutation/selection dynamics. A full C++ research
+  platform with its own virtual machine; not something to adapt into curry.
+- **Tierra** (Tom Ray, 1990) — the historical precursor: self-replicating
+  machine-code creatures competing for CPU time and memory. Conceptually
+  simple, but the real implementation is a custom VM plus an instruction set
+  designed to tolerate mutation without crashing.
+- **Dawkins' Biomorphs / "Weasel" program** (*The Blind Watchmaker*, 1986) —
+  the right ancestor to actually crib from. A genome is a short vector of
+  numbers; a genotype→phenotype mapping turns it into something with a
+  fitness value; selection picks who reproduces. This is the simplest
+  *correct* toy model in the whole field.
+- **Lenia** (Bert Chan) — beautiful continuous-cellular-automaton life, but
+  it's a convolution-kernel PDE system, closer in spirit to the
+  reaction-diffusion/Turing-pattern idea than to genetics.
+
+Conclusion: build a small Dawkins-style toy, not a port of any of the above.
+
+## Core data model
+
+```scheme
+;; A genome is just a vector of alleles -- numbers, symbols, whatever a given
+;; experiment wants an allele to mean. No fixed interpretation baked in here;
+;; genotype->phenotype mapping is always supplied by the caller.
+(define-record-type <genome>
+  (make-genome alleles)
+  genome?
+  (alleles genome-alleles))   ; a vector
+
+(define-record-type <organism>
+  (make-organism genome fitness-cache)
+  organism?
+  (genome        organism-genome)
+  (fitness-cache organism-fitness-cache set-organism-fitness-cache!))
+```
+
+## Mutation operators — composable, like the Gillespie rate-law combinators
+
+Each operator is `(genome) -> genome` (pure, returns a new genome rather than
+mutating in place, so operators compose by simple procedure composition):
+
+- `(point-mutate genome rate allele-generator)` — each allele independently
+  has probability `rate` of being replaced by `(allele-generator)`
+- `(insert-mutate genome rate allele-generator)` — probability `rate` per
+  position of inserting a fresh allele
+- `(delete-mutate genome rate)` — probability `rate` per position of deletion
+  (genome shrinks — lets genome *length itself* be under selection, which is
+  most of what makes indels interesting versus point mutation alone)
+- `(duplicate-mutate genome rate)` — probability `rate` per position of
+  duplicating a short run (the toy analogue of gene duplication, the actual
+  mechanism believed to originate new gene families in real biology)
+
+Composed the same way the Gillespie rate-law combinators are meant to be:
+
+```scheme
+(define (my-mutation-pipeline g)
+  (delete-mutate (insert-mutate (point-mutate g 0.01 random-allele) 0.005 random-allele) 0.002))
+```
+
+## Modes of gene transfer — the part you specifically asked for
+
+Three distinct mechanisms, each a separate procedure rather than a single
+parameterized "reproduce" call, since biologically they really are different
+things happening on different timescales:
+
+1. **Vertical / asexual** — `(reproduce-asexual parent mutation-pipeline)`.
+   One parent, copy the genome, run it through the mutation pipeline. This is
+   what almost every existing "genetic algorithm" tutorial calls
+   "reproduction" and stops there.
+
+2. **Vertical / sexual (crossover)** — `(reproduce-sexual parent-a parent-b
+   crossover-points mutation-pipeline)`. Splice both genomes at one or more
+   crossover points (single-point, two-point, or uniform crossover — same
+   three classic GA variants), then mutate the result. Requires the two
+   genomes to be roughly comparable in structure to be meaningful, same as
+   real meiosis requiring homologous chromosomes.
+
+3. **Horizontal gene transfer** — `(transfer-genes! donor recipient segment)`.
+   Splice a subsequence from one *unrelated, already-existing* organism's
+   genome directly into another's, with no reproduction event and no
+   generational relationship at all. This is the easiest of the three to
+   implement (it's just "copy this slice from here to there") and the one
+   that makes the model behave unlike a classic GA — a beneficial trait can
+   jump sideways across the population in one step, the way antibiotic
+   resistance genes actually spread across bacterial populations via
+   plasmids, rather than only propagating down a lineage tree.
+
+## Selection
+
+Ordinary, well-trodden ground — roulette-wheel or tournament selection over a
+user-supplied fitness function, `(fitness organism) -> nonneg-real`. Nothing
+novel needed here; this is the one part of the model where reusing a standard
+algorithm rather than inventing something is exactly right.
+
+## Where this gets interesting: composing with `(curry gillespie)`
+
+This is the part worth writing down carefully, since it's the actual reason
+to build both modules rather than either alone.
+
+A Gillespie `<cell>` (see the sibling design/implementation for the base
+module) has a reaction network — a list of `<reaction>` records, each
+carrying a *propensity function* closed over some rate constants. The
+insight: **a genome can just be the vector of those rate constants.**
+
+```scheme
+;; genotype -> phenotype, in the most literal sense possible: each allele IS
+;; a reaction's rate constant, in order.
+(define (genome->reactions genome reaction-templates)
+  (map (lambda (template rate-const)
+         (make-reaction (reaction-template-name template)
+                         (reaction-template-reactants template)
+                         (reaction-template-products template)
+                         (mass-action rate-const)))
+       reaction-templates
+       (vector->list (genome-alleles genome))))
+
+;; A cell's fitness is defined by running its OWN Gillespie simulation and
+;; reading off something that matters -- e.g. how much of some product
+;; species it accumulates before nutrients run out.
+(define (cell-fitness organism environment t-max)
+  (let* ((reactions (genome->reactions (organism-genome organism) *reaction-templates*))
+         (cell      (make-cell (initial-species) reactions environment 0)))
+    (gillespie-run! cell t-max)
+    (hash-table-ref (cell-species cell) 'product 0)))
+```
+
+Run this across a population, and "evolution" is no longer a separate toy
+model bolted on next to the biochemistry — it *is* selection over which
+reaction-rate-constant vectors survive and reproduce, with:
+
+- **Mutation** perturbing individual rate constants (a point mutation
+  changing one enzyme's `k` by a random multiplicative factor is a very
+  natural allele-generator here — rates are positive reals, so a log-normal
+  perturbation is the right shape, not a uniform one)
+- **Sexual reproduction** mixing two cell lineages' rate-constant vectors —
+  modeling, loosely, what happens when two strains' regulatory networks
+  recombine
+- **Horizontal gene transfer** splicing one cell's successful rate constant
+  (say, a faster nutrient-uptake enzyme) directly into an unrelated cell's
+  network mid-simulation — which is a genuinely reasonable toy model of
+  plasmid-mediated antibiotic-resistance spread, not just a cute analogy
+
+And because the shared `<environment>` (temperature, pH, nutrient pool) from
+the Gillespie design already feeds into every cell's propensity functions,
+you get environmental selection pressure for free: a population evolving
+under one temperature/nutrient regime will drift toward different rate
+constants than the same starting population evolving under another, without
+writing a single extra line of "environment affects fitness" glue code — the
+environment already *is* wired into fitness, since fitness is defined by
+running the actual simulation.
+
+## Rough sizing
+
+Genome/mutation/selection: comparable in size to `(curry random)` (a few
+hundred lines, all pure Scheme, record types + composable procedures, no new
+C). The genome↔reaction-network bridge above is maybe 30–50 lines on top of
+whatever `(curry gillespie)`'s own public API ends up being. Total: an
+afternoon of focused work, same ballpark as the Gillespie module itself, not
+a second research-grant-sized undertaking.
+
+## Open questions to resolve before implementing
+
+- Should `<organism>` carry a *lineage* (parent pointers) for later
+  phylogenetic-tree visualization, or stay lineage-free to keep the base
+  version minimal? (Lean toward lineage-free v1, add it later if the
+  visualization work wants it.)
+- Crossover on rate-constant genomes needs the two parents' reaction
+  templates to line up positionally — fine for a fixed reaction network
+  shared across the population, but breaks down if genome *length* itself
+  varies (via indel mutations) once genomes start encoding variable-size
+  reaction networks rather than fixed-size rate-constant vectors. Worth
+  deciding whether v1 supports variable-topology reaction networks at all,
+  or deliberately restricts evolution to rate-constant tuning over a fixed
+  topology first, and treats topology evolution as a stretch goal.
+- Population-level driver loop (spawn N cell-actors each running its own
+  Gillespie simulation, collect fitness, apply selection, repeat) maps
+  naturally onto curry's existing actor system the same way multi-cell
+  Gillespie does — worth designing the two population loops (plain Gillespie
+  multi-cell, and evolving multi-cell) so they share as much of that driver
+  machinery as possible rather than duplicating it.
+
+## See also
+
+- The `(curry gillespie)` design/implementation this composes with
+- `docs/thoughts/anarchists-cookbook.md` — this pairs naturally with a
+  cookbook chapter once both modules exist: "grow a population of digital
+  cells, watch a beneficial mutation sweep through it, then watch it jump
+  sideways via horizontal transfer into an unrelated lineage"

--- a/docs/thoughts/toy-evolution-model.md
+++ b/docs/thoughts/toy-evolution-model.md
@@ -198,7 +198,7 @@ a second research-grant-sized undertaking.
 
 ## See also
 
-- The `(curry gillespie)` design/implementation this composes with
+- [`gillespie-cell-model.md`](gillespie-cell-model.md) — the `(curry gillespie)` design/implementation this composes with
 - `docs/thoughts/anarchists-cookbook.md` — this pairs naturally with a
   cookbook chapter once both modules exist: "grow a population of digital
   cells, watch a beneficial mutation sweep through it, then watch it jump

--- a/lib/curry/modules/curry/gillespie.scm
+++ b/lib/curry/modules/curry/gillespie.scm
@@ -1,0 +1,318 @@
+;;; (curry gillespie) — stochastic simulation of cell biochemistry
+;;;
+;;; The Gillespie algorithm (SSA) models a set of chemical species
+;;; undergoing reactions as a continuous-time Markov chain: instead of
+;;; solving smooth ODEs for concentrations, it simulates individual random
+;;; reaction events, which matters because real gene expression is noisy at
+;;; low molecule counts -- a handful of mRNA copies, not a continuous
+;;; concentration.
+;;;
+;;; Design doc: docs/thoughts/gillespie-cell-model.md (also covers an SBML
+;;; import angle and composing this with a toy evolution model -- neither
+;;; implemented here, this file is just the base simulation engine).
+;;;
+;;; A reaction's propensity (its probability-per-unit-time of firing next,
+;;; given the current state) is an ordinary Scheme closure of
+;;; (species-table environment) -> nonnegative-real. That's the whole
+;;; composability story: temperature/pH/nutrient sensitivity isn't a
+;;; separate feature bolted on, it's just a propensity function reading
+;;; environment fields, and richer propensities are built by composing the
+;;; small combinators below (mass-action, arrhenius, michaelis-menten,
+;;; rate*) with ordinary procedure composition -- not a special mini-DSL.
+
+(define-library (curry gillespie)
+  (import (scheme base) (scheme inexact))
+  (export
+    ;; reactions
+    make-reaction reaction? reaction-name reaction-reactants reaction-products
+    reaction-propensity
+
+    ;; environment
+    make-environment environment?
+    environment-temperature set-environment-temperature!
+    environment-ph set-environment-ph!
+    environment-nutrients set-environment-nutrients!
+
+    ;; species tables (a species table is a plain hash-table: symbol -> count)
+    make-species species-count set-species-count! adjust-species!
+
+    ;; cells
+    make-cell cell? cell-species cell-reactions cell-environment
+    cell-time set-cell-time!
+
+    ;; composable rate-law combinators
+    mass-action arrhenius michaelis-menten hill rate*
+
+    ;; simulation
+    gillespie-step! gillespie-run! cell-trajectory)
+  (begin
+
+;;; ── reactions ────────────────────────────────────────────────────────────
+;;; reactants/products are alists: ((species-symbol . stoichiometry) ...)
+
+(define-record-type <reaction>
+  (make-reaction name reactants products propensity)
+  reaction?
+  (name       reaction-name)
+  (reactants  reaction-reactants)
+  (products   reaction-products)
+  (propensity reaction-propensity))
+
+;;; ── environment ──────────────────────────────────────────────────────────
+;;; Deliberately just three fields for the base model -- temperature (K),
+;;; ph (dimensionless), nutrients (a plain number, meant to double as an
+;;; extra species pool an uptake reaction depletes). A caller who wants
+;;; more environment axes can always fold them into the species table
+;;; itself instead (e.g. "oxygen" as an ordinary species).
+
+(define-record-type <environment>
+  (make-environment temperature ph nutrients)
+  environment?
+  (temperature environment-temperature set-environment-temperature!)
+  (ph          environment-ph          set-environment-ph!)
+  (nutrients   environment-nutrients   set-environment-nutrients!))
+
+;;; ── species tables ───────────────────────────────────────────────────────
+
+;; (make-species '((A . 10) (B . 0))) -> hash-table
+(define (make-species initial-alist)
+  (let ((tbl (make-hash-table)))
+    (for-each (lambda (p) (hash-table-set! tbl (car p) (cdr p))) initial-alist)
+    tbl))
+
+(define (species-count species key)
+  (hash-table-ref species key 0))
+
+(define (set-species-count! species key n)
+  (hash-table-set! species key n))
+
+(define (adjust-species! species key delta)
+  (set-species-count! species key (+ (species-count species key) delta)))
+
+;;; ── cells ────────────────────────────────────────────────────────────────
+
+(define-record-type <cell>
+  (make-cell species reactions environment time)
+  cell?
+  (species     cell-species)
+  (reactions   cell-reactions)
+  (environment cell-environment)
+  (time        cell-time set-cell-time!))
+
+;;; ── composable rate-law combinators ─────────────────────────────────────
+;;; Every combinator below returns a propensity procedure of
+;;; (species environment) -> nonnegative-real. Combine them with rate* or
+;;; ordinary lambda wrapping -- there's no separate combinator algebra to
+;;; learn beyond "these are just functions."
+
+;; Universal gas constant, J/(mol*K), for the Arrhenius combinator.
+(define %R 8.314)
+
+;; The falling factorial n*(n-1)*...*(n-k+1) -- the standard Gillespie
+;; combinatorial correction for a reactant with stoichiometry k: k
+;; molecules of the same species must be drawn from n available without
+;; replacement, e.g. 2A -> B has propensity k*n*(n-1)/2, not k*n^2.
+;; Note: no separate n<=0 guard -- when n < k, one of the k factors (n-i)
+;; for i in [0, n] is exactly 0, so the product is correctly 0 without any
+;; special case. An earlier version special-cased n<=0 by returning acc
+;; unmultiplied (i.e. 1, the identity), which meant a fully depleted
+;; reactant (count 0) still had a nonzero mass-action propensity -- found
+;; via a real simulation run that consumed a finite resource down to
+;; -970 instead of stopping at 0.
+(define (%falling-factorial n k)
+  (let loop ((i 0) (acc 1))
+    (if (= i k)
+        acc
+        (loop (+ i 1) (* acc (- n i))))))
+
+;; (mass-action k reactants) -- the standard elementary-reaction rate law:
+;; propensity = k * product over each reactant of its falling-factorial
+;; term, and stoichiometry 2+ divided by the corresponding factorial (so
+;; 2A -> B is k*C(n,2) = k*n*(n-1)/2, not k*n*(n-1)).
+(define (mass-action k reactants)
+  (lambda (species environment)
+    (* k (%mass-action-combinatorial species reactants))))
+
+(define (%factorial n)
+  (let loop ((i 2) (acc 1)) (if (> i n) acc (loop (+ i 1) (* acc i)))))
+
+;; Clamps a negative count to 0 before computing the falling factorial --
+;; species-count/adjust-species! are plain hash-table wrappers that don't
+;; themselves forbid a negative count (found by code review: nothing
+;; upstream of this function *should* ever produce one now that
+;; %falling-factorial correctly zeroes out a depleted reactant, but a
+;; negative count reaching here at all -- via direct adjust-species!
+;; misuse, or a future reaction-application bug -- would otherwise make
+;; %falling-factorial return a *negative* propensity, silently corrupting
+;; %pick-weighted's cumulative-sum bucket test rather than raising or
+;; clamping to a sane 0).
+(define (%mass-action-combinatorial species reactants)
+  (apply * (map (lambda (r)
+                  (let ((n (max 0 (species-count species (car r))))
+                        (k (cdr r)))
+                    (/ (%falling-factorial n k) (%factorial k))))
+                reactants)))
+
+;; (arrhenius A Ea) -- temperature-dependent rate constant, k(T) = A *
+;; exp(-Ea / (R*T)). Meant to be combined with mass-action via rate* to
+;; make a mass-action reaction temperature-sensitive, e.g.
+;;   (rate* (mass-action 1 reactants) (arrhenius 1e13 50000))
+;; Guards temperature = 0 (absolute zero -- a degenerate but reachable
+;; parameter, same class of caller mistake as km=0/S=0 in
+;; michaelis-menten) by returning 0 rather than dividing by zero: as T -> 0+
+;; with Ea > 0, exp(-Ea/(R*T)) -> 0 in the actual limit, so 0 is the
+;; physically correct answer here, not just an arbitrary guard value.
+;; Found by code review, which noted this combinator lacked the same
+;; zero-denominator guard michaelis-menten already has.
+(define (arrhenius A Ea)
+  (lambda (species environment)
+    (let ((T (environment-temperature environment)))
+      (if (= T 0) 0 (* A (exp (- (/ Ea (* %R T)))))))))
+
+;; (michaelis-menten vmax km substrate-key) -- saturating uptake/enzyme
+;; kinetics: rate = vmax*S / (km+S). Approaches vmax as substrate S grows
+;; large, approaches zero as it's depleted -- the standard toy model for
+;; nutrient-limited growth. Guards km+S = 0 (only possible when both are
+;; 0 -- km negative would be a nonsensical parameter, S is never negative
+;; after the max-0 clamp) by returning 0 rather than dividing 0 by 0,
+;; found by code review: an unguarded 0/0 there is a silent NaN whose
+;; propensity then poisons gillespie-step!'s (> a0 0) quiescence check
+;; forever, permanently freezing an otherwise-live cell with no error.
+(define (michaelis-menten vmax km substrate-key)
+  (lambda (species environment)
+    (let ((s (max 0 (species-count species substrate-key))))
+      (if (= (+ km s) 0) 0 (/ (* vmax s) (+ km s))))))
+
+;; (hill optimal width) -- a bell-curve multiplier peaking at 1.0 when
+;; (env-reader environment) = optimal, falling off over the given width.
+;; The generic shape behind "this reaction's rate depends on pH" or any
+;; other environment axis with an optimum rather than a monotonic scaling.
+;; Guards width = 0 (a degenerate parameter -- the bell curve's limit as
+;; width -> 0 is a delta function, 1.0 exactly at the optimum and 0
+;; everywhere else) rather than dividing by zero. Found by code review
+;; alongside the same gap in arrhenius.
+(define (hill env-reader optimal width)
+  (lambda (species environment)
+    (let ((x (env-reader environment)))
+      (if (= width 0)
+          (if (= x optimal) 1 0)
+          (exp (- (/ (* (- x optimal) (- x optimal)) (* 2 width width))))))))
+
+;; (rate* proc ...) -- combine any number of propensity procedures by
+;; multiplying their outputs. This is the actual composability mechanism:
+;; a temperature-sensitive, pH-sensitive, nutrient-saturating reaction is
+;; just (rate* (mass-action ...) (arrhenius ...) (hill ...) (michaelis-menten ...)).
+(define (rate* . procs)
+  (lambda (species environment)
+    (apply * (map (lambda (p) (p species environment)) procs))))
+
+;;; ── the Gillespie direct method ──────────────────────────────────────────
+
+;; One step: draw an exponential waiting time from the sum of all
+;; propensities, pick which reaction fires weighted by its own share,
+;; apply it, advance time. Returns #f (and changes nothing) when every
+;; propensity is zero -- e.g. a nutrient pool has run out and nothing can
+;; react any more -- rather than looping or raising, so a caller can
+;; treat "the cell went quiescent" as an ordinary, checkable outcome.
+;; random-real can return exactly 0.0 (an all-zero 53-bit mantissa,
+;; probability 2^-53 per draw but not zero) -- (log 0.0) is -inf.0, which
+;; would make tau below +inf.0 and jump the cell's clock to infinity in a
+;; single step, silently ending the run with no error. Found by code
+;; review. Redrawing on the (astronomically rare) exact-zero case is
+;; effectively free amortized and avoids ever computing (log 0.0) at all.
+(define (%random-real-nonzero)
+  (let ((u (random-real)))
+    (if (= u 0.0) (%random-real-nonzero) u)))
+
+(define (gillespie-step! cell)
+  (let* ((reactions (cell-reactions cell))
+         (props (map (lambda (r) ((reaction-propensity r)
+                                   (cell-species cell) (cell-environment cell)))
+                      reactions))
+         (a0 (apply + props)))
+    (and (> a0 0)
+         (let ((tau (/ (- (log (%random-real-nonzero))) a0))
+               (chosen (%pick-weighted reactions props a0)))
+           (set-cell-time! cell (+ (cell-time cell) tau))
+           (%apply-reaction! cell chosen)
+           #t))))
+
+(define (%pick-weighted reactions props a0)
+  (let ((r (* (random-real) a0)))
+    (let loop ((rs reactions) (ps props) (acc 0))
+      (let ((acc* (+ acc (car ps))))
+        (if (or (null? (cdr rs)) (< r acc*))
+            (car rs)
+            (loop (cdr rs) (cdr ps) acc*))))))
+
+(define (%apply-reaction! cell reaction)
+  (let ((species (cell-species cell)))
+    (for-each (lambda (r) (adjust-species! species (car r) (- (cdr r))))
+              (reaction-reactants reaction))
+    (for-each (lambda (p) (adjust-species! species (car p) (cdr p)))
+              (reaction-products reaction))))
+
+;; (gillespie-run! cell t-max) -- step until cell-time reaches t-max or the
+;; cell goes quiescent (every propensity zero). Mutates cell in place;
+;; returns the final cell-time reached (which is < t-max exactly when the
+;; run ended by quiescence rather than reaching t-max).
+(define (gillespie-run! cell t-max)
+  (let loop ()
+    (if (and (< (cell-time cell) t-max) (gillespie-step! cell))
+        (loop)
+        (cell-time cell))))
+
+;; (cell-trajectory cell t-max dt) -- run the simulation to t-max,
+;; recording a snapshot of every species count every dt time units (not
+;; every reaction event, which for a fast reaction network could be
+;; thousands of points for a single dt worth of biological time). Returns
+;; a list of (time . ((species . count) ...)) pairs, oldest first --
+;; directly usable as the data series for a Qt canvas or any plotting
+;; code. Mutates cell in place, same as gillespie-run!.
+;;
+;; dt must be positive -- found by code review: an unguarded dt <= 0 (a
+;; swapped-argument call, or dt computed as t-max/n for some n that
+;; rounds to 0) left next-sample fixed forever, hanging the process with
+;; no error and no way to tell what went wrong.
+;;
+;; Sample times are i*dt for an integer step count i, not built by
+;; repeatedly adding dt to itself -- found by code review: repeated
+;; floating-point addition of a dt that isn't an exact binary fraction
+;; (e.g. 0.1) accumulates rounding error over many steps, which can shift
+;; the final sample across the t-max boundary and silently produce one
+;; more or fewer samples than (+ 1 (/ t-max dt)) would predict.
+;;
+;; Once the cell goes quiescent (every reaction's propensity is 0 -- see
+;; gillespie-step!) nothing will ever change again, so this stops calling
+;; gillespie-step! for the remaining samples and reuses one cached
+;; snapshot instead of rebuilding an identical hash-table->alist every
+;; time -- found by code review: without the cache, a cell that goes
+;; quiescent early in a long, fine-grained run (e.g. t-max=10000, dt=0.01,
+;; quiescent by t=1) still reallocated an identical alist from scratch at
+;; each of the ~1,000,000 remaining sample points for no new information.
+(define (cell-trajectory cell t-max dt)
+  (unless (> dt 0)
+    (error "cell-trajectory: dt must be positive" dt))
+  (let loop ((i 0) (quiescent-snapshot #f) (acc '()))
+    (let ((next-sample (* i dt)))
+      (cond
+        ((> next-sample t-max) (reverse acc))
+        (quiescent-snapshot
+         (loop (+ i 1) quiescent-snapshot
+               (cons (cons (cell-time cell) quiescent-snapshot) acc)))
+        (else
+         (let record-until ()
+           (if (< (cell-time cell) next-sample)
+               (if (gillespie-step! cell)
+                   (record-until)
+                   ;; Just went quiescent this iteration -- cache the
+                   ;; snapshot from here on instead of rebuilding it.
+                   (let ((s (%species-snapshot cell)))
+                     (loop (+ i 1) s (cons (cons (cell-time cell) s) acc))))
+               (loop (+ i 1) #f
+                     (cons (cons (cell-time cell) (%species-snapshot cell)) acc)))))))))
+
+(define (%species-snapshot cell)
+  (hash-table->alist (cell-species cell)))
+
+  )) ;; end begin, define-library

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ add_test(NAME aviation_weather COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURC
 add_test(NAME naips COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/naips_tests.scm)
 add_test(NAME base64 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/base64_tests.scm)
 add_test(NAME random       COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/random_tests.scm)
+add_test(NAME gillespie    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/gillespie_tests.scm)
 add_test(NAME sets         COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/set_tests.scm)
 add_test(NAME sets_module  COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sets_module_tests.scm)
 add_test(NAME oop          COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/oop_tests.scm)
@@ -124,7 +125,7 @@ add_test(NAME debugger
 set(MOD_PATH "${CMAKE_BINARY_DIR}/mods")
 set_tests_properties(akkadian PROPERTIES
     ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
-set_tests_properties(numeric_ext actors ode pde_numerical d_operator tuples partial trig pde_symbolic sicm sexagesimal logic sets_module random oop yaml PROPERTIES
+set_tests_properties(numeric_ext actors ode pde_numerical d_operator tuples partial trig pde_symbolic sicm sexagesimal logic sets_module random gillespie oop yaml PROPERTIES
     ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 
 if(BUILD_MODULE_GIT AND TARGET curry_git)

--- a/tests/gillespie_tests.scm
+++ b/tests/gillespie_tests.scm
@@ -1,0 +1,295 @@
+;;; gillespie_tests.scm — tests for (curry gillespie)
+
+(import (curry gillespie))
+
+;; Deterministic from here on -- the stochastic-run tests below check
+;; statistical properties (mean within a tolerance band, not exact
+;; values), but a fixed seed still keeps the whole suite reproducible
+;; run to run instead of occasionally flaking on an unlucky draw.
+(random-source-pseudo-randomize! (make-random-source) 20260827 1)
+
+(define pass 0)
+(define fail 0)
+
+(define-syntax check
+  (syntax-rules ()
+    ((_ label expr expected)
+     (let ((got expr))
+       (if (equal? got expected)
+           (set! pass (+ pass 1))
+           (begin
+             (set! fail (+ fail 1))
+             (display "FAIL: ") (display label) (newline)
+             (display "  expected: ") (write expected) (newline)
+             (display "  got:      ") (write got) (newline)))))))
+
+(define-syntax check-approx
+  (syntax-rules ()
+    ((_ label expr expected tol)
+     (let ((got expr))
+       (if (< (abs (- got expected)) tol)
+           (set! pass (+ pass 1))
+           (begin
+             (set! fail (+ fail 1))
+             (display "FAIL: ") (display label) (newline)
+             (display "  expected ~") (display expected)
+             (display " ± ") (display tol) (newline)
+             (display "  got: ") (display got) (newline)))))))
+
+(define-syntax check-true
+  (syntax-rules ()
+    ((_ label expr)
+     (if expr
+         (set! pass (+ pass 1))
+         (begin
+           (set! fail (+ fail 1))
+           (display "FAIL: ") (display label) (newline))))))
+
+;; every isn't a core builtin outside (scheme base)'s own list procedures
+;; (same gap noted in random_tests.scm's own sibling file) -- small local
+;; definition, no shared private module for one call site.
+(define (%every pred lst)
+  (or (null? lst) (and (pred (car lst)) (%every pred (cdr lst)))))
+
+;;; ── species tables ───────────────────────────────────────────────────────
+
+(let ((s (make-species (list (cons 'A 10) (cons 'B 0)))))
+  (check "species-count reads initial value" (species-count s 'A) 10)
+  (check "species-count defaults to 0 for unset key" (species-count s 'C) 0)
+  (set-species-count! s 'A 5)
+  (check "set-species-count! overwrites" (species-count s 'A) 5)
+  (adjust-species! s 'A 3)
+  (check "adjust-species! adds delta" (species-count s 'A) 8)
+  (adjust-species! s 'A -20)
+  (check "adjust-species! allows negative delta arithmetically" (species-count s 'A) -12))
+
+;;; ── environment ──────────────────────────────────────────────────────────
+
+(let ((env (make-environment 310.0 7.0 1000)))
+  (check "environment-temperature" (environment-temperature env) 310.0)
+  (check "environment-ph" (environment-ph env) 7.0)
+  (check "environment-nutrients" (environment-nutrients env) 1000)
+  (set-environment-temperature! env 250.0)
+  (check "set-environment-temperature!" (environment-temperature env) 250.0)
+  (set-environment-nutrients! env 0)
+  (check "set-environment-nutrients!" (environment-nutrients env) 0))
+
+;;; ── mass-action ──────────────────────────────────────────────────────────
+
+(let* ((species (make-species (list (cons 'A 5))))
+       (env (make-environment 310.0 7.0 0))
+       (rate (mass-action 2.0 (list (cons 'A 1)))))
+  (check-approx "mass-action stoich-1 propensity = k*n" (rate species env) 10.0 1e-9))
+
+(let* ((species (make-species (list (cons 'A 5))))
+       (env (make-environment 310.0 7.0 0))
+       (rate (mass-action 1.0 (list (cons 'A 2)))))
+  ;; C(5,2) = 10
+  (check-approx "mass-action stoich-2 uses combinatorial C(n,2)" (rate species env) 10.0 1e-9))
+
+(let* ((species (make-species (list (cons 'A 0))))
+       (env (make-environment 310.0 7.0 0))
+       (rate (mass-action 5.0 (list (cons 'A 1)))))
+  (check-approx "mass-action propensity is 0 when reactant depleted" (rate species env) 0.0 1e-9))
+
+(let* ((species (make-species (list (cons 'A 1))))
+       (env (make-environment 310.0 7.0 0))
+       (rate (mass-action 5.0 (list (cons 'A 2)))))
+  ;; C(1,2) = 0 -- can't choose 2 from 1 available
+  (check-approx "mass-action propensity is 0 when n < stoichiometry" (rate species env) 0.0 1e-9))
+
+(let* ((species (make-species '()))
+       (env (make-environment 310.0 7.0 0))
+       (rate (mass-action 3.0 '())))
+  (check-approx "mass-action with no reactants (zero-order) = k" (rate species env) 3.0 1e-9))
+
+;;; ── zero-denominator guards (arrhenius, hill) ────────────────────────────
+;;; Found by code review: michaelis-menten already guarded km=0/S=0 (see
+;;; below), but arrhenius and hill had no analogous guard for their own
+;;; degenerate zero-denominator inputs (temperature=0, width=0).
+
+(let* ((species (make-species '()))
+       (env (make-environment 0 7.0 0)))
+  (check "arrhenius at temperature=0 is 0, not a division error"
+    ((arrhenius 1.0 100.0) species env) 0))
+
+(let* ((species (make-species '()))
+       (curve (hill environment-ph 7.0 0)))
+  (check "hill at width=0 is 1 exactly at the optimum"
+    (curve species (make-environment 310 7.0 0)) 1)
+  (check "hill at width=0 is 0 away from the optimum"
+    (curve species (make-environment 310 5.0 0)) 0))
+
+;;; ── arrhenius ────────────────────────────────────────────────────────────
+
+(let* ((species (make-species '()))
+       (hot (make-environment 400.0 7.0 0))
+       (cold (make-environment 200.0 7.0 0))
+       (rate (arrhenius 1.0 5000.0)))
+  (check-true "arrhenius: hotter environment gives a larger rate"
+    (> (rate species hot) (rate species cold))))
+
+;;; ── michaelis-menten ─────────────────────────────────────────────────────
+
+(let* ((env (make-environment 310.0 7.0 0))
+       (rate (michaelis-menten 10.0 5.0 'S)))
+  (check-approx "michaelis-menten at S=km is half of vmax"
+    (rate (make-species (list (cons 'S 5))) env) 5.0 1e-9)
+  (check-approx "michaelis-menten approaches vmax for S >> km"
+    (rate (make-species (list (cons 'S 100000))) env) 10.0 1e-3)
+  (check-approx "michaelis-menten is 0 with no substrate"
+    (rate (make-species (list (cons 'S 0))) env) 0.0 1e-9))
+
+;; km=0 and S=0 together would be 0/0 unguarded -- silent NaN that then
+;; poisons gillespie-step!'s (> a0 0) quiescence check forever, permanently
+;; freezing an otherwise-live cell. Found by code review.
+(let* ((species (make-species (list (cons 'S 0))))
+       (env (make-environment 310.0 7.0 0))
+       (rate (michaelis-menten 10.0 0 'S)))
+  (check "michaelis-menten with km=0 and S=0 is 0, not NaN" (rate species env) 0))
+
+;; A negative species count (reachable only via direct adjust-species!
+;; misuse, since correctly-computed propensities never let a reaction
+;; drive a count below 0) must not make mass-action return a negative
+;; propensity -- that would silently corrupt %pick-weighted's cumulative-
+;; sum bucket test. Found by code review.
+(let* ((species (make-species (list (cons 'A 0)))))
+  (adjust-species! species 'A -5)
+  (check-approx "mass-action clamps a corrupted negative count to 0 propensity"
+    ((mass-action 1.0 (list (cons 'A 1))) species (make-environment 310.0 7.0 0))
+    0.0 1e-9))
+
+;;; ── hill (bell-curve environment sensitivity) ────────────────────────────
+
+(let* ((species (make-species '()))
+       (curve (hill environment-ph 7.0 1.0)))
+  (check-approx "hill peaks at 1.0 at the optimum"
+    (curve species (make-environment 310 7.0 0)) 1.0 1e-9)
+  (check-true "hill falls off away from the optimum"
+    (< (curve species (make-environment 310 5.0 0)) 1.0))
+  (check-approx "hill is symmetric around the optimum"
+    (curve species (make-environment 310 5.0 0))
+    (curve species (make-environment 310 9.0 0))
+    1e-9))
+
+;;; ── rate* composition ────────────────────────────────────────────────────
+
+(let* ((species (make-species (list (cons 'S 5))))
+       (env (make-environment 310.0 7.0 0))
+       (a (lambda (s e) 2.0))
+       (b (lambda (s e) 3.0))
+       (composed (rate* a b)))
+  (check-approx "rate* multiplies component propensities together"
+    (composed species env) 6.0 1e-9))
+
+;;; ── the Gillespie step/run mechanics ─────────────────────────────────────
+
+;; A single reaction with a food pool of exactly 5 units, one consumed per
+;; firing: must reach exactly 0 and go quiescent, never negative -- this
+;; is the direct regression test for the %falling-factorial bug found
+;; while writing this suite (a stale early-exit guard returned the
+;; unmultiplied accumulator when the reactant was fully depleted, instead
+;; of the correct 0, so the reaction kept firing on an empty pool and
+;; drove the count to -970 in a real run).
+(let* ((r (make-reaction "consume" (list (cons 'food 1)) '()
+                          (mass-action 1.0 (list (cons 'food 1)))))
+       (cell (make-cell (make-species (list (cons 'food 5))) (list r)
+                         (make-environment 310 7 0) 0)))
+  (define final-t (gillespie-run! cell 10000.0))
+  (check "consuming reaction never drives count negative"
+    (species-count (cell-species cell) 'food) 0)
+  (check-true "quiescent run stops before t-max"
+    (< final-t 10000.0)))
+
+;; 2A -> B: an odd starting count must leave exactly 1 A unpaired.
+(let* ((r (make-reaction "dimerize" (list (cons 'a 2)) (list (cons 'b 1))
+                          (mass-action 1.0 (list (cons 'a 2)))))
+       (cell (make-cell (make-species (list (cons 'a 5) (cons 'b 0))) (list r)
+                         (make-environment 310 7 0) 0)))
+  (gillespie-run! cell 10000.0)
+  (check "stoich-2 reaction leaves the odd molecule out" (species-count (cell-species cell) 'a) 1)
+  (check "stoich-2 reaction produces the right count of product" (species-count (cell-species cell) 'b) 2))
+
+;; gillespie-step! on an all-zero-propensity cell returns #f and changes nothing.
+(let* ((r (make-reaction "dead" (list (cons 'x 1)) '() (mass-action 1.0 (list (cons 'x 1)))))
+       (cell (make-cell (make-species (list (cons 'x 0))) (list r) (make-environment 310 7 0) 0)))
+  (check "gillespie-step! returns #f when every propensity is 0"
+    (gillespie-step! cell) #f)
+  (check "gillespie-step! leaves time unchanged when it returns #f"
+    (cell-time cell) 0)
+  (check "gillespie-step! leaves species unchanged when it returns #f"
+    (species-count (cell-species cell) 'x) 0))
+
+;; Birth-death process A: born at rate 5.0, degraded at rate 0.1 per
+;; molecule. Analytical steady-state mean is birth/death = 50 -- run many
+;; independent replicates and check the mean lands in a wide statistical
+;; band around it (this is a real stochastic process, not a deterministic
+;; check, so the tolerance has to be generous).
+(define (%birth-death-final-count)
+  (let* ((birth (make-reaction "birth" '() (list (cons 'A 1)) (mass-action 5.0 '())))
+         (death (make-reaction "death" (list (cons 'A 1)) '() (mass-action 0.1 (list (cons 'A 1)))))
+         (cell (make-cell (make-species (list (cons 'A 0))) (list birth death)
+                           (make-environment 310 7 0) 0)))
+    (gillespie-run! cell 200.0)
+    (species-count (cell-species cell) 'A)))
+
+(let loop ((i 0) (total 0))
+  (if (= i 30)
+      (check-approx "birth-death process settles near its analytical steady state (5.0/0.1 = 50)"
+        (/ total 30.0) 50.0 15.0)
+      (loop (+ i 1) (+ total (%birth-death-final-count)))))
+
+;;; ── cell-trajectory ──────────────────────────────────────────────────────
+
+(let* ((birth (make-reaction "birth" '() (list (cons 'A 1)) (mass-action 5.0 '())))
+       (death (make-reaction "death" (list (cons 'A 1)) '() (mass-action 0.1 (list (cons 'A 1)))))
+       (cell (make-cell (make-species (list (cons 'A 0))) (list birth death)
+                         (make-environment 310 7 0) 0))
+       (traj (cell-trajectory cell 10.0 1.0)))
+  (check-true "cell-trajectory returns a non-empty list of samples" (pair? traj))
+  (check-true "cell-trajectory samples are time-ordered"
+    (let loop ((ts (map car traj)))
+      (or (null? (cdr ts)) (and (<= (car ts) (cadr ts)) (loop (cdr ts))))))
+  (check-true "each cell-trajectory sample carries a species snapshot"
+    (%every (lambda (sample) (assq 'A (cdr sample))) traj)))
+
+;; A cell that goes quiescent almost immediately must still let
+;; cell-trajectory run to completion quickly over many remaining samples,
+;; instead of recomputing every reaction's propensity from scratch at each
+;; one for no new information. Found by code review; regression-tests the
+;; short-circuit, not just correctness (a slow-but-correct implementation
+;; would still pass a plain equality check, so this asserts on the actual
+;; sample count and repeated-snapshot shape rather than timing directly).
+(let* ((r (make-reaction "consume" (list (cons 'food 1)) '()
+                          (mass-action 1.0 (list (cons 'food 1)))))
+       (cell (make-cell (make-species (list (cons 'food 3))) (list r)
+                         (make-environment 310.0 7.0 0) 0))
+       (traj (cell-trajectory cell 1000.0 1.0)))
+  (check "cell-trajectory samples the full requested range even once quiescent"
+    (length traj) 1001)
+  (check "cell-trajectory repeats the final snapshot once quiescent"
+    (cdr (list-ref traj 500)) (cdr (list-ref traj 999))))
+
+;; dt <= 0 must raise, not hang forever (next-sample never advancing past
+;; t-max). Found by code review.
+(let ((cell (make-cell (make-species '()) '() (make-environment 310 7 0) 0)))
+  (check "cell-trajectory raises for dt = 0"
+    (guard (e (#t 'raised)) (cell-trajectory cell 10.0 0)) 'raised)
+  (check "cell-trajectory raises for negative dt"
+    (guard (e (#t 'raised)) (cell-trajectory cell 10.0 -1)) 'raised))
+
+;; Sample count must be exact for a dt that isn't a binary fraction (e.g.
+;; 0.1) -- found by code review: accumulating next-sample via repeated
+;; floating-point addition drifts and can land one sample off the correct
+;; count; sampling as i*dt from an integer i (which the fix switched to)
+;; doesn't have this problem.
+(let ((cell (make-cell (make-species '()) '() (make-environment 310 7 0) 0)))
+  (check "cell-trajectory sample count is exact for a non-binary dt"
+    (length (cell-trajectory cell 100.0 0.1)) 1001))
+
+;;; ── summary ──────────────────────────────────────────────────────────────
+
+(newline)
+(display "Gillespie tests: ") (display pass) (display " passed, ")
+(display fail) (display " failed") (newline)
+(when (> fail 0) (error "test failures" fail))


### PR DESCRIPTION
## Summary
- Adds `(curry gillespie)`: the Gillespie stochastic simulation algorithm (SSA) for modeling a set of chemical species undergoing reactions as a continuous-time Markov chain, rather than a system of smooth ODEs.
- Environment sensitivity (temperature, pH, nutrients) is never a special feature — it falls out of propensities just being ordinary procedures of `(species environment)`. Composable rate-law combinators (`mass-action`, `arrhenius`, `michaelis-menten`, `hill`, glued with `rate*`) let a caller build arbitrarily rich reaction kinetics from a handful of small pieces.
- Design doc, reference doc, guide (every code example independently verified to actually run), and a cookbook chapter (`docs/thoughts/anarchists-cookbook.md`).
- Also parks a related design sketch for a toy population-genetics model that composes with this one (a genome as a cells own vector of reaction rate constants) — not implemented, written up for later per explicit request.

## Bugs found and fixed before this landed

Two independent code-review rounds plus direct manual runtime testing found five real bugs:

1. `%falling-factorial`s `n<=0` early-exit returned the unmultiplied accumulator (`1`) instead of the correct `0` for a depleted reactant, so `mass-action` kept a nonzero propensity after a reactant hit zero — a real simulation run consumed a finite resource down to `-970` instead of stopping at `0`.
2. `michaelis-menten`s `km+S=0` case divided `0` by `0` unguarded — a silent NaN that poisons `gillespie-step!`s `(> a0 0)` quiescence check forever, permanently freezing an otherwise-live cell with no error.
3. `cell-trajectory` hung forever for `dt <= 0`.
4. `cell-trajectory` accumulated sample times via repeated floating-point addition, drifting for a `dt` that isnt an exact binary fraction — switched to `i*dt` from an integer step count.
5. `random-real()` can return exactly `0.0` (probability 2^-53 per draw), making `(log 0.0)` = `-inf.0` and silently jumping the cells clock to infinity in one step. Fixed with a redraw-on-exact-zero wrapper.
6. `arrhenius`/`hill` lacked the same zero-denominator guard `michaelis-menten` got — both now return their correct mathematical limit instead of dividing by zero.

## Test plan
- [x] 44/44 gillespie-specific tests pass, including regression tests for all bugs above
- [x] `ctest --test-dir build` — 103/103 suites pass, fresh `--clear-cache` run — confirmed independently of PR #77 (this branch doesnt have that RNG-determinism fix; the gillespie tests use statistical tolerances, not exact seeded values, so they pass either way)
- [x] Two independent code-review passes plus a security review (no findings — pure Scheme, no crypto usage, no untrusted input)
- [x] Every code example in `docs/guides/gillespie-cells.md` run and verified directly
