### PR TITLE
feat(srfi): close Tier 1 gaps in SRFI-125/128/170/227

### DIFF
--- a/lib/curry/modules/srfi/125.scm
+++ b/lib/curry/modules/srfi/125.scm
@@ -7,6 +7,7 @@
     hash-table-empty? hash-table-size hash-table-count hash-table-ref
     hash-table-ref/default hash-table-set! hash-table-delete!
     hash-table-intern! hash-table-update! hash-table-update!/default
+    hash-table-mutable?
     hash-table-clear! hash-table-copy hash-table-empty-copy hash-table-keys
     hash-table-values hash-table-entries hash-table->alist alist->hash-table
     hash-table-walk hash-table-for-each hash-table-map->list hash-table-fold

--- a/lib/curry/modules/srfi/128.scm
+++ b/lib/curry/modules/srfi/128.scm
@@ -11,6 +11,7 @@
     number-comparator char-comparator char-ci-comparator string-comparator
     string-ci-comparator symbol-comparator pair-comparator list-comparator
     vector-comparator eq-comparator eqv-comparator equal-comparator
+    make-eq-comparator make-eqv-comparator make-equal-comparator
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; dayyānum: "judge" -- a comparator decides order/equality, exactly
     ;; what a judge does.

--- a/lib/curry/modules/srfi/170.scm
+++ b/lib/curry/modules/srfi/170.scm
@@ -13,6 +13,8 @@
     current-directory set-current-directory! pid nice user-uid user-gid
     user-effective-uid user-effective-gid user-supplementary-gids user-info
     user-info? user-info:name user-info:uid user-info:gid user-info:home-dir
-    user-info:shell user-info:full-name group-info group-info?
+    user-info:shell user-info:full-name user-info:parsed-full-name
+    group-info group-info?
     group-info:name group-info:gid posix-time monotonic-time
-    set-environment-variable! delete-environment-variable! terminal?))
+    set-environment-variable! delete-environment-variable! terminal?
+    owner/unchanged group/unchanged))

--- a/lib/curry/modules/srfi/227.scm
+++ b/lib/curry/modules/srfi/227.scm
@@ -2,7 +2,8 @@
   (import (srfi s227 optional-arguments))
   (import (curry private lang-aliases))
   (export
-    opt-lambda let-optionals let-optionals* default-object default-object?
+    opt-lambda opt*-lambda let-optionals let-optionals* default-object default-object?
+    define-optionals define-optionals*
     %opt-bind %opt-bind-optional
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; watrum: "surplus, extra" (already used for extended-gcd/

--- a/lib/curry/modules/srfi/s125/hash-tables.scm
+++ b/lib/curry/modules/srfi/s125/hash-tables.scm
@@ -8,6 +8,7 @@
     hash-table-ref hash-table-ref/default
     hash-table-set! hash-table-delete! hash-table-intern!
     hash-table-update! hash-table-update!/default
+    hash-table-mutable?
     hash-table-clear! hash-table-copy hash-table-empty-copy
     hash-table-keys hash-table-values hash-table-entries
     hash-table->alist alist->hash-table
@@ -64,6 +65,10 @@
       (hash-table-ref/default %table-comparators t equal-comparator))
 
     (define (hash-table-empty? t) (= (hash-table-size t) 0))
+
+    ; curry has no immutable hash tables (SRFI-126's own hashtable-mutable?
+    ; -- s126/hashtables.scm -- is the same constant #t for the same reason).
+    (define (hash-table-mutable? t) #t)
     (define hash-table-count hash-table-size)
     (define hash-table-contains? hash-table-exists?)
 

--- a/lib/curry/modules/srfi/s128/comparators.scm
+++ b/lib/curry/modules/srfi/s128/comparators.scm
@@ -12,7 +12,8 @@
     char-comparator char-ci-comparator
     string-comparator string-ci-comparator symbol-comparator
     pair-comparator list-comparator vector-comparator
-    eq-comparator eqv-comparator equal-comparator)
+    eq-comparator eqv-comparator equal-comparator
+    make-eq-comparator make-eqv-comparator make-equal-comparator)
   (begin
 
     ;; ------------------------------------------------------------------
@@ -89,6 +90,13 @@
     (define eq-comparator (%make-comparator (lambda (x) #t) eq? #f #f))
     (define eqv-comparator (%make-comparator (lambda (x) #t) eqv? #f %default-hash))
     (define equal-comparator (%make-comparator (lambda (x) #t) equal? #f %default-hash))
+
+    ; The spec's typed constructors alongside the ready-made comparator
+    ; values above -- both forms are standard SRFI-128, just two ways to
+    ; get the same object (a zero-arg procedure call vs. a plain value).
+    (define (make-eq-comparator) eq-comparator)
+    (define (make-eqv-comparator) eqv-comparator)
+    (define (make-equal-comparator) equal-comparator)
 
     (define boolean-comparator
       (%make-comparator boolean? (lambda (a b) (eq? a b))

--- a/lib/curry/modules/srfi/s170/posix.scm
+++ b/lib/curry/modules/srfi/s170/posix.scm
@@ -22,6 +22,7 @@
 
     user-info user-info? user-info:name user-info:uid user-info:gid
     user-info:home-dir user-info:shell user-info:full-name
+    user-info:parsed-full-name
 
     group-info group-info? group-info:name group-info:gid
 
@@ -29,12 +30,48 @@
 
     set-environment-variable! delete-environment-variable!
 
-    terminal?)
+    terminal?
+
+    owner/unchanged group/unchanged)
   (begin
-    ; All identifiers are already named per the SRFI-170 spec and delegate
+    ; Most identifiers are already named per the SRFI-170 spec and delegate
     ; directly to the C-level (curry posix) module — re-exported here only
     ; so portable code using the (srfi s170 posix) naming convention
     ; works unchanged. Requires curry built with -DBUILD_MODULE_POSIX=ON
     ; (the default). See docs/reference/module-posix.md for the (curry
     ; posix) scope this covers and deliberately leaves out.
+    ;
+    ; Three names below have no (curry posix) counterpart and are defined
+    ; here instead, spec-compliance sugar rather than core POSIX surface:
+
+    ; owner/unchanged and group/unchanged -- pass either as the
+    ; corresponding argument to set-file-owner to leave that half alone.
+    ; Both are -1, the same sentinel chown(2) itself treats as "don't
+    ; change this id" -- set-file-owner's C implementation (fn_set_file_
+    ; owner, modules/posix/posix.c) already passes uid/gid straight
+    ; through to chown() with no translation, so passing -1 explicitly
+    ; here needs no C-side change at all.
+    (define owner/unchanged -1)
+    (define group/unchanged -1)
+
+    ; user-info:parsed-full-name -- the GECOS field (user-info:full-name)
+    ; is conventionally comma-separated (full name, office, work phone,
+    ; home phone -- the layout SRFI-170's own "parsed" variant is defined
+    ; against); this returns just the full-name portion, up to the first
+    ; comma (or the whole string if there is none). A minority of systems
+    ; instead write GECOS as "Lastname, Firstname" with no office/phone
+    ; fields at all -- on those, this returns just the surname. There is
+    ; no reliable way to distinguish the two conventions from the string
+    ; alone; this matches the convention SRFI-170 itself assumes.
+    (define (user-info:parsed-full-name info)
+      (let* ((full (user-info:full-name info))
+             (comma (%string-index full #\,)))
+        (if comma (substring full 0 comma) full)))
+
+    (define (%string-index s ch)
+      (let ((len (string-length s)))
+        (let loop ((i 0))
+          (cond ((= i len) #f)
+                ((char=? (string-ref s i) ch) i)
+                (else (loop (+ i 1)))))))
     ))

--- a/lib/curry/modules/srfi/s227/optional-arguments.scm
+++ b/lib/curry/modules/srfi/s227/optional-arguments.scm
@@ -1,6 +1,7 @@
 (define-library (srfi s227 optional-arguments)
   (import (scheme base))
-  (export opt-lambda let-optionals let-optionals* default-object default-object?
+  (export opt-lambda opt*-lambda let-optionals let-optionals* default-object default-object?
+    define-optionals define-optionals*
     %opt-bind %opt-bind-optional)
   (begin
 
@@ -63,6 +64,29 @@
         ((_ formals body ...)
          (lambda %opt-args (%opt-bind %opt-args formals body ...)))))
 
+    ;; The spec distinguishes opt-lambda (default-exprs see only the
+    ;; required parameters, not each other -- let-like) from opt*-lambda
+    ;; (each default-expr also sees previously-bound optionals -- let*-
+    ;; like). %opt-bind-optional above is already sequential/let*-like
+    ;; (each optional's binding is a nested let around the rest, so a
+    ;; later default-expr can reference an earlier optional's value) --
+    ;; the same simplification let-optionals/let-optionals* below already
+    ;; make for the same reason (comment above): curry's opt-lambda
+    ;; itself never had the spec's let-like (parallel) semantics to begin
+    ;; with, pre-dating this file's opt*-lambda addition. opt*-lambda is
+    ;; therefore a pure forwarding macro with no logic of its own -- it
+    ;; contains nothing that could drift out of sync with opt-lambda,
+    ;; since it IS opt-lambda under a second name. If opt-lambda's own
+    ;; behavior is ever changed to be genuinely parallel per spec, this
+    ;; forwarding macro needs no change at all; a new, separate
+    ;; %opt-bind-optional-parallel would back opt-lambda instead, and
+    ;; opt*-lambda would keep forwarding to today's (correct, sequential)
+    ;; implementation, wherever that ends up living.
+    (define-syntax opt*-lambda
+      (syntax-rules ()
+        ((_ formals body ...)
+         (opt-lambda formals body ...))))
+
     ;; (let-optionals* rest-list ((var default) ... [. tail-var]) body ...)
     ;; rest-list is evaluated once; both forms bind sequentially (each
     ;; default-expr may refer to earlier vars) — curry does not distinguish
@@ -77,4 +101,18 @@
     (define-syntax let-optionals
       (syntax-rules ()
         ((_ rest-expr spec body ...)
-         (let-optionals* rest-expr spec body ...))))))
+         (let-optionals* rest-expr spec body ...))))
+
+    ;; (define-optionals (name . formals) body ...) -- definition-form
+    ;; sugar equivalent to (define name (opt-lambda formals body ...)),
+    ;; the same relationship ordinary (define (name . formals) body ...)
+    ;; has to (define name (lambda formals body ...)).
+    (define-syntax define-optionals
+      (syntax-rules ()
+        ((_ (name . formals) body ...)
+         (define name (opt-lambda formals body ...)))))
+
+    (define-syntax define-optionals*
+      (syntax-rules ()
+        ((_ (name . formals) body ...)
+         (define name (opt*-lambda formals body ...)))))))

--- a/lib/curry/modules/srfi/srfi-125.scm
+++ b/lib/curry/modules/srfi/srfi-125.scm
@@ -7,6 +7,7 @@
     hash-table-empty? hash-table-size hash-table-count hash-table-ref
     hash-table-ref/default hash-table-set! hash-table-delete!
     hash-table-intern! hash-table-update! hash-table-update!/default
+    hash-table-mutable?
     hash-table-clear! hash-table-copy hash-table-empty-copy hash-table-keys
     hash-table-values hash-table-entries hash-table->alist alist->hash-table
     hash-table-walk hash-table-for-each hash-table-map->list hash-table-fold

--- a/lib/curry/modules/srfi/srfi-128.scm
+++ b/lib/curry/modules/srfi/srfi-128.scm
@@ -11,6 +11,7 @@
     number-comparator char-comparator char-ci-comparator string-comparator
     string-ci-comparator symbol-comparator pair-comparator list-comparator
     vector-comparator eq-comparator eqv-comparator equal-comparator
+    make-eq-comparator make-eqv-comparator make-equal-comparator
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; dayyānum: "judge" -- a comparator decides order/equality, exactly
     ;; what a judge does.

--- a/lib/curry/modules/srfi/srfi-170.scm
+++ b/lib/curry/modules/srfi/srfi-170.scm
@@ -13,6 +13,8 @@
     current-directory set-current-directory! pid nice user-uid user-gid
     user-effective-uid user-effective-gid user-supplementary-gids user-info
     user-info? user-info:name user-info:uid user-info:gid user-info:home-dir
-    user-info:shell user-info:full-name group-info group-info?
+    user-info:shell user-info:full-name user-info:parsed-full-name
+    group-info group-info?
     group-info:name group-info:gid posix-time monotonic-time
-    set-environment-variable! delete-environment-variable! terminal?))
+    set-environment-variable! delete-environment-variable! terminal?
+    owner/unchanged group/unchanged))

--- a/lib/curry/modules/srfi/srfi-227.scm
+++ b/lib/curry/modules/srfi/srfi-227.scm
@@ -2,7 +2,8 @@
   (import (srfi s227 optional-arguments))
   (import (curry private lang-aliases))
   (export
-    opt-lambda let-optionals let-optionals* default-object default-object?
+    opt-lambda opt*-lambda let-optionals let-optionals* default-object default-object?
+    define-optionals define-optionals*
     %opt-bind %opt-bind-optional
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; watrum: "surplus, extra" (already used for extended-gcd/

--- a/modules/posix/posix.c
+++ b/modules/posix/posix.c
@@ -335,6 +335,14 @@ static curry_val fn_set_file_mode(int ac, curry_val *av, void *ud) {
 static curry_val fn_set_file_owner(int ac, curry_val *av, void *ud) {
     (void)ud;
     const char *path = req_string(av[0], "set-file-owner");
+    /* uid/gid pass straight through to chown(2) with no validation --
+       SRFI-170's owner/unchanged and group/unchanged constants (both -1,
+       lib/curry/modules/srfi/s170/posix.scm) rely on this: -1 is the
+       POSIX sentinel chown(2) itself treats as "leave this id alone",
+       so those constants need no special-casing here at all. Keep it
+       that way -- rejecting negative uid/gid here would silently break
+       both Scheme-level constants with no compiler or test signal
+       pointing back to this function. */
     uid_t uid = (uid_t)req_fixnum(av[1], "set-file-owner");
     gid_t gid = ac >= 3 ? (gid_t)req_fixnum(av[2], "set-file-owner") : (gid_t)-1;
     if (chown(path, uid, gid) < 0) posix_error("set-file-owner");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -228,6 +228,13 @@ if(BUILD_MODULE_POSIX AND TARGET curry_posix)
     add_test(NAME time_srfi COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/time_srfi_tests.scm)
     set_tests_properties(time_srfi PROPERTIES
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+    add_test(NAME srfi_170 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_170_tests.scm)
+    set_tests_properties(srfi_170 PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+    # Also needs (curry posix), transitively via (srfi srfi-170).
+    add_test(NAME srfi_legacy_dashed_names COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_legacy_dashed_names_tests.scm)
+    set_tests_properties(srfi_legacy_dashed_names PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
     # (curry okf) imports (curry posix) for directory walking and (srfi 19)
     # for staleness/log timestamps.
     add_test(NAME okf COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/okf_tests.scm)

--- a/tests/srfi_170_tests.scm
+++ b/tests/srfi_170_tests.scm
@@ -1,0 +1,49 @@
+;;; srfi_170_tests.scm — tests for (srfi 170) additions not already covered
+;;; by posix_tests.scm's (curry posix) coverage: owner/unchanged,
+;;; group/unchanged, user-info:parsed-full-name.
+
+(import (srfi 170))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label result expected)
+  (if (equal? result expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " got ") (write result)
+             (display " expected ") (write expected)
+             (newline)
+             (set! fail (+ fail 1)))))
+
+;;; owner/unchanged, group/unchanged -- both -1, the same sentinel chown(2)
+;;; itself treats as "leave this id alone".
+
+(check "owner/unchanged is -1" owner/unchanged -1)
+(check "group/unchanged is -1" group/unchanged -1)
+
+;;; user-info:parsed-full-name -- the full-name portion of the GECOS field,
+;;; up to the first comma (or the whole string if there is none). Can't
+;;; fabricate a comma-containing GECOS field for the real current user, so
+;;; this checks it agrees with user-info:full-name whenever the real value
+;;; has no comma (the common case), which is still a real behavioral check.
+
+(let* ((me (user-info (user-uid)))
+       (full (user-info:full-name me))
+       (parsed (user-info:parsed-full-name me)))
+  (check "user-info:parsed-full-name returns a string" (string? parsed) #t)
+  (if (not (memv #\, (string->list full)))
+      (check "user-info:parsed-full-name matches full-name when no comma present"
+             parsed full)
+      (check "user-info:parsed-full-name is a prefix of full-name when a comma is present"
+             (string=? (substring full 0 (string-length parsed)) parsed)
+             #t)))
+
+;;; Summary
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/srfi_comparators_tests.scm
+++ b/tests/srfi_comparators_tests.scm
@@ -51,6 +51,17 @@
        (guard (e (#t 'caught)) (comparator-check-type real-comparator "x"))
        'caught)
 
+;;; make-eq-comparator / make-eqv-comparator / make-equal-comparator --
+;;; the spec's typed constructor form alongside the ready-made
+;;; eq-comparator/eqv-comparator/equal-comparator values.
+(check "make-eq-comparator produces a comparator" (comparator? (make-eq-comparator)) #t)
+(check "make-eq-comparator matches eq-comparator's equality"
+       (=? (make-eq-comparator) 'a 'a) #t)
+(check "make-eqv-comparator matches eqv-comparator's equality"
+       (=? (make-eqv-comparator) 1.0 1.0) #t)
+(check "make-equal-comparator matches equal-comparator's equality"
+       (=? (make-equal-comparator) (list 1 2) (list 1 2)) #t)
+
 ;;; Summary
 
 (newline)

--- a/tests/srfi_hash_tables_125_126_tests.scm
+++ b/tests/srfi_hash_tables_125_126_tests.scm
@@ -62,6 +62,12 @@
        (procedure? (hashtable-hash-function (make-hashtable equal-hash equal?)))
        #t)
 
+;;; hash-table-mutable? -- curry has no immutable hash tables, so this is
+;;; always #t (same as SRFI-126's own hashtable-mutable? above it).
+(check "hash-table-mutable? is #t"
+       (hash-table-mutable? (make-hash-table equal-comparator))
+       #t)
+
 ;;; Summary
 
 (newline)

--- a/tests/srfi_legacy_dashed_names_tests.scm
+++ b/tests/srfi_legacy_dashed_names_tests.scm
@@ -1,0 +1,56 @@
+;;; srfi_legacy_dashed_names_tests.scm — regression coverage for the
+;;; legacy dashed-name library aliases (e.g. (srfi srfi-170), distinct
+;;; from the numeric (srfi 170)). A code-review pass found these four
+;;; hadn't been updated to re-export the new Tier-1 SRFI-gap additions
+;;; alongside their numeric-named counterparts -- `(import (srfi
+;;; srfi-170))` then calling `user-info:parsed-full-name` raised
+;;; unbound-variable while `(import (srfi 170))` worked fine for the
+;;; exact same call. This file exists specifically so that class of gap
+;;; can't reappear silently.
+
+(import (srfi srfi-125) (srfi srfi-128) (srfi srfi-170) (srfi srfi-227))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label result expected)
+  (if (equal? result expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " got ") (write result)
+             (display " expected ") (write expected)
+             (newline)
+             (set! fail (+ fail 1)))))
+
+;;; (srfi srfi-125)
+(check "srfi-125 legacy shim exports hash-table-mutable?"
+       (hash-table-mutable? (make-hash-table (make-equal-comparator)))
+       #t)
+
+;;; (srfi srfi-128)
+(check "srfi-128 legacy shim exports make-eq-comparator"
+       (comparator? (make-eq-comparator))
+       #t)
+
+;;; (srfi srfi-170)
+(check "srfi-170 legacy shim exports owner/unchanged" owner/unchanged -1)
+(check "srfi-170 legacy shim exports group/unchanged" group/unchanged -1)
+(check "srfi-170 legacy shim exports user-info:parsed-full-name"
+       (string? (user-info:parsed-full-name (user-info (user-uid))))
+       #t)
+
+;;; (srfi srfi-227)
+(define-optionals (f a #:optional (b (* a 2))) (+ a b))
+(check "srfi-227 legacy shim exports define-optionals" (f 5) 15)
+
+(define-optionals* (g a #:optional (b (* a 3)) (c (+ a b))) (list a b c))
+(check "srfi-227 legacy shim exports define-optionals*" (g 4) (list 4 12 16))
+
+;;; Summary
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/srfi_receive_assume_optional_tests.scm
+++ b/tests/srfi_receive_assume_optional_tests.scm
@@ -46,6 +46,19 @@
        (let-optionals* (list 1 2 3 4) ((x 0) (y 0) . rest) (list x y rest))
        (list 1 2 '(3 4)))
 
+;;; opt*-lambda / define-optionals / define-optionals*
+
+(define h (opt*-lambda (a #:optional (b (* a 2)) (c (+ a b))) (list a b c)))
+(check "opt*-lambda: later default sees an earlier optional's value" (h 5) (list 5 10 15))
+(check "opt*-lambda: explicit args still override defaults" (h 5 1) (list 5 1 6))
+
+(define-optionals (i a #:optional (b (* a 3))) (+ a b))
+(check "define-optionals: default applied" (i 4) 16)
+(check "define-optionals: explicit arg overrides default" (i 4 100) 104)
+
+(define-optionals* (j a #:optional (b (* a 3)) (c (+ a b))) (list a b c))
+(check "define-optionals*: later default sees an earlier optional's value" (j 4) (list 4 12 16))
+
 ;;; Summary
 
 (newline)


### PR DESCRIPTION
## Summary

Closes the "Tier 1" (trivial-effort) gaps found by a full 39-SRFI compatibility audit run this session:

- **SRFI-170** (POSIX): `owner/unchanged`, `group/unchanged` constants for `set-file-owner`, and `user-info:parsed-full-name`
- **SRFI-125** (hash tables): `hash-table-mutable?`
- **SRFI-128** (comparators): `make-eq-comparator`, `make-eqv-comparator`, `make-equal-comparator`
- **SRFI-227** (optional arguments): `opt*-lambda`, `define-optionals`, `define-optionals*`

Plus a regression test for a real bug an independent code review caught: every fix above only updated each SRFI's numeric-named shim (e.g. `170.scm`), not its legacy dashed-name sibling (`srfi-170.scm`) — each is a separate `define-library` with its own independent export list, so `(import (srfi srfi-170))` raised unbound-variable on a call that worked fine via `(import (srfi 170))`. All four dashed-name shims are fixed now, with dedicated coverage so that class of gap can't reappear silently.

## Commits
- `feat(srfi170)`, `feat(srfi125)`, `feat(srfi128)`, `feat(srfi227)` — one per SRFI, each with its own tests
- `test(srfi)` — cross-cutting legacy dashed-name-shim regression coverage

## Test plan
- [x] `ctest --test-dir build` — 105/105 suites pass, fresh `--clear-cache` run, verified independently on this branch (cherry-picked onto current `origin/main`, not just on the original working branch)
- [x] Independent code review — found and fixed the legacy-shim gap above, a fragile invisible C/Scheme dependency (documented on both sides now), and tightened a comment on `opt*-lambda`'s forwarding-macro design
