### PR TITLE
feat(srfi): close Tier 2 gaps in SRFI-1/27/125/128/133

### DIFF
--- a/lib/curry/modules/srfi/1.scm
+++ b/lib/curry/modules/srfi/1.scm
@@ -21,11 +21,15 @@
 
     ; Fold, unfold, map
     fold fold-right reduce reduce-right
+    pair-fold pair-fold-right
     unfold unfold-right
-    map! pair-for-each append-map append-map! filter-map flat-map
+    map! map-in-order pair-for-each append-map append-map! filter-map flat-map
 
     ; Filtering / partitioning
-    any every remove delete delete! partition count
+    any every remove remove! filter! delete delete! partition partition! count
+
+    ; car+cdr, length+, except-last-pair
+    car+cdr length+ except-last-pair except-last-pair!
 
     ; Searching
     find find-tail take-while drop-while span break list-index
@@ -50,6 +54,7 @@
     lset<= lset= lset-adjoin
     lset-union lset-intersection lset-difference lset-xor
     lset-union! lset-intersection! lset-difference! lset-xor!
+    lset-diff+intersection lset-diff+intersection!
 
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     rakāsum-mala 𒈠𒀀

--- a/lib/curry/modules/srfi/125.scm
+++ b/lib/curry/modules/srfi/125.scm
@@ -13,6 +13,7 @@
     hash-table-walk hash-table-for-each hash-table-map->list hash-table-fold
     hash-table-count-matching hash-table-map! hash-table-prune!
     hash-table-union! hash-table-intersection! hash-table-difference!
+    hash-table=? hash-table-find hash-table-pop! hash-table-xor!
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; kunukkum: "seal" (same root as SRFI 69, above) -- the words are
     ;; shared for shared english names, distinct where the APIs diverge.

--- a/lib/curry/modules/srfi/128.scm
+++ b/lib/curry/modules/srfi/128.scm
@@ -12,6 +12,9 @@
     string-ci-comparator symbol-comparator pair-comparator list-comparator
     vector-comparator eq-comparator eqv-comparator equal-comparator
     make-eq-comparator make-eqv-comparator make-equal-comparator
+    boolean-hash char-hash char-ci-hash string-hash string-ci-hash
+    symbol-hash number-hash default-hash hash-bound hash-salt
+    comparator-if<=>
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; dayyānum: "judge" -- a comparator decides order/equality, exactly
     ;; what a judge does.

--- a/lib/curry/modules/srfi/133.scm
+++ b/lib/curry/modules/srfi/133.scm
@@ -8,7 +8,10 @@
     vector-swap! reverse! vector-reverse! vector-reverse!* vector-index
     vector-index-right vector-count vector-any vector-every vector-fold
     vector-fold-right vector-binary-search vector-concatenate vector-unfold
-    vector-unfold-right
+    vector-unfold-right vector-unfold! vector-unfold-right!
+    vector-reverse-copy vector-append-subvectors vector-map! vector-cumulate
+    vector-skip vector-skip-right vector-partition
+    reverse-vector->list reverse-list->vector
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; Extends the vector root (ṣindum) already established for the
     ;; R7RS core vector procedures.

--- a/lib/curry/modules/srfi/27.scm
+++ b/lib/curry/modules/srfi/27.scm
@@ -4,6 +4,7 @@
   (export
     default-random-source make-random-source random-source?
     random-source-randomize! random-source-pseudo-randomize!
+    random-source-state-ref random-source-state-set!
     random-source->random-real random-source->random-integer random-real
     random-integer
     ;; Akkadian synonym -- pūrum: "lot" (as in casting lots), the genuine

--- a/lib/curry/modules/srfi/s1/lists.scm
+++ b/lib/curry/modules/srfi/s1/lists.scm
@@ -20,11 +20,15 @@
 
     ; Fold, unfold, map
     fold fold-right reduce reduce-right
+    pair-fold pair-fold-right
     unfold unfold-right
-    map! pair-for-each append-map append-map! filter-map flat-map
+    map! map-in-order pair-for-each append-map append-map! filter-map flat-map
 
     ; Filtering / partitioning
-    any every remove delete delete! partition count
+    any every remove remove! filter! delete delete! partition partition! count
+
+    ; car+cdr, length+, except-last-pair
+    car+cdr length+ except-last-pair except-last-pair!
 
     ; Searching
     find find-tail take-while drop-while span break list-index
@@ -48,7 +52,8 @@
     ; Lists as sets
     lset<= lset= lset-adjoin
     lset-union lset-intersection lset-difference lset-xor
-    lset-union! lset-intersection! lset-difference! lset-xor!)
+    lset-union! lset-intersection! lset-difference! lset-xor!
+    lset-diff+intersection lset-diff+intersection!)
   (begin
 
     ;;; ---- iota (pre-existing) ----
@@ -64,6 +69,10 @@
     ;;; ---- Constructors ----
 
     (define (xcons d a) (cons a d))
+
+    ;;; ---- car+cdr ----
+    (define (car+cdr p) (values (car p) (cdr p)))
+
     ;; Accumulator-based, not the naive (cons (car args) (apply cons*
     ;; (cdr args))) recursion -- that builds one C stack frame per
     ;; argument with the cons happening AFTER the recursive call returns
@@ -188,6 +197,21 @@
     (define (last-pair lst)
       (if (null? (cdr lst)) lst (last-pair (cdr lst))))
 
+    ;; #f for a circular list rather than hanging forever -- reuses the
+    ;; already cycle-safe circular-list? (its own tortoise/hare walk)
+    ;; instead of a third independent manual walk here, the same
+    ;; deliberate choice dotted-list?'s own comment above explains (an
+    ;; earlier version of that predicate did its own naive walk with no
+    ;; cycle detection and hung forever; not repeating that mistake here).
+    (define (length+ lst) (if (circular-list? lst) #f (length lst)))
+
+    ;; Accumulator-based tail loop -- see take's own comment above on why
+    ;; (same non-tail-cons-recursion stack-overflow risk this avoids).
+    (define (except-last-pair lst)
+      (let loop ((l lst) (acc '()))
+        (if (null? (cdr l)) (reverse acc) (loop (cdr l) (cons (car l) acc)))))
+    (define (except-last-pair! lst) (except-last-pair lst))
+
     ;;; ---- Fold / unfold / map ----
 
     ;; SRFI-1's fold calls kons with the CURRENT ELEMENT(S) FIRST and the
@@ -222,6 +246,32 @@
           (let ((rev (reverse lst)))
             (fold f (car rev) (cdr rev)))))
 
+    ;; Like fold, but f receives the current PAIR (cons cell), not its
+    ;; car -- lets f side-effect the list's structure (e.g. set-cdr!) as
+    ;; it walks, which is the entire point of this variant over plain
+    ;; fold. Already tail-recursive: grabs (cdr lis) before calling f, in
+    ;; case f mutates lis's own cdr.
+    (define (pair-fold f zero lis)
+      (let loop ((lis lis) (acc zero))
+        (if (null? lis)
+            acc
+            (let ((tail (cdr lis)))
+              (loop tail (f lis acc))))))
+
+    ;; Right-to-left version. The reference implementation is naturally
+    ;; recursive (f's result depends on recursing into the tail first) --
+    ;; avoided here per this file's established convention (see take's
+    ;; comment above): walk left-to-right collecting each pair by
+    ;; consing (which reverses the order, so the resulting list has the
+    ;; last pair first), then a single ordinary left-to-right fold over
+    ;; that already-reversed list computes the same right-to-left result,
+    ;; with no non-tail recursion anywhere.
+    (define (pair-fold-right f zero lis)
+      (let loop ((l lis) (tails '()))
+        (if (null? l)
+            (fold f zero tails)
+            (loop (cdr l) (cons l tails)))))
+
     ;; (unfold p f g seed [tail-gen]) builds a list left-to-right: stops
     ;; when (p seed) is true, otherwise conses (f seed) and recurses on
     ;; (g seed). tail-gen (default: seed is dropped, proper list) computes
@@ -241,6 +291,23 @@
         (if (p seed) acc (loop (g seed) (cons (f seed) acc)))))
 
     (define (map! f lst1 . rest) (apply map f lst1 rest))
+
+    ;; Guaranteed strictly left-to-right application order, unlike plain
+    ;; map/map! above -- curry's core global map (which map/map! both
+    ;; ultimately are, re-exported from the global env at the top of this
+    ;; file) goes parallel above a size threshold (src/builtins_curry.c,
+    ;; map_par_threshold), so it does NOT guarantee left-to-right side-
+    ;; effect ordering. map-in-order exists specifically for callers that
+    ;; need that guarantee (f has side effects whose order matters), so
+    ;; it's a real sequential loop here, not an alias.
+    (define (map-in-order f lst . rest)
+      (if (null? rest)
+          (let loop ((l lst) (acc '()))
+            (if (null? l) (reverse acc) (loop (cdr l) (cons (f (car l)) acc))))
+          (let loop ((ls (cons lst rest)) (acc '()))
+            (if (any null? ls)
+                (reverse acc)
+                (loop (map cdr ls) (cons (apply f (map car ls)) acc))))))
 
     (define (pair-for-each f lst)
       (let loop ((p lst)) (when (pair? p) (f p) (loop (cdr p)))))
@@ -291,6 +358,12 @@
 
     (define (remove pred lst) (filter (lambda (x) (not (pred x))) lst))
 
+    ;; SRFI-1 permits (doesn't require) the !-suffixed variants to
+    ;; imperatively splice -- plain aliases, same rationale as take!/
+    ;; drop-right! above.
+    (define (filter! pred lst) (filter pred lst))
+    (define (remove! pred lst) (remove pred lst))
+
     (define (delete x lst . rest)
       (let ((=? (if (null? rest) equal? (car rest))))
         (filter (lambda (y) (not (=? x y))) lst)))
@@ -323,6 +396,8 @@
         (cond ((null? l) (values (reverse yes) (reverse no)))
               ((pred (car l)) (loop (cdr l) (cons (car l) yes) no))
               (else           (loop (cdr l) yes (cons (car l) no))))))
+
+    (define (partition! pred lst) (partition pred lst))
 
     ;;; ---- Searching ----
 
@@ -453,4 +528,16 @@
     (define (lset-union! =? . lists) (apply lset-union =? lists))
     (define (lset-intersection! =? lst1 . lists) (apply lset-intersection =? lst1 lists))
     (define (lset-difference! =? lst1 . lists) (apply lset-difference =? lst1 lists))
-    (define (lset-xor! =? . lists) (apply lset-xor =? lists))))
+    (define (lset-xor! =? . lists) (apply lset-xor =? lists))
+
+    ;; Combined difference+intersection in one pass, rather than calling
+    ;; lset-difference and lset-intersection separately (each its own
+    ;; full walk over lst1). A single partition over the same "is x in
+    ;; any of lists?" test gives both: the "not in any" bucket IS the
+    ;; difference, and everything else (in at least one) IS the
+    ;; intersection -- and partition already returns (values yes no) in
+    ;; that same difference-then-intersection order the spec requires.
+    (define (lset-diff+intersection =? lst1 . lists)
+      (partition (lambda (x) (not (any (lambda (l) (any (lambda (y) (=? x y)) l)) lists)))
+                 lst1))
+    (define (lset-diff+intersection! =? lst1 . lists) (apply lset-diff+intersection =? lst1 lists))))

--- a/lib/curry/modules/srfi/s125/hash-tables.scm
+++ b/lib/curry/modules/srfi/s125/hash-tables.scm
@@ -15,7 +15,8 @@
     hash-table-walk hash-table-for-each hash-table-map->list
     hash-table-fold hash-table-count-matching
     hash-table-map! hash-table-prune!
-    hash-table-union! hash-table-intersection! hash-table-difference!)
+    hash-table-union! hash-table-intersection! hash-table-difference!
+    hash-table=? hash-table-find hash-table-pop! hash-table-xor!)
   (begin
 
     ; curry's native hash table (src/set.h) supports exactly three
@@ -157,4 +158,53 @@
       (for-each (lambda (kv) (if (hash-table-contains? t2 (car kv))
                                   (hash-table-delete! t1 (car kv))))
                 (hash-table->alist t1))
+      t1)
+
+    ; Same keys (both directions, so an extra key on either side fails
+    ; immediately via the size check) and every shared key's value equal
+    ; per value-comparator's own equality predicate -- not necessarily
+    ; equal? or either table's own key-equality, which is exactly why
+    ; the spec takes value-comparator as an explicit argument here rather
+    ; than reusing hash-table-comparator.
+    (define (hash-table=? value-comparator t1 t2)
+      (and (= (hash-table-size t1) (hash-table-size t2))
+           (let ((=? (comparator-equality-predicate value-comparator)))
+             (let loop ((kvs (hash-table->alist t1)))
+               (or (null? kvs)
+                   (and (hash-table-contains? t2 (caar kvs))
+                        (=? (cdar kvs) (hash-table-ref t2 (caar kvs)))
+                        (loop (cdr kvs))))))))
+
+    ; (proc key value) for each entry until it returns non-#f, in which
+    ; case that return value is hash-table-find's own result; (failure)
+    ; if no entry satisfies proc. Iteration order matches hash-table->
+    ; alist's own (native hash-table bucket order, not insertion order).
+    (define (hash-table-find proc t failure)
+      (let loop ((kvs (hash-table->alist t)))
+        (if (null? kvs)
+            (failure)
+            (let ((r (proc (caar kvs) (cdar kvs))))
+              (or r (loop (cdr kvs)))))))
+
+    ; Removes and returns one (arbitrary -- native hash-table bucket
+    ; order, not insertion order) entry as two values. Spec says the
+    ; behavior on an empty table is unspecified; raising here rather
+    ; than returning something meaningless.
+    (define (hash-table-pop! t)
+      (if (hash-table-empty? t)
+          (error "hash-table-pop!: table is empty")
+          (let* ((kv (car (hash-table->alist t))))
+            (hash-table-delete! t (car kv))
+            (values (car kv) (cdr kv)))))
+
+    ; Symmetric difference of KEYS, in place on t1: a key present in both
+    ; is removed from t1; a key present only in t2 is copied into t1
+    ; (with t2's value) -- t1 ends up holding exactly the keys that were
+    ; in exactly one of the two tables, mirroring set-xor!'s own shape.
+    (define (hash-table-xor! t1 t2)
+      (for-each (lambda (kv)
+                  (if (hash-table-contains? t1 (car kv))
+                      (hash-table-delete! t1 (car kv))
+                      (hash-table-set! t1 (car kv) (cdr kv))))
+                (hash-table->alist t2))
       t1)))

--- a/lib/curry/modules/srfi/s128/comparators.scm
+++ b/lib/curry/modules/srfi/s128/comparators.scm
@@ -13,7 +13,10 @@
     string-comparator string-ci-comparator symbol-comparator
     pair-comparator list-comparator vector-comparator
     eq-comparator eqv-comparator equal-comparator
-    make-eq-comparator make-eqv-comparator make-equal-comparator)
+    make-eq-comparator make-eqv-comparator make-equal-comparator
+    boolean-hash char-hash char-ci-hash string-hash string-ci-hash
+    symbol-hash number-hash default-hash hash-bound hash-salt
+    comparator-if<=>)
   (begin
 
     ;; ------------------------------------------------------------------
@@ -73,6 +76,22 @@
     (define (<=? cmp . objs) (%chain (lambda (a b) (not ((comparator-ordering-predicate cmp) b a))) cmp objs))
     (define (>=? cmp . objs) (%chain (lambda (a b) (not ((comparator-ordering-predicate cmp) a b))) cmp objs))
 
+    ;; (comparator-if<=> [comparator] a b less-branch equal-branch greater-branch)
+    ;; -- computes the 3-way comparison once (equality first, then
+    ;; ordering) and evaluates exactly one branch. comparator is optional
+    ;; per spec, defaulting to (default-comparator); the two clauses
+    ;; below dispatch on that via ordinary syntax-rules arity matching
+    ;; (5 sub-forms vs. 6), which is unambiguous since the two shapes
+    ;; have different lengths.
+    (define-syntax comparator-if<=>
+      (syntax-rules ()
+        ((_ a b less eq gtr)
+         (comparator-if<=> default-comparator a b less eq gtr))
+        ((_ comparator a b less eq gtr)
+         (cond ((=? comparator a b) eq)
+               ((<? comparator a b) less)
+               (else gtr)))))
+
     ;; ------------------------------------------------------------------
     ;; Basic-type comparators
     ;; ------------------------------------------------------------------
@@ -97,6 +116,37 @@
     (define (make-eq-comparator) eq-comparator)
     (define (make-eqv-comparator) eqv-comparator)
     (define (make-equal-comparator) equal-comparator)
+
+    ; The spec's standalone hash procedures, alongside the comparators
+    ; above that already use %default-hash internally for the same
+    ; types -- %default-hash's write-then-hash approach already handles
+    ; every one of these types correctly (write produces distinguishing
+    ; text per type: #t/#f, #\a, "str", a-symbol, 42), so each of these
+    ; is a direct call except the two case-insensitive ones, which fold
+    ; case first so char-ci=?/string-ci=?-equal values hash the same.
+    (define (boolean-hash b) (%default-hash b))
+    (define (char-hash c) (%default-hash c))
+    (define (char-ci-hash c) (%default-hash (char-foldcase c)))
+    (define (string-hash s) (%default-hash s))
+    (define (string-ci-hash s) (%default-hash (string-foldcase s)))
+    (define (symbol-hash s) (%default-hash s))
+    (define (number-hash n) (%default-hash n))
+    (define (default-hash obj) (%default-hash obj))
+
+    ; %default-hash's own modulus (see its definition below) -- every
+    ; hash-bound-and-hash-salt pair curry ships is fixed and known ahead
+    ; of time, so hash-bound is a plain constant rather than something
+    ; computed from a comparator's own hash-function.
+    (define (hash-bound) 1073741824)
+
+    ; A fixed, non-secret salt value: %default-hash and every hash
+    ; procedure above are pure functions of their input with no salting
+    ; at all, so this exists only so a caller writing their OWN salted
+    ; hash function has a stable value to fold in for consistency with
+    ; the rest of a program -- curry's own built-in hash functions don't
+    ; read it, which the spec permits (it requires hash-salt to exist and
+    ; be stable, not that every hash function must incorporate it).
+    (define (hash-salt) 0)
 
     (define boolean-comparator
       (%make-comparator boolean? (lambda (a b) (eq? a b))

--- a/lib/curry/modules/srfi/s133/vectors.scm
+++ b/lib/curry/modules/srfi/s133/vectors.scm
@@ -12,7 +12,10 @@
     vector-any vector-every
     vector-fold vector-fold-right
     vector-binary-search vector-concatenate
-    vector-unfold vector-unfold-right)
+    vector-unfold vector-unfold-right vector-unfold! vector-unfold-right!
+    vector-reverse-copy vector-append-subvectors vector-map! vector-cumulate
+    vector-skip vector-skip-right vector-partition
+    reverse-vector->list reverse-list->vector)
   (begin
 
     (define (vector-empty? v) (= (vector-length v) 0))
@@ -124,4 +127,122 @@
           (if (>= i 0)
               (call-with-values (lambda () (apply f i ss))
                 (lambda (val . next-ss) (vector-set! v i val) (loop (- i 1) next-ss)))))
-        v))))
+        v))
+
+    ;; In-place variants of vector-unfold/vector-unfold-right above --
+    ;; write into an existing v's [start, end) instead of allocating a
+    ;; new vector.
+    (define (vector-unfold! f v start end . seeds)
+      (let loop ((i start) (ss seeds))
+        (when (< i end)
+          (call-with-values (lambda () (apply f i ss))
+            (lambda (val . next-ss) (vector-set! v i val) (loop (+ i 1) next-ss))))))
+
+    (define (vector-unfold-right! f v start end . seeds)
+      (let loop ((i (- end 1)) (ss seeds))
+        (when (>= i start)
+          (call-with-values (lambda () (apply f i ss))
+            (lambda (val . next-ss) (vector-set! v i val) (loop (- i 1) next-ss))))))
+
+    (define (vector-reverse-copy v . range)
+      (call-with-values (lambda () (%range v range))
+        (lambda (start end)
+          (let* ((len (- end start)) (result (make-vector len)))
+            (let loop ((i start) (j (- len 1)))
+              (when (< i end)
+                (vector-set! result j (vector-ref v i))
+                (loop (+ i 1) (- j 1))))
+            result))))
+
+    ;; (vector-append-subvectors v1 start1 end1 v2 start2 end2 ...) --
+    ;; like vector-append, but each argument is a (vector start end)
+    ;; triple rather than a whole vector, avoiding an intermediate
+    ;; vector-copy per input the naive (vector-append (vector-copy v1
+    ;; start1 end1) ...) approach would need. Two passes: compute the
+    ;; total length first so the result is allocated exactly once, then
+    ;; fill each region via vector-copy!.
+    (define (vector-append-subvectors . args)
+      (define (triples lst)
+        (if (null? lst) '() (cons (list (car lst) (cadr lst) (caddr lst)) (triples (cdddr lst)))))
+      (let* ((ts (triples args))
+             (total (fold-left (lambda (acc t) (+ acc (- (caddr t) (cadr t)))) 0 ts))
+             (result (make-vector total)))
+        (let loop ((ts ts) (pos 0))
+          (if (null? ts)
+              result
+              (let* ((t (car ts)) (v (car t)) (s (cadr t)) (e (caddr t)))
+                (vector-copy! result pos v s e)
+                (loop (cdr ts) (+ pos (- e s))))))))
+
+    ;; Destructive map into the FIRST vector -- like vector-map, but v's
+    ;; own contents are overwritten instead of a new vector allocated.
+    ;; Iterates only over the shortest vector's length when the argument
+    ;; vectors have unequal lengths, per SRFI-133's own convention for
+    ;; this procedure -- checked directly, this is NOT what curry's own
+    ;; native (core, non-SRFI) vector-map does with mismatched lengths
+    ;; (it raises instead), so don't assume the two agree on that case.
+    (define (vector-map! f v . vs)
+      (let ((len (apply min (vector-length v) (map vector-length vs))))
+        (let loop ((i 0))
+          (when (< i len)
+            (vector-set! v i (apply f (vector-ref v i) (map (lambda (v2) (vector-ref v2 i)) vs)))
+            (loop (+ i 1))))
+        v))
+
+    ;; Cumulative fold: result[0] = (f knil v[0]), result[i] = (f
+    ;; result[i-1] v[i]) -- a running total/max/etc. as a new vector the
+    ;; same length as v, not a single final accumulator the way
+    ;; vector-fold's own single return value is.
+    (define (vector-cumulate f knil v)
+      (let* ((len (vector-length v)) (result (make-vector len)))
+        (let loop ((i 0) (acc knil))
+          (if (= i len)
+              result
+              (let ((acc2 (f acc (vector-ref v i))))
+                (vector-set! result i acc2)
+                (loop (+ i 1) acc2))))))
+
+    ;; The complement of vector-index/vector-index-right: the index of
+    ;; the first (resp. last) element pred does NOT match, rather than
+    ;; does.
+    (define (vector-skip pred v . range) (apply vector-index (lambda (x) (not (pred x))) v range))
+    (define (vector-skip-right pred v . range)
+      (apply vector-index-right (lambda (x) (not (pred x))) v range))
+
+    ;; Returns two values: a new vector with every pred-satisfying
+    ;; element first (stable, original relative order preserved), then
+    ;; every non-satisfying element (also stable), and the count of
+    ;; satisfying elements -- that count is also the boundary index
+    ;; between the two groups in the result vector.
+    (define (vector-partition pred v . range)
+      (call-with-values (lambda () (%range v range))
+        (lambda (start end)
+          (let* ((len (- end start))
+                 (result (make-vector len))
+                 (count (vector-count pred v start end)))
+            (let loop ((i start) (yes-idx 0) (no-idx count))
+              (if (= i end)
+                  (values result count)
+                  (if (pred (vector-ref v i))
+                      (begin (vector-set! result yes-idx (vector-ref v i))
+                             (loop (+ i 1) (+ yes-idx 1) no-idx))
+                      (begin (vector-set! result no-idx (vector-ref v i))
+                             (loop (+ i 1) yes-idx (+ no-idx 1))))))))))
+
+    ;; A list of v's elements in reverse order -- consing while walking
+    ;; forward naturally produces the reverse, so this needs no separate
+    ;; reverse step over vector->list's own result.
+    (define (reverse-vector->list v . range)
+      (call-with-values (lambda () (%range v range))
+        (lambda (start end)
+          (let loop ((i start) (acc '()))
+            (if (= i end) acc (loop (+ i 1) (cons (vector-ref v i) acc)))))))
+
+    ;; A vector containing lst's elements in reverse order -- placing
+    ;; each list element from the END of the vector backward as we walk
+    ;; the list forward achieves this in one pass, without building a
+    ;; forward vector first and reversing it.
+    (define (reverse-list->vector lst)
+      (let* ((len (length lst)) (v (make-vector len)))
+        (let loop ((l lst) (i (- len 1)))
+          (if (null? l) v (begin (vector-set! v i (car l)) (loop (cdr l) (- i 1)))))))))

--- a/lib/curry/modules/srfi/s27/random-bits.scm
+++ b/lib/curry/modules/srfi/s27/random-bits.scm
@@ -6,6 +6,8 @@
     random-source?
     random-source-randomize!
     random-source-pseudo-randomize!
+    random-source-state-ref
+    random-source-state-set!
     random-source->random-real
     random-source->random-integer
     random-real

--- a/lib/curry/modules/srfi/srfi-1.scm
+++ b/lib/curry/modules/srfi/srfi-1.scm
@@ -21,11 +21,15 @@
 
     ; Fold, unfold, map
     fold fold-right reduce reduce-right
+    pair-fold pair-fold-right
     unfold unfold-right
-    map! pair-for-each append-map append-map! filter-map flat-map
+    map! map-in-order pair-for-each append-map append-map! filter-map flat-map
 
     ; Filtering / partitioning
-    any every remove delete delete! partition count
+    any every remove remove! filter! delete delete! partition partition! count
+
+    ; car+cdr, length+, except-last-pair
+    car+cdr length+ except-last-pair except-last-pair!
 
     ; Searching
     find find-tail take-while drop-while span break list-index
@@ -50,6 +54,7 @@
     lset<= lset= lset-adjoin
     lset-union lset-intersection lset-difference lset-xor
     lset-union! lset-intersection! lset-difference! lset-xor!
+    lset-diff+intersection lset-diff+intersection!
 
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     rakāsum-mala 𒈠𒀀

--- a/lib/curry/modules/srfi/srfi-125.scm
+++ b/lib/curry/modules/srfi/srfi-125.scm
@@ -13,6 +13,7 @@
     hash-table-walk hash-table-for-each hash-table-map->list hash-table-fold
     hash-table-count-matching hash-table-map! hash-table-prune!
     hash-table-union! hash-table-intersection! hash-table-difference!
+    hash-table=? hash-table-find hash-table-pop! hash-table-xor!
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; kunukkum: "seal" (same root as SRFI 69, above) -- the words are
     ;; shared for shared english names, distinct where the APIs diverge.

--- a/lib/curry/modules/srfi/srfi-128.scm
+++ b/lib/curry/modules/srfi/srfi-128.scm
@@ -12,6 +12,9 @@
     string-ci-comparator symbol-comparator pair-comparator list-comparator
     vector-comparator eq-comparator eqv-comparator equal-comparator
     make-eq-comparator make-eqv-comparator make-equal-comparator
+    boolean-hash char-hash char-ci-hash string-hash string-ci-hash
+    symbol-hash number-hash default-hash hash-bound hash-salt
+    comparator-if<=>
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; dayyānum: "judge" -- a comparator decides order/equality, exactly
     ;; what a judge does.

--- a/lib/curry/modules/srfi/srfi-133.scm
+++ b/lib/curry/modules/srfi/srfi-133.scm
@@ -8,7 +8,10 @@
     vector-swap! reverse! vector-reverse! vector-reverse!* vector-index
     vector-index-right vector-count vector-any vector-every vector-fold
     vector-fold-right vector-binary-search vector-concatenate vector-unfold
-    vector-unfold-right
+    vector-unfold-right vector-unfold! vector-unfold-right!
+    vector-reverse-copy vector-append-subvectors vector-map! vector-cumulate
+    vector-skip vector-skip-right vector-partition
+    reverse-vector->list reverse-list->vector
     ;; Akkadian synonyms -- lib/curry/modules/curry/private/lang-aliases.scm
     ;; Extends the vector root (ṣindum) already established for the
     ;; R7RS core vector procedures.

--- a/lib/curry/modules/srfi/srfi-27.scm
+++ b/lib/curry/modules/srfi/srfi-27.scm
@@ -4,6 +4,7 @@
   (export
     default-random-source make-random-source random-source?
     random-source-randomize! random-source-pseudo-randomize!
+    random-source-state-ref random-source-state-set!
     random-source->random-real random-source->random-integer random-real
     random-integer
     ;; Akkadian synonym -- pūrum: "lot" (as in casting lots), the genuine

--- a/src/builtins_curry.c
+++ b/src/builtins_curry.c
@@ -1377,6 +1377,43 @@ static val_t prim_random_source_p(int ac, val_t *av, void *ud) {
     return vis_symbol(av[0]) ? V_TRUE : V_FALSE;
 }
 
+/* random-source-state-ref source -- SRFI 27 leaves the state object's
+   representation entirely up to the implementation (it's opaque, only
+   meant to round-trip through random-source-state-set!); a 4-element
+   list of exact integers, one per xoshiro256+ state word, is as good a
+   choice as any. Each word is reinterpreted as a signed int64 for
+   num_make_bignum_i (which itself falls back to a plain fixnum when the
+   value fits, in_fixnum_range) -- decoding does the reverse
+   reinterpretation via num_to_long, so the round-trip preserves the
+   exact original bit pattern regardless of whether a given word's top
+   bit happens to be set. */
+static val_t prim_random_source_state_ref(int ac, val_t *av, void *ud) {
+    (void)ac; (void)av; (void)ud;
+    val_t words[4];
+    pthread_mutex_lock(&rng_mutex);
+    for (int i = 0; i < 4; i++) words[i] = num_make_bignum_i((long)(int64_t)rng_s[i]);
+    pthread_mutex_unlock(&rng_mutex);
+    val_t lst = V_NIL;
+    for (int i = 3; i >= 0; i--) lst = scm_cons(words[i], lst);
+    return lst;
+}
+
+static val_t prim_random_source_state_set(int ac, val_t *av, void *ud) {
+    (void)ac; (void)ud;
+    val_t lst = av[1];
+    uint64_t words[4];
+    for (int i = 0; i < 4; i++) {
+        if (!vis_pair(lst)) scm_raise(V_FALSE, "random-source-state-set!: state list too short");
+        words[i] = (uint64_t)(int64_t)num_to_long(vcar(lst));
+        lst = vcdr(lst);
+    }
+    pthread_mutex_lock(&rng_mutex);
+    for (int i = 0; i < 4; i++) rng_s[i] = words[i];
+    rng_seeded = true;
+    pthread_mutex_unlock(&rng_mutex);
+    return V_VOID;
+}
+
 static val_t prim_random_source_to_real(int ac, val_t *av, void *ud) {
     (void)ac; (void)av; (void)ud;
     return env_lookup(GLOBAL_ENV, sym_intern_cstr("random-real"));
@@ -1647,6 +1684,8 @@ void builtins_curry_register(val_t env) {
     DEF("random-integer",                 prim_random_integer,        1,1);
     DEF("make-random-source",             prim_make_random_source,    0,0);
     DEF("random-source?",                 prim_random_source_p,       1,1);
+    DEF("random-source-state-ref",        prim_random_source_state_ref, 1,1);
+    DEF("random-source-state-set!",       prim_random_source_state_set, 2,2);
     DEF("random-source-randomize!",       prim_random_seed,           1,1);
     DEF("random-source-pseudo-randomize!",prim_random_pseudo_seed,    3,3);
     DEF("random-source->random-real",     prim_random_source_to_real, 1,1);

--- a/tests/random_tests.scm
+++ b/tests/random_tests.scm
@@ -213,6 +213,18 @@
       (or (= i 50)
           (and (< (gen 100) 100) (loop (+ i 1)))))))
 
+;;; ── SRFI-27 random-source-state-ref / random-source-state-set! ─────────────
+;;; Tier 2 gap-closing addition: capture the RNG's current state, run some
+;;; draws, restore the captured state, and confirm the same draws repeat.
+
+(random-source-pseudo-randomize! (make-random-source) 99 3)
+(define %captured-state (random-source-state-ref (make-random-source)))
+(define %post-capture-run-1 (list (random-real) (random-real) (random-integer 1000)))
+(random-source-state-set! (make-random-source) %captured-state)
+(define %post-capture-run-2 (list (random-real) (random-real) (random-integer 1000)))
+(check "random-source-state-ref/set! round-trips the RNG state"
+  %post-capture-run-1 %post-capture-run-2)
+
 ;;; ── summary ──────────────────────────────────────────────────────────────────
 (newline)
 (display "Random tests: ") (display pass) (display " passed, ")

--- a/tests/srfi_1_tests.scm
+++ b/tests/srfi_1_tests.scm
@@ -189,6 +189,44 @@
 (check "every: returns last predicate value on success"
        (every (lambda (x) (and (odd? x) x)) (list 1 3 5)) 5)
 
+;;; ---- Tier 2 gap-closing additions ----
+
+(call-with-values (lambda () (car+cdr (cons 1 2)))
+  (lambda (a b) (check "car+cdr" (list a b) (list 1 2))))
+
+(check "pair-fold walks pairs left-to-right"
+       (pair-fold (lambda (pair acc) (cons (car pair) acc)) '() (list 1 2 3))
+       (list 3 2 1))
+(check "pair-fold-right walks pairs right-to-left"
+       (pair-fold-right (lambda (pair acc) (cons (car pair) acc)) '() (list 1 2 3))
+       (list 1 2 3))
+
+(check "map-in-order single list" (map-in-order (lambda (x) (* x x)) (list 1 2 3 4))
+       (list 1 4 9 16))
+(check "map-in-order multi-list" (map-in-order + (list 1 2 3) (list 10 20 30))
+       (list 11 22 33))
+(let ((order '()))
+  (map-in-order (lambda (x) (set! order (cons x order))) (list 1 2 3 4 5))
+  (check "map-in-order applies strictly left-to-right" (reverse order) (list 1 2 3 4 5)))
+
+(check "filter! same as filter" (filter! odd? (list 1 2 3 4 5)) (list 1 3 5))
+(check "remove! same as remove" (remove! odd? (list 1 2 3 4 5)) (list 2 4))
+(call-with-values (lambda () (partition! odd? (list 1 2 3 4 5)))
+  (lambda (yes no) (check "partition!" (list yes no) (list (list 1 3 5) (list 2 4)))))
+
+(check "length+ on a proper list" (length+ (list 1 2 3)) 3)
+(check "length+ on a circular list is #f" (length+ (circular-list 1 2 3)) #f)
+
+(check "except-last-pair drops the last element" (except-last-pair (list 1 2 3 4))
+       (list 1 2 3))
+(check "except-last-pair! same as except-last-pair" (except-last-pair! (list 1 2 3 4))
+       (list 1 2 3))
+
+(call-with-values (lambda () (lset-diff+intersection eqv? (list 1 2 3 4) (list 2 4)))
+  (lambda (diff inter)
+    (check "lset-diff+intersection: difference" diff (list 1 3))
+    (check "lset-diff+intersection: intersection" inter (list 2 4))))
+
 ;;; ---- Summary ----
 
 (newline)

--- a/tests/srfi_comparators_tests.scm
+++ b/tests/srfi_comparators_tests.scm
@@ -62,6 +62,32 @@
 (check "make-equal-comparator matches equal-comparator's equality"
        (=? (make-equal-comparator) (list 1 2) (list 1 2)) #t)
 
+;;; Standalone hash procedures + hash-bound/hash-salt + comparator-if<=> --
+;;; Tier 2 gap-closing additions.
+
+(check "boolean-hash is within hash-bound" (< (boolean-hash #t) (hash-bound)) #t)
+(check "char-hash is consistent for equal chars" (= (char-hash #\a) (char-hash #\a)) #t)
+(check "char-ci-hash ignores case" (= (char-ci-hash #\a) (char-ci-hash #\A)) #t)
+(check "string-hash is consistent for equal strings"
+       (= (string-hash "hello") (string-hash "hello")) #t)
+(check "string-ci-hash ignores case"
+       (= (string-ci-hash "Hello") (string-ci-hash "HELLO")) #t)
+(check "symbol-hash is consistent for eq symbols" (= (symbol-hash 'a) (symbol-hash 'a)) #t)
+(check "number-hash is consistent for equal numbers" (= (number-hash 42) (number-hash 42)) #t)
+(check "default-hash is within hash-bound" (< (default-hash "anything") (hash-bound)) #t)
+(check "hash-salt is a nonnegative exact integer within hash-bound"
+       (and (exact-integer? (hash-salt)) (>= (hash-salt) 0) (< (hash-salt) (hash-bound)))
+       #t)
+
+(check "comparator-if<=>: less branch, default comparator"
+       (comparator-if<=> 1 2 'less 'eq 'gtr) 'less)
+(check "comparator-if<=>: equal branch, default comparator"
+       (comparator-if<=> 5 5 'less 'eq 'gtr) 'eq)
+(check "comparator-if<=>: greater branch, default comparator"
+       (comparator-if<=> 9 5 'less 'eq 'gtr) 'gtr)
+(check "comparator-if<=>: explicit comparator"
+       (comparator-if<=> real-comparator 9 5 'less 'eq 'gtr) 'gtr)
+
 ;;; Summary
 
 (newline)

--- a/tests/srfi_hash_tables_125_126_tests.scm
+++ b/tests/srfi_hash_tables_125_126_tests.scm
@@ -68,6 +68,47 @@
        (hash-table-mutable? (make-hash-table equal-comparator))
        #t)
 
+;;; hash-table=? / hash-table-find / hash-table-pop! / hash-table-xor! --
+;;; Tier 2 gap-closing additions.
+
+(let ((a (make-hash-table equal-comparator))
+      (b (make-hash-table equal-comparator)))
+  (hash-table-set! a "x" 1) (hash-table-set! a "y" 2)
+  (hash-table-set! b "x" 1) (hash-table-set! b "y" 2)
+  (check "hash-table=? true for equal tables" (hash-table=? equal-comparator a b) #t)
+  (hash-table-set! b "y" 99)
+  (check "hash-table=? false when a value differs" (hash-table=? equal-comparator a b) #f)
+  (hash-table-set! b "y" 2) (hash-table-set! b "z" 3)
+  (check "hash-table=? false when sizes differ" (hash-table=? equal-comparator a b) #f))
+
+(let ((t (make-hash-table equal-comparator)))
+  (hash-table-set! t "x" 1) (hash-table-set! t "y" 2)
+  (check "hash-table-find locates a matching entry"
+         (hash-table-find (lambda (k v) (and (= v 1) k)) t (lambda () 'none))
+         "x")
+  (check "hash-table-find calls failure thunk when nothing matches"
+         (hash-table-find (lambda (k v) (= v 999)) t (lambda () 'none))
+         'none))
+
+(let ((t (make-hash-table equal-comparator)))
+  (hash-table-set! t "only" 42)
+  (call-with-values (lambda () (hash-table-pop! t))
+    (lambda (k v) (check "hash-table-pop! returns the entry" (list k v) (list "only" 42))))
+  (check "hash-table-pop! removes the entry" (hash-table-size t) 0)
+  (check "hash-table-pop! raises on an empty table"
+         (guard (e (#t 'raised)) (hash-table-pop! t))
+         'raised))
+
+(let ((a (make-hash-table equal-comparator))
+      (b (make-hash-table equal-comparator)))
+  (hash-table-set! a "shared" 1) (hash-table-set! a "only-a" 2)
+  (hash-table-set! b "shared" 99) (hash-table-set! b "only-b" 3)
+  (hash-table-xor! a b)
+  (check "hash-table-xor! removes shared keys" (hash-table-contains? a "shared") #f)
+  (check "hash-table-xor! keeps a-only keys" (hash-table-ref a "only-a") 2)
+  (check "hash-table-xor! adds b-only keys" (hash-table-ref a "only-b") 3)
+  (check "hash-table-xor! result size" (hash-table-size a) 2))
+
 ;;; Summary
 
 (newline)

--- a/tests/srfi_sorting_vectors_tests.scm
+++ b/tests/srfi_sorting_vectors_tests.scm
@@ -48,6 +48,42 @@
 (check "vector-concatenate joins vectors" (vector-concatenate (list #(1 2) #(3 4))) #(1 2 3 4))
 (check "vector-unfold builds via seed-free generator" (vector-unfold (lambda (i) i) 5) #(0 1 2 3 4))
 
+;;; SRFI-133 Tier 2 gap-closing additions
+
+(check "vector-reverse-copy" (vector-reverse-copy #(1 2 3 4)) #(4 3 2 1))
+(check "vector-reverse-copy with a range" (vector-reverse-copy #(1 2 3 4 5) 1 4) #(4 3 2))
+
+(check "vector-append-subvectors"
+       (vector-append-subvectors #(1 2 3) 0 2 #(10 20 30) 1 3)
+       #(1 2 20 30))
+
+(let ((v (vector 1 2 3 4)))
+  (vector-map! (lambda (x) (* x x)) v)
+  (check "vector-map! mutates in place" v #(1 4 9 16)))
+
+(check "vector-cumulate accumulates a running total"
+       (vector-cumulate + 0 #(1 2 3 4))
+       #(1 3 6 10))
+
+(check "vector-skip finds first non-matching index" (vector-skip even? #(2 4 6 7 8)) 3)
+(check "vector-skip-right finds last non-matching index" (vector-skip-right even? #(2 7 4 6 8)) 1)
+
+(call-with-values (lambda () (vector-partition even? #(1 2 3 4 5 6)))
+  (lambda (result count)
+    (check "vector-partition groups matches first, stably" result #(2 4 6 1 3 5))
+    (check "vector-partition returns the match count" count 3)))
+
+(check "reverse-vector->list" (reverse-vector->list #(1 2 3)) (list 3 2 1))
+(check "reverse-list->vector" (reverse-list->vector (list 1 2 3)) #(3 2 1))
+
+(let ((v (make-vector 5 0)))
+  (vector-unfold! (lambda (i) i) v 1 4)
+  (check "vector-unfold! fills a range in place" v #(0 1 2 3 0)))
+
+(let ((v (make-vector 5 0)))
+  (vector-unfold-right! (lambda (i) (* i 10)) v 1 4)
+  (check "vector-unfold-right! fills a range in place, right to left" v #(0 10 20 30 0)))
+
 ;;; Summary
 
 (newline)


### PR DESCRIPTION
## Summary

Closes the "Tier 2" (moderate-effort) gaps found by the full 39-SRFI compatibility audit run earlier this session, independent of Tier 1 (#79):

- **SRFI-1** (lists): `car+cdr`, `pair-fold`, `pair-fold-right`, `map-in-order`, `filter!`, `remove!`, `partition!`, `length+`, `except-last-pair`, `except-last-pair!`, `lset-diff+intersection`, `lset-diff+intersection!`
- **SRFI-27** (random bits): `random-source-state-ref`, `random-source-state-set!`
- **SRFI-125** (hash tables): `hash-table=?`, `hash-table-find`, `hash-table-pop!`, `hash-table-xor!`
- **SRFI-128** (comparators): the standalone hash procedures (`boolean-hash`, `char-hash`, `char-ci-hash`, `string-hash`, `string-ci-hash`, `symbol-hash`, `number-hash`, `default-hash`), `hash-bound`, `hash-salt`, `comparator-if<=>`
- **SRFI-133** (vectors): `vector-reverse-copy`, `vector-append-subvectors`, `vector-map!`, `vector-cumulate`, `vector-skip`, `vector-skip-right`, `vector-partition`, `reverse-vector->list`, `reverse-list->vector`, `vector-unfold!`, `vector-unfold-right!`

Worth calling out:
- `map-in-order` (SRFI-1) is a genuine sequential loop, not an alias — curry's core global `map` goes parallel above a size threshold and doesn't guarantee left-to-right side-effect ordering.
- `pair-fold-right` (SRFI-1) avoids the reference implementation's natural non-tail recursion via a fold-based reversal trick, same stack-overflow-avoidance convention already used elsewhere in that file.
- Two real bugs were caught during manual testing (not the review agent — see below): `comparator-if<=>`'s 5-arg clause initially called `(default-comparator)` as a procedure when it's a plain value, and `vector-map!`'s own comment falsely claimed consistency with curry's native `vector-map` on mismatched-length arguments (checked directly: native `vector-map` raises, this one follows SRFI-133's own "stop at the shortest vector" convention instead — corrected the comment, not the behavior, since the behavior is spec-correct).

## Independent review note

The primary code-review agent hit its monthly spend limit partway through reviewing this diff (recorded as a known recurring issue this session). Fell back to a careful manual read — focused on the trickiest logic (`pair-fold-right`'s reversal trick, `lset-diff+intersection`'s single-partition derivation, `hash-table=?`'s size-plus-subset equality proof, `hash-table-xor!`'s self-xor edge case, `vector-partition`'s two-cursor fill) — plus live execution of every new procedure against hand-computed expected values.

## Commits
- `feat(srfi1)`, `feat(srfi27)`, `feat(srfi125)`, `feat(srfi128)`, `feat(srfi133)` — one per SRFI, each with its own tests

## Test plan
- [x] `ctest --test-dir build` — 105/105 suites pass, fresh `--clear-cache` run, verified independently on this branch (cherry-picked onto current `origin/main`, standalone from Tier 1's still-open PR #79)
- [x] Every new procedure exercised directly at the REPL against hand-computed expected output before being written into the test suite
