### PR TITLE
feat(srfi): add SRFI-9, SRFI-31, SRFI-45

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -114,7 +114,7 @@ and extra runtime dependencies:
 
 ## SRFI compatibility
 
-39 portable `(srfi sN name)` libraries — the same naming convention Guile,
+42 portable `(srfi sN name)` libraries — the same naming convention Guile,
 Chicken, and Chibi-Scheme use, so the same `(import ...)` line works across
 implementations. Coverage runs from foundational list/vector/hash-table
 libraries (SRFI-1, 125/126, 128, 132/133) through concurrency (SRFI-18),

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Documentation is split into two directories:
 - [Akkadian / Cuneiform reference](docs/reference/akkadian-reference.md) — complete vocabulary of special forms and procedures in all three languages, plus the runtime error-message phrase table
 - [Error codes](docs/reference/error-codes.md) — stable machine-legible `error-object-code`/`condition-code` registry for tooling
 - [Module index](docs/reference/modules.md) — the full list of `(curry ...)` modules, import names, and extra build dependencies
-- [SRFI compatibility](docs/reference/srfi/index.md) — the 39 portable `(srfi sN name)` libraries, one page each
+- [SRFI compatibility](docs/reference/srfi/index.md) — the 42 portable `(srfi sN name)` libraries, one page each
 - [Parallel map/reduce](docs/reference/parallel.md) — the work-stealing thread pool behind `map`/`reduce`
 - [LLVM JIT backend](docs/reference/llvm-jit.md) — auto-JIT, benchmark numbers, build flags
 - [Garbage collector reference](docs/reference/gc.md) — the two GC backends and `(gc-stats)` fields

--- a/docs/reference/srfi/index.md
+++ b/docs/reference/srfi/index.md
@@ -32,11 +32,14 @@ The same import-collision caveat as `(srfi N)` above applies identically here (i
 | [`(srfi s1 lists)`](s1.md) | [SRFI-1](https://srfi.schemers.org/srfi-1/) | List library |
 | [`(srfi s4 uniform-vectors)`](s4.md) | [SRFI-4](https://srfi.schemers.org/srfi-4/) | Homogeneous numeric vectors — u8/s8/u16/s16/u32/s32/u64/s64vector from `(curry typedvec)` plus f64vector from `(curry f64vector)`; no f32vector (curry's numeric tower has no native single-precision type) |
 | [`(srfi s8 receive)`](s8.md) | [SRFI-8](https://srfi.schemers.org/srfi-8/) | `receive` multiple-values binding macro — shadows curry's own actor `receive` special form when imported |
+| [`(srfi s9 records)`](s9.md) | [SRFI-9](https://srfi.schemers.org/srfi-9/) | `define-record-type` — thin re-export of curry's own core special form, a strict superset of SRFI-9's grammar |
 | [`(srfi s14 char-sets)`](s14.md) | [SRFI-14](https://srfi.schemers.org/srfi-14/) | Character sets — construction, iteration, set algebra, and the standard predefined sets (`char-set:letter`, `char-set:whitespace`, etc), backed by a sorted-range representation over curry's full Unicode codepoint space |
 | [`(srfi s18 multithreading)`](s18.md) | [SRFI-18](https://srfi.schemers.org/srfi-18/) | Thread/mutex/condition-variable naming over curry's actor `spawn` and `(curry sync)` |
 | [`(srfi s19 time)`](s19.md) | [SRFI-19](https://srfi.schemers.org/srfi-19/) | Time/date objects, Julian Day conversions, `strftime`-style formatting — requires `-DBUILD_MODULE_POSIX=ON` (default) for `current-time` |
 | [`(srfi s26 cut)`](s26.md) | [SRFI-26](https://srfi.schemers.org/srfi-26/) | `cut`/`cute` — partial application without writing `lambda` by hand; the reference implementation verbatim (its recursive-macro shape found and drove a real curry `syntax-rules` hygiene fix — see the doc page) |
 | [`(srfi s27 random-bits)`](s27.md) | [SRFI-27](https://srfi.schemers.org/srfi-27/) | Random-number sources |
+| [`(srfi s31 rec)`](s31.md) | [SRFI-31](https://srfi.schemers.org/srfi-31/) | `rec` — a special form for self-referential (typically recursive-lambda) expressions without a surrounding `define`/`letrec` |
+| [`(srfi s45 lazy)`](s45.md) | [SRFI-45](https://srfi.schemers.org/srfi-45/) | `lazy`/`eager` for iterative lazy algorithms — thin aliases over curry's own core `delay-force`/`make-promise`, which already implement SRFI-45's semantics |
 | [`(srfi s54 cat)`](s54.md) | [SRFI-54](https://srfi.schemers.org/srfi-54/) | `cat` — order-independent object-to-string formatting (width, padding, precision, radix, separators, pipes, converters) |
 | [`(srfi s59 vicinity)`](s59.md) | [SRFI-59](https://srfi.schemers.org/srfi-59/) | Vicinity (directory-of-a-path) string utilities |
 | [`(srfi s64 testing)`](s64.md) | [SRFI-64](https://srfi.schemers.org/srfi-64/) | Unit-testing framework — test cases/groups, skip/expect-fail specifiers, pluggable test runners; curry's own test suites use this |

--- a/docs/reference/srfi/s31.md
+++ b/docs/reference/srfi/s31.md
@@ -1,0 +1,29 @@
+# `(srfi s31 rec)` — SRFI-31 `rec`
+
+```scheme
+(import (srfi s31 rec))
+```
+
+[SRFI-31](https://srfi.schemers.org/srfi-31/): a special form for writing a self-referential expression — most commonly a recursive lambda — without a surrounding `define` or `letrec`.
+
+#### `(rec name expr)` — *syntax*
+
+Binds `name` to itself within `expr`, then evaluates `expr`. Equivalent to `(letrec ((name expr)) name)`.
+
+```scheme
+((rec fact (lambda (n) (if (= n 0) 1 (* n (fact (- n 1)))))) 5)  ; => 120
+```
+
+#### `(rec (name . args) body ...)` — *syntax*
+
+Shorthand for the common case where `expr` is itself a lambda: `(rec (name . args) body ...)` is equivalent to `(rec name (lambda args body ...))`.
+
+```scheme
+((rec (fact n) (if (= n 0) 1 (* n (fact (- n 1))))) 5)  ; => 120
+```
+
+Useful anywhere a one-off recursive procedure is needed as a value (e.g. passed straight to `map` or returned from another procedure) without polluting the enclosing scope with a named `define`.
+
+## See also
+
+- [`index.md`](index.md) — full SRFI availability table

--- a/docs/reference/srfi/s45.md
+++ b/docs/reference/srfi/s45.md
@@ -1,0 +1,33 @@
+# `(srfi s45 lazy)` — SRFI-45 Primitives for Expressing Iterative Lazy Algorithms
+
+```scheme
+(import (srfi s45 lazy))
+```
+
+[SRFI-45](https://srfi.schemers.org/srfi-45/): promise primitives with the guarantee that forcing a chain of "lazy" promises doesn't grow the call stack, needed for genuinely iterative lazy algorithms (e.g. an infinite stream walked far enough to otherwise overflow).
+
+Curry's core `delay`, `force`, `delay-force`, and `make-promise` (all available with no import, per R7RS) already implement this: R7RS's `delay-force` is exactly SRFI-45's `lazy` — a promise whose forcing may itself return another promise, iterated in place rather than recursively — and R7RS's `make-promise` on a plain value is exactly SRFI-45's `eager`. This library only needs to supply those two names; `force`, `delay` are re-exported unchanged.
+
+#### `(lazy expr)` — *syntax*
+
+Alias for `delay-force`. Use this (instead of plain `delay`) whenever the delayed expression may itself produce another promise that needs forcing — e.g. every step of a lazily-generated stream.
+
+```scheme
+(define (integers-from n) (lazy (cons n (integers-from (+ n 1)))))
+```
+
+#### `(eager v)` — *procedure*
+
+Wraps `v` in an already-forced promise: `(force (eager v))` returns `v` immediately, without ever calling anything. Alias for `make-promise`.
+
+#### `(force promise)` — *procedure*
+
+R7RS's own `force`, re-exported unchanged.
+
+#### `(delay expr)` — *syntax*
+
+R7RS's own `delay`, re-exported unchanged, for programs that want both names available from one import.
+
+## See also
+
+- [`index.md`](index.md) — full SRFI availability table

--- a/docs/reference/srfi/s9.md
+++ b/docs/reference/srfi/s9.md
@@ -1,0 +1,27 @@
+# `(srfi s9 records)` — SRFI-9 Defining Record Types
+
+```scheme
+(import (srfi s9 records))
+```
+
+[SRFI-9](https://srfi.schemers.org/srfi-9/): the original `define-record-type` proposal — construct a record type with a constructor, a predicate, and one read-only accessor per field.
+
+#### `(define-record-type <name> (constructor field ...) predicate (field accessor) ...)` — *syntax*
+
+```scheme
+(define-record-type <point>
+  (make-point x y)
+  point?
+  (x point-x)
+  (y point-y))
+
+(define p (make-point 3 4))
+(point? p)      ; => #t
+(point-x p)     ; => 3
+```
+
+Curry's own core `define-record-type` special form (used directly, with no import needed) already implements the R7RS grammar, which is a strict superset of SRFI-9's: R7RS additionally allows field mutators (`(field accessor modifier)`) and constructors that omit fields (left uninitialized). Every valid SRFI-9 form is therefore already valid curry syntax without this library — this shim exists purely so code written against SRFI-9's own name can `(import (srfi s9 records))` (or `(srfi 9)` / `(srfi srfi-9)`) portably, the same as any other Scheme implementation shipping this SRFI.
+
+## See also
+
+- [`index.md`](index.md) — full SRFI availability table

--- a/lib/curry/modules/srfi/31.scm
+++ b/lib/curry/modules/srfi/31.scm
@@ -1,0 +1,3 @@
+(define-library (srfi 31)
+  (import (srfi s31 rec))
+  (export rec))

--- a/lib/curry/modules/srfi/45.scm
+++ b/lib/curry/modules/srfi/45.scm
@@ -1,0 +1,3 @@
+(define-library (srfi 45)
+  (import (srfi s45 lazy))
+  (export lazy force delay eager))

--- a/lib/curry/modules/srfi/9.scm
+++ b/lib/curry/modules/srfi/9.scm
@@ -1,0 +1,3 @@
+(define-library (srfi 9)
+  (import (srfi s9 records))
+  (export define-record-type))

--- a/lib/curry/modules/srfi/s31/rec.scm
+++ b/lib/curry/modules/srfi/s31/rec.scm
@@ -1,0 +1,13 @@
+;; SRFI-31: A special form `rec` for recursive evaluation, allowing
+;; self-referential expressions (most commonly a lambda) to be built
+;; without a surrounding `define` or `letrec`.
+(define-library (srfi s31 rec)
+  (import (scheme base))
+  (export rec)
+  (begin
+    (define-syntax rec
+      (syntax-rules ()
+        ((_ (name . args) body ...)
+         (letrec ((name (lambda args body ...))) name))
+        ((_ name expr)
+         (letrec ((name expr)) name))))))

--- a/lib/curry/modules/srfi/s45/lazy.scm
+++ b/lib/curry/modules/srfi/s45/lazy.scm
@@ -1,0 +1,18 @@
+;; SRFI-45: Primitives for Expressing Iterative Lazy Algorithms.
+;;
+;; curry's core `delay`/`force`/`delay-force`/`make-promise`/`promise?`
+;; already implement R7RS's promise semantics, which subsume SRFI-45's:
+;; R7RS's `delay-force` is exactly SRFI-45's `lazy` (a promise whose forcing
+;; may itself return another promise, iterated without growing the call
+;; stack -- the whole point of SRFI-45, needed for genuinely iterative lazy
+;; streams/algorithms rather than ones that blow the stack after enough
+;; steps), and R7RS's `make-promise` on a non-promise value is exactly
+;; SRFI-45's `eager`. This shim only needs to supply the two names.
+(define-library (srfi s45 lazy)
+  (import (scheme base))
+  (export lazy force delay eager)
+  (begin
+    (define-syntax lazy
+      (syntax-rules ()
+        ((_ expr) (delay-force expr))))
+    (define (eager v) (make-promise v))))

--- a/lib/curry/modules/srfi/s9/records.scm
+++ b/lib/curry/modules/srfi/s9/records.scm
@@ -1,0 +1,12 @@
+;; SRFI-9: Defining Record Types.
+;;
+;; curry's core `define-record-type` special form already implements the
+;; R7RS form, which is a strict superset of SRFI-9's own -- SRFI-9 requires
+;; exactly one accessor per field (no mutators, no field omitted from the
+;; constructor), while R7RS additionally allows mutators and constructors
+;; that only take a subset of fields. Every valid SRFI-9 form is therefore
+;; already valid curry syntax; this shim just makes the name importable
+;; under SRFI-9's own library path.
+(define-library (srfi s9 records)
+  (import (scheme base))
+  (export define-record-type))

--- a/lib/curry/modules/srfi/srfi-31.scm
+++ b/lib/curry/modules/srfi/srfi-31.scm
@@ -1,0 +1,3 @@
+(define-library (srfi srfi-31)
+  (import (srfi s31 rec))
+  (export rec))

--- a/lib/curry/modules/srfi/srfi-45.scm
+++ b/lib/curry/modules/srfi/srfi-45.scm
@@ -1,0 +1,3 @@
+(define-library (srfi srfi-45)
+  (import (srfi s45 lazy))
+  (export lazy force delay eager))

--- a/lib/curry/modules/srfi/srfi-9.scm
+++ b/lib/curry/modules/srfi/srfi-9.scm
@@ -1,0 +1,3 @@
+(define-library (srfi srfi-9)
+  (import (srfi s9 records))
+  (export define-record-type))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ add_test(NAME srfi_s252_property_testing COMMAND curry --clear-cache ${CMAKE_CUR
 add_test(NAME srfi_s209_enums COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s209_enums_tests.scm)
 add_test(NAME srfi_s210_multiple_values COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s210_multiple_values_tests.scm)
 add_test(NAME srfi_s54_cat COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s54_cat_tests.scm)
+add_test(NAME srfi_9_31_45 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_9_31_45_tests.scm)
 if(BUILD_MPFR)
   add_test(NAME mpfr COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/mpfr_tests.scm)
 endif()

--- a/tests/srfi_9_31_45_tests.scm
+++ b/tests/srfi_9_31_45_tests.scm
@@ -1,0 +1,79 @@
+;;; srfi_9_31_45_tests.scm — SRFI-9 (records), SRFI-31 (rec), SRFI-45
+;;; (lazy). Each SRFI is exercised via all three library paths: the real
+;;; (srfi sN name) implementation, the bare-numbered (srfi N) shim, and
+;;; the dashed (srfi srfi-N) shim -- per the lesson recorded during the
+;;; Tier-1 gap fixes, a fix that only touches one of the three silently
+;;; misses the others.
+
+(import (scheme base)
+        (srfi s9 records) (srfi 9) (srfi srfi-9)
+        (srfi s31 rec) (srfi 31) (srfi srfi-31)
+        (srfi s45 lazy) (srfi 45) (srfi srfi-45))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label result expected)
+  (if (equal? result expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " got ") (write result)
+             (display " expected ") (write expected)
+             (newline)
+             (set! fail (+ fail 1)))))
+
+;;; SRFI-9: define-record-type
+
+(define-record-type <point>
+  (make-point x y)
+  point?
+  (x point-x)
+  (y point-y))
+
+(define p (make-point 3 4))
+(check "srfi-9 define-record-type: predicate" (point? p) #t)
+(check "srfi-9 define-record-type: accessors" (list (point-x p) (point-y p)) (list 3 4))
+(check "srfi-9 define-record-type: non-instance predicate" (point? 5) #f)
+
+;;; SRFI-31: rec
+
+(check "srfi-31 rec: self-referential lambda"
+       ((rec fact (lambda (n) (if (= n 0) 1 (* n (fact (- n 1)))))) 6)
+       720)
+(check "srfi-31 rec: plain named expression" (rec x (+ 1 2)) 3)
+
+;;; SRFI-45: lazy, force, delay, eager
+
+(define (integers-from n) (lazy (cons n (integers-from (+ n 1)))))
+
+(define (stream-take s n)
+  (if (= n 0)
+      '()
+      (let ((pr (force s)))
+        (cons (car pr) (stream-take (cdr pr) (- n 1))))))
+
+;; stream-take itself is ordinary (non-tail) recursion bounded by n, not a
+;; test of delay-force's own iteration -- that part is what `integers-from`
+;; exercises: each `force` only ever unwinds one delay-force layer deep
+;; regardless of how many integers have been generated before it, which is
+;; the whole point of SRFI-45's `lazy` over plain `delay`.
+(check "srfi-45 lazy/force: produces a working infinite stream"
+       (stream-take (integers-from 0) 20)
+       (let loop ((i 19) (acc '())) (if (< i 0) acc (loop (- i 1) (cons i acc)))))
+
+(check "srfi-45 eager: wraps a plain value in an already-forced promise"
+       (force (eager 42))
+       42)
+
+(check "srfi-45 delay/force: ordinary (non-lazy) promise still works"
+       (force (delay (+ 1 2)))
+       3)
+
+;;; Summary
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/srfi_legacy_dashed_names_tests.scm
+++ b/tests/srfi_legacy_dashed_names_tests.scm
@@ -8,7 +8,8 @@
 ;;; exact same call. This file exists specifically so that class of gap
 ;;; can't reappear silently.
 
-(import (srfi srfi-125) (srfi srfi-128) (srfi srfi-170) (srfi srfi-227))
+(import (srfi srfi-125) (srfi srfi-128) (srfi srfi-170) (srfi srfi-227)
+        (srfi srfi-9) (srfi srfi-31) (srfi srfi-45))
 
 (define pass 0)
 (define fail 0)
@@ -46,6 +47,18 @@
 
 (define-optionals* (g a #:optional (b (* a 3)) (c (+ a b))) (list a b c))
 (check "srfi-227 legacy shim exports define-optionals*" (g 4) (list 4 12 16))
+
+;;; (srfi srfi-9)
+(define-record-type <pt> (make-pt x) pt? (x pt-x))
+(check "srfi-9 legacy shim exports define-record-type" (pt-x (make-pt 7)) 7)
+
+;;; (srfi srfi-31)
+(check "srfi-31 legacy shim exports rec" (rec x (+ 1 1)) 2)
+
+;;; (srfi srfi-45)
+(check "srfi-45 legacy shim exports lazy/force/eager"
+       (force (eager (force (lazy 5))))
+       5)
 
 ;;; Summary
 


### PR DESCRIPTION
## Summary

Implements three of the four SRFI gaps assessed as free/trivial in the last audit round:

- **SRFI-9** (Defining Record Types) — thin re-export of curry's own core `define-record-type`, already a strict superset of SRFI-9's grammar
- **SRFI-31** (`rec`) — self-referential-expression macro, transcribed from the SRFI's own reference implementation
- **SRFI-45** (Primitives for Iterative Lazy Algorithms) — `lazy`/`eager` as thin aliases over curry's existing `delay-force`/`make-promise`, whose semantics were verified against the actual C implementation, not just a passing test

Each ships the standard three-file shape (`srfi sN name`, `srfi N`, `srfi srfi-N`), with tests covering all three paths and doc pages.

**SRFI-61 was dropped from this batch** — it requires `cond` itself to accept a new clause shape, but curry's `cond` is a hardcoded special form the evaluator/compiler dispatches on directly, not something a `define-syntax cond` shim can override. Filed as #81 for future compiler-level work.

README.md/FEATURES.md's SRFI count bumped 39 → 42.

## Test plan

- [x] 106/106 ctest suites pass, fresh `--clear-cache` run, rebuilt standalone on this branch off `origin/main`
- [x] New `tests/srfi_9_31_45_tests.scm` exercises all three library paths per SRFI
- [x] `tests/srfi_legacy_dashed_names_tests.scm` extended to cover the three new dashed shims
- [x] Independent code review (fresh subagent, no shared context): export-list consistency checked across all three tiers, `rec` macro checked against the SRFI-31 spec, `lazy`/`eager` semantics verified by reading curry's actual `prim_force`/`prim_make_promise` implementation. No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
