### PR TITLE
feat(srfi): add SRFI-41 (Streams)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -95,7 +95,7 @@ and extra runtime dependencies:
 
 ## SRFI compatibility
 
-46 portable `(srfi sN name)` libraries — the same naming convention Guile,
+47 portable `(srfi sN name)` libraries — the same naming convention Guile,
 Chicken, and Chibi-Scheme use, so the same `(import ...)` line works across
 implementations. Coverage runs from foundational list/vector/hash-table
 libraries (SRFI-1, 125/126, 128, 132/133) through concurrency (SRFI-18),

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Documentation is split into two directories:
 - [Akkadian / Cuneiform reference](docs/reference/akkadian-reference.md) — complete vocabulary of special forms and procedures in all three languages, plus the runtime error-message phrase table
 - [Error codes](docs/reference/error-codes.md) — stable machine-legible `error-object-code`/`condition-code` registry for tooling
 - [Module index](docs/reference/modules.md) — the full list of `(curry ...)` modules, import names, and extra build dependencies
-- [SRFI compatibility](docs/reference/srfi/index.md) — the 46 portable `(srfi sN name)` libraries, one page each
+- [SRFI compatibility](docs/reference/srfi/index.md) — the 47 portable `(srfi sN name)` libraries, one page each
 - [Parallel map/reduce](docs/reference/parallel.md) — the work-stealing thread pool behind `map`/`reduce`
 - [LLVM JIT backend](docs/reference/llvm-jit.md) — auto-JIT, benchmark numbers, build flags
 - [Garbage collector reference](docs/reference/gc.md) — the two GC backends and `(gc-stats)` fields

--- a/docs/reference/srfi/index.md
+++ b/docs/reference/srfi/index.md
@@ -39,6 +39,7 @@ The same import-collision caveat as `(srfi N)` above applies identically here (i
 | [`(srfi s26 cut)`](s26.md) | [SRFI-26](https://srfi.schemers.org/srfi-26/) | `cut`/`cute` — partial application without writing `lambda` by hand; the reference implementation verbatim (its recursive-macro shape found and drove a real curry `syntax-rules` hygiene fix — see the doc page) |
 | [`(srfi s27 random-bits)`](s27.md) | [SRFI-27](https://srfi.schemers.org/srfi-27/) | Random-number sources |
 | [`(srfi s31 rec)`](s31.md) | [SRFI-31](https://srfi.schemers.org/srfi-31/) | `rec` — a special form for self-referential (typically recursive-lambda) expressions without a surrounding `define`/`letrec` |
+| [`(srfi s41 streams)`](s41.md) | [SRFI-41](https://srfi.schemers.org/srfi-41/) | Lazy, memoizing streams — a stream is literally a curry promise, built directly on core `delay-force`; `stream?` is therefore looser than the spec (see `s41.md`) |
 | [`(srfi s45 lazy)`](s45.md) | [SRFI-45](https://srfi.schemers.org/srfi-45/) | `lazy`/`eager` for iterative lazy algorithms — thin aliases over curry's own core `delay-force`/`make-promise`, which already implement SRFI-45's semantics |
 | [`(srfi s54 cat)`](s54.md) | [SRFI-54](https://srfi.schemers.org/srfi-54/) | `cat` — order-independent object-to-string formatting (width, padding, precision, radix, separators, pipes, converters) |
 | [`(srfi s59 vicinity)`](s59.md) | [SRFI-59](https://srfi.schemers.org/srfi-59/) | Vicinity (directory-of-a-path) string utilities |

--- a/docs/reference/srfi/s41.md
+++ b/docs/reference/srfi/s41.md
@@ -1,0 +1,50 @@
+# `(srfi s41 streams)` — SRFI-41 Streams
+
+```scheme
+(import (srfi s41 streams))
+```
+
+[SRFI-41](https://srfi.schemers.org/srfi-41/): lazy, memoizing streams — `cons`/`car`/`cdr` for infinite and long sequences.
+
+## Representation, and one deliberate deviation from the spec
+
+The reference implementation builds its own memoizing lazy-promise machinery from scratch (SRFI-41 predates R7RS's `delay-force`). curry already has `delay`/`delay-force`/`force` natively with exactly the iterative, stack-safe chain-flattening SRFI-41's own spec calls "vitally critical" — so this port uses those directly: **a stream *is* a curry promise.** `stream-null` is an already-forced promise holding a unique sentinel; `stream-cons`'s car is an ordinary memoizing `delay`, its cdr is `delay-force` (plain `delay` would grow the stack one frame per element on a long stream — `delay-force`'s iterative flattening is the entire point).
+
+The cost of this representation: `stream?` really means "is this a promise", not "is this specifically a stream" — `(stream? (delay 5))` is `#t` here, where the reference implementation says `#f`. This is unavoidable while keeping the stack-safety property: wrapping the promise in a distinct record for stronger typing would stop `delay-force`'s own chain-flattening from seeing through it (it only continues chaining when the unwrapped value is itself a promise), defeating the reason to use `delay-force` at all. In exchange, traversing an arbitrarily long stream never grows the call stack — verified directly, not assumed: `(stream-length (stream-range 0 100000))` and similar completes without touching the VM's 256-frame guard.
+
+## Primitives
+
+`stream-null`, `stream-cons`, `stream?`, `stream-null?`, `stream-pair?`, `stream-car`, `stream-cdr`, `stream-lambda` — the eight the rest of the library is built from. Match the spec exactly except for `stream?`'s looseness noted above.
+
+## Constructors / destructors
+
+`(stream x ...)`, `list->stream`, `stream->list` (optionally `(stream->list n strm)` to take only the first `n`), `stream-ref`, `stream-length`, `stream-from`, `stream-range`, `stream-iterate`, `stream-unfold`, `stream-unfolds` (multiple parallel output streams from one generator — see the warning below), `port->stream`, `stream-constant`.
+
+**`stream-unfolds` gotcha, worth calling out explicitly:** the generator returns `(values next-seed result ...)`, one `result` per output stream. Each `result` is a one-element list to emit a value, `'()` to end that output stream, or `#f` to **skip this round and keep going** — not to terminate. Returning `#f` forever with an unchanging seed is an easy way to write an infinite loop by accident (confirmed directly while writing this port's own tests).
+
+## Transformations
+
+`stream-map`, `stream-filter`, `stream-append`, `stream-concat`, `stream-reverse`, `stream-take`, `stream-take-while`, `stream-drop`, `stream-drop-while`, `stream-scan`, `stream-zip`.
+
+## Folding / iteration
+
+`stream-fold`, `stream-for-each`.
+
+## Syntactic sugar
+
+`define-stream`, `stream-let`, `stream-of` (comprehension syntax: `(stream-of expr (var in stream) (var is value) guard ...)`).
+
+#### `(stream-match strm clause ...)` — *syntax*
+
+Pattern-matches a stream's structure. Ported using curry's own established syntax-rules wildcard idiom (a literal `_` in the macro's literals list, matched before the general pattern-variable clause — the same technique `(curry matchable)` already uses) rather than the reference implementation's `syntax-case`/`identifier?`/`free-identifier=?` version, since curry's macro system is `syntax-rules` only.
+
+```scheme
+(stream-match (stream 1 2 3)
+  (() 'empty)
+  ((a b . rest) (list a b (stream->list rest))))   ; => (1 2 (3))
+```
+
+## See also
+
+- [`(srfi s45 lazy)`](s45.md) — the `delay-force`/`lazy` primitives this library is built directly on top of
+- [`index.md`](index.md) — full SRFI availability table

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,7 +79,7 @@ dependency, not ambition; each phase unblocks the phases above it.
 | **R7RS `cond-expand`/`(features)`** | ✓ **v1.20.0** |
 | **`(curry gillespie)`** — Gillespie stochastic simulation algorithm | ✓ unreleased, merged to `main` — composable propensity/rate-law combinators (`mass-action`/`arrhenius`/`michaelis-menten`/`hill`), multi-cell simulation via actors, no separate concurrency model |
 | **`(curry websocket)`** + **`(curry ros)`** — RFC 6455 client + rosbridge v2.0 JSON protocol client | ✓ unreleased, merged to `main` — pure Scheme, no ROS install/DDS transport needed; see `docs/guides/ros-robot.md` for driving real GPIO/PWM motors via `(curry rpi)` from ROS teleop |
-| **SRFI compatibility** | ✓ **46 libraries** as of the unreleased work below (39 at the start of the audit work this update covers, v1.23.3) — see the new SRFI section below for audit status and known gaps |
+| **SRFI compatibility** | ✓ **47 libraries** as of the unreleased work below (39 at the start of the audit work this update covers, v1.23.3) — see the new SRFI section below for audit status and known gaps |
 | **Full multi-shot `call/cc`** | ✗ — `setjmp`/`longjmp` escape-only continuations remain the whole story; the target strategy (VM frame-stack copying, decided against CPS — see "Decided against") is chosen but not implemented. See "Active work outside the phase numbering" below |
 | Green threads | ✗ |
 | Hot code reloading | ✗ |
@@ -170,7 +170,7 @@ unresolved regardless of `gc-rewrite`'s status.
 
 ### SRFI compatibility
 
-46 `(srfi sN name)` libraries as of the work merged to `main` covered in
+47 `(srfi sN name)` libraries as of the work merged to `main` covered in
 the summary timeline below (39 at the start of the audit work covered
 here, v1.23.3). Two rounds of work distinct from ordinary new-library
 additions:
@@ -187,7 +187,11 @@ additions:
   SRFI-9 (records), SRFI-31 (`rec`), SRFI-45 (lazy/iterative algorithms),
   SRFI-95 (sorting/merging), SRFI-78 (lightweight testing), SRFI-212
   (aliases), SRFI-141 (integer division: `ceiling`/`round`/`euclidean`/
-  `balanced` families beyond R7RS's own `floor`/`truncate`).
+  `balanced` families beyond R7RS's own `floor`/`truncate`), SRFI-41
+  (Streams — a stream is literally a curry promise, built directly on
+  the core `delay-force` SRFI-45 above wraps; verified stack-safe on a
+  100,000-element stream, not just correct; `stream?` is deliberately
+  looser than the spec as a result, see `s41.md`).
 - **Blocked:** SRFI-61 (a more general `cond` clause) can't be
   implemented as a library — `cond` is a hardcoded special form the
   evaluator dispatches on directly, not resolved through macro lookup, so
@@ -208,9 +212,9 @@ additions:
   tree structure curry doesn't have anything to build on today), SRFI-275
   (URIs/IRIs/paths, draft status — RFC 3986/3987-grade parsing from
   scratch, real risk of rework before the draft finalizes), SRFI-13
-  (Strings, ~100+ procedures), SRFI-41 (Streams), SRFI-115 (SRE regex —
-  a genuine standalone regex-engine project, distinct from curry's
-  existing POSIX-based `(curry regex)`).
+  (Strings, ~100+ procedures), SRFI-115 (SRE regex — a genuine
+  standalone regex-engine project, distinct from curry's existing
+  POSIX-based `(curry regex)`).
 
 ---
 

--- a/lib/curry/modules/srfi/41.sld
+++ b/lib/curry/modules/srfi/41.sld
@@ -1,0 +1,15 @@
+(define-library (srfi 41)
+  (import (srfi s41 streams))
+  (export
+    stream-null stream-cons stream? stream-null? stream-pair?
+    stream-car stream-cdr stream-lambda
+    define-stream list->stream stream stream->list
+    stream-filter stream-map stream-from stream-take
+    stream-append stream-concat stream-constant
+    stream-drop stream-drop-while stream-fold stream-for-each
+    stream-iterate stream-length stream-of stream-of-aux
+    stream-range stream-ref stream-reverse stream-scan
+    stream-take-while stream-unfold stream-unfolds stream-zip
+    stream-let port->stream stream-match
+    stream-match-test stream-match-pattern
+    %make-stream-pare))

--- a/lib/curry/modules/srfi/s41/streams.scm
+++ b/lib/curry/modules/srfi/s41/streams.scm
@@ -1,0 +1,422 @@
+;;; SRFI-41: Streams.
+;;;
+;;; The reference implementation builds its own memoizing lazy-promise
+;;; machinery from scratch (a record type wrapping an eager/lazy tagged
+;;; thunk) because SRFI-41 predates R7RS's delay-force. curry already
+;;; has R7RS delay/delay-force/force natively -- with the exact
+;;; iterative, stack-safe chain-flattening SRFI-41's own spec calls
+;;; "vitally critical" already verified correct (a 3+-level delay-force
+;;; chain-flattening bug was found and fixed here independently of this
+;;; SRFI, see CHANGELOG v1.22.0) -- so this port replaces the from-
+;;; scratch promise machinery with curry's own, rather than porting it.
+;;;
+;;; Representation: a stream IS a curry promise. stream-null is an
+;;; already-forced promise holding a unique sentinel; stream-cons
+;;; wraps its car in an ordinary memoizing (delay ...) and its cdr in
+;;; (delay-force ...) -- ordinary delay would NOT be safe for the cdr,
+;;; since a long chain of nested delay-forces (e.g. stream-filter's own
+;;; recursive definition) is exactly the case delay-force's iterative
+;;; flattening exists for; plain delay would grow the stack one frame
+;;; per element instead.
+;;;
+;;; Deliberate deviation from the spec, clearly noted: reusing curry's
+;;; raw promise type directly (rather than wrapping it in a distinct
+;;; record, the way the reference implementation's own stream-type
+;;; does) means stream? is really "is this a promise", not "is this
+;;; specifically a stream" -- (stream? (delay 5)) is #t here, where the
+;;; reference implementation would say #f. This is unavoidable: wrapping
+;;; the promise in a separate record for stronger typing would break
+;;; delay-force's own chain-flattening (it only continues chaining when
+;;; the value it unwraps is itself a promise; a custom record wouldn't
+;;; qualify), defeating the entire point of using delay-force for the
+;;; cdr. In exchange, this is a strictly more capable representation on
+;;; the one axis that actually matters for a stream library: no stack
+;;; growth walking an arbitrarily long stream.
+;;;
+;;; stream-match ported using curry's own established syntax-rules
+;;; wildcard idiom (a literal `_` in the literals list, matched by
+;;; position before the general pattern-variable clause) -- the same
+;;; technique (curry matchable) already uses -- rather than the
+;;; reference implementation's syntax-case/identifier?/free-identifier=?
+;;; version, since curry's macro system is syntax-rules only.
+(define-library (srfi s41 streams)
+  (import (scheme base) (srfi s1 lists))
+  (export
+    stream-null stream-cons stream? stream-null? stream-pair?
+    stream-car stream-cdr stream-lambda
+    define-stream list->stream stream stream->list
+    stream-filter stream-map stream-from stream-take
+    stream-append stream-concat stream-constant
+    stream-drop stream-drop-while stream-fold stream-for-each
+    stream-iterate stream-length stream-of stream-of-aux
+    stream-range stream-ref stream-reverse stream-scan
+    stream-take-while stream-unfold stream-unfolds stream-zip
+    stream-let port->stream stream-match
+    stream-match-test stream-match-pattern
+    %make-stream-pare) ; not public API -- stream-cons's expansion
+                       ; references it, and curry's syntax-rules isn't
+                       ; hygienic across define-library boundaries
+  (begin
+
+    ;; ---- primitives ----
+
+    (define %stream-null-tag (list 'stream-null))
+    (define stream-null (make-promise %stream-null-tag))
+
+    (define (stream? obj) (promise? obj))
+    (define (stream-null? obj) (eqv? (force obj) %stream-null-tag))
+
+    (define-record-type <stream-pare>
+      (%make-stream-pare kar kdr) %stream-pare?
+      (kar %stream-pare-kar)
+      (kdr %stream-pare-kdr))
+
+    (define (stream-pair? obj) (and (promise? obj) (%stream-pare? (force obj))))
+
+    (define-syntax stream-cons
+      (syntax-rules ()
+        ((_ obj strm) (make-promise (%make-stream-pare (delay obj) (delay-force strm))))))
+
+    (define (stream-car strm)
+      (cond
+        ((not (stream? strm)) (error "stream-car: non-stream argument" strm))
+        ((stream-null? strm) (error "stream-car: null stream" strm))
+        (else (force (%stream-pare-kar (force strm))))))
+
+    (define (stream-cdr strm)
+      (cond
+        ((not (stream? strm)) (error "stream-cdr: non-stream argument" strm))
+        ((stream-null? strm) (error "stream-cdr: null stream" strm))
+        (else (%stream-pare-kdr (force strm)))))
+
+    (define-syntax stream-lambda
+      (syntax-rules ()
+        ((_ formals body0 body1 ...) (lambda formals (delay-force (let () body0 body1 ...))))))
+
+    ;; ---- derived ----
+
+    (define-syntax define-stream
+      (syntax-rules ()
+        ((_ (name . formal) body0 body1 ...) (define name (stream-lambda formal body0 body1 ...)))))
+
+    (define (list->stream objs)
+      (define %list->stream
+        (stream-lambda (objs)
+          (if (null? objs) stream-null (stream-cons (car objs) (%list->stream (cdr objs))))))
+      (if (not (list? objs)) (error "list->stream: non-list argument" objs) (%list->stream objs)))
+
+    (define-syntax stream
+      (syntax-rules ()
+        ((_) stream-null)
+        ((_ x y ...) (stream-cons x (stream y ...)))))
+
+    ;; curry has no case-lambda (see e.g. lib/curry/modules/curry/schematic/
+    ;; format.scm's own note on the same gap) -- dispatch on argument count
+    ;; via a plain rest-arg, matching the reference implementation's own
+    ;; approach exactly (it doesn't use case-lambda either).
+    (define (stream->list . args)
+      (let ((n (if (= 1 (length args)) #f (car args)))
+            (strm (if (= 1 (length args)) (car args) (cadr args))))
+        (cond
+          ((not (stream? strm)) (error "stream->list: non-stream argument" strm))
+          ((and n (not (integer? n))) (error "stream->list: non-integer count" n))
+          ((and n (negative? n)) (error "stream->list: negative count" n))
+          (else
+           (let loop ((n (if n n -1)) (strm strm))
+             (if (or (zero? n) (stream-null? strm))
+                 '()
+                 (cons (stream-car strm) (loop (- n 1) (stream-cdr strm)))))))))
+
+    (define (stream-filter pred? strm)
+      (define %stream-filter
+        (stream-lambda (strm)
+          (cond
+            ((stream-null? strm) stream-null)
+            ((pred? (stream-car strm)) (stream-cons (stream-car strm) (%stream-filter (stream-cdr strm))))
+            (else (%stream-filter (stream-cdr strm))))))
+      (cond
+        ((not (procedure? pred?)) (error "stream-filter: non-procedural argument" pred?))
+        ((not (stream? strm)) (error "stream-filter: non-stream argument" strm))
+        (else (%stream-filter strm))))
+
+    (define (stream-map proc . strms)
+      (define %stream-map
+        (stream-lambda (strms)
+          (if (any stream-null? strms)
+              stream-null
+              (stream-cons (apply proc (map stream-car strms)) (%stream-map (map stream-cdr strms))))))
+      (cond
+        ((not (procedure? proc)) (error "stream-map: non-procedural argument" proc))
+        ((null? strms) (error "stream-map: no stream arguments"))
+        ((any (lambda (x) (not (stream? x))) strms) (error "stream-map: non-stream argument"))
+        (else (%stream-map strms))))
+
+    (define (stream-from first . step)
+      (define %stream-from
+        (stream-lambda (first delta)
+          (stream-cons first (%stream-from (+ first delta) delta))))
+      (let ((delta (if (null? step) 1 (car step))))
+        (cond
+          ((not (number? first)) (error "stream-from: non-numeric starting value" first))
+          ((not (number? delta)) (error "stream-from: non-numeric step" delta))
+          (else (%stream-from first delta)))))
+
+    (define (stream-take n strm)
+      (define %stream-take
+        (stream-lambda (n strm)
+          (if (or (stream-null? strm) (zero? n))
+              stream-null
+              (stream-cons (stream-car strm) (%stream-take (- n 1) (stream-cdr strm))))))
+      (cond
+        ((not (stream? strm)) (error "stream-take: non-stream argument" strm))
+        ((not (integer? n)) (error "stream-take: non-integer argument" n))
+        ((negative? n) (error "stream-take: negative argument" n))
+        (else (%stream-take n strm))))
+
+    ;; Not in the spec's own reference-implementation appendix -- derived
+    ;; here by mirroring stream-concat's own structure directly below
+    ;; (a plain Scheme list of stream arguments, not a stream-of-streams)
+    ;; and verified by hand-tracing a two-stream example.
+    (define (stream-append . strms)
+      (define %stream-append
+        (stream-lambda (strms)
+          (cond
+            ((null? strms) stream-null)
+            ((not (stream? (car strms))) (error "stream-append: non-stream argument"))
+            ((stream-null? (car strms)) (%stream-append (cdr strms)))
+            (else (stream-cons (stream-car (car strms))
+                                (%stream-append (cons (stream-cdr (car strms)) (cdr strms))))))))
+      (%stream-append strms))
+
+    (define (stream-concat strms)
+      (define %stream-concat
+        (stream-lambda (strms)
+          (cond
+            ((stream-null? strms) stream-null)
+            ((not (stream? (stream-car strms))) (error "stream-concat: non-stream object in input stream"))
+            ((stream-null? (stream-car strms)) (%stream-concat (stream-cdr strms)))
+            (else (stream-cons (stream-car (stream-car strms))
+                                (%stream-concat (stream-cons (stream-cdr (stream-car strms)) (stream-cdr strms))))))))
+      (if (not (stream? strms)) (error "stream-concat: non-stream argument" strms) (%stream-concat strms)))
+
+    (define stream-constant
+      (stream-lambda objs
+        (cond
+          ((null? objs) stream-null)
+          ((null? (cdr objs)) (stream-cons (car objs) (stream-constant (car objs))))
+          (else (stream-cons (car objs) (apply stream-constant (append (cdr objs) (list (car objs)))))))))
+
+    (define (stream-drop n strm)
+      (define %stream-drop
+        (stream-lambda (n strm)
+          (if (or (zero? n) (stream-null? strm)) strm (%stream-drop (- n 1) (stream-cdr strm)))))
+      (cond
+        ((not (integer? n)) (error "stream-drop: non-integer argument" n))
+        ((negative? n) (error "stream-drop: negative argument" n))
+        ((not (stream? strm)) (error "stream-drop: non-stream argument" strm))
+        (else (%stream-drop n strm))))
+
+    (define (stream-drop-while pred? strm)
+      (define %stream-drop-while
+        (stream-lambda (strm)
+          (if (and (stream-pair? strm) (pred? (stream-car strm)))
+              (%stream-drop-while (stream-cdr strm))
+              strm)))
+      (cond
+        ((not (procedure? pred?)) (error "stream-drop-while: non-procedural argument" pred?))
+        ((not (stream? strm)) (error "stream-drop-while: non-stream argument" strm))
+        (else (%stream-drop-while strm))))
+
+    (define (stream-fold proc base strm)
+      (cond
+        ((not (procedure? proc)) (error "stream-fold: non-procedural argument" proc))
+        ((not (stream? strm)) (error "stream-fold: non-stream argument" strm))
+        (else (let loop ((base base) (strm strm))
+                (if (stream-null? strm) base (loop (proc base (stream-car strm)) (stream-cdr strm)))))))
+
+    (define (stream-for-each proc . strms)
+      (define (%stream-for-each strms)
+        (if (not (any stream-null? strms))
+            (begin (apply proc (map stream-car strms)) (%stream-for-each (map stream-cdr strms)))))
+      (cond
+        ((not (procedure? proc)) (error "stream-for-each: non-procedural argument" proc))
+        ((null? strms) (error "stream-for-each: no stream arguments"))
+        ((any (lambda (x) (not (stream? x))) strms) (error "stream-for-each: non-stream argument"))
+        (else (%stream-for-each strms))))
+
+    (define (stream-iterate proc base)
+      (define %stream-iterate
+        (stream-lambda (base) (stream-cons base (%stream-iterate (proc base)))))
+      (if (not (procedure? proc)) (error "stream-iterate: non-procedural argument" proc) (%stream-iterate base)))
+
+    (define (stream-length strm)
+      (if (not (stream? strm))
+          (error "stream-length: non-stream argument" strm)
+          (let loop ((len 0) (strm strm))
+            (if (stream-null? strm) len (loop (+ len 1) (stream-cdr strm))))))
+
+    (define-syntax stream-of
+      (syntax-rules ()
+        ((_ expr rest ...) (stream-of-aux expr stream-null rest ...))))
+
+    (define-syntax stream-of-aux
+      (syntax-rules (in is)
+        ((_ expr base) (stream-cons expr base))
+        ((_ expr base (var in strm) rest ...)
+         (stream-let %loop ((s strm))
+           (if (stream-null? s)
+               base
+               (let ((var (stream-car s)))
+                 (stream-of-aux expr (%loop (stream-cdr s)) rest ...)))))
+        ((_ expr base (var is exp) rest ...)
+         (let ((var exp)) (stream-of-aux expr base rest ...)))
+        ((_ expr base pred? rest ...)
+         (if pred? (stream-of-aux expr base rest ...) base))))
+
+    (define (stream-range first past . step)
+      (define %stream-range
+        (stream-lambda (first past delta lt?)
+          (if (lt? first past)
+              (stream-cons first (%stream-range (+ first delta) past delta lt?))
+              stream-null)))
+      (cond
+        ((not (number? first)) (error "stream-range: non-numeric starting number" first))
+        ((not (number? past)) (error "stream-range: non-numeric ending number" past))
+        (else
+         (let ((delta (cond ((pair? step) (car step)) ((< first past) 1) (else -1))))
+           (if (not (number? delta))
+               (error "stream-range: non-numeric step size" delta)
+               (let ((lt? (if (< 0 delta) < >)))
+                 (%stream-range first past delta lt?)))))))
+
+    (define (stream-ref strm n)
+      (cond
+        ((not (stream? strm)) (error "stream-ref: non-stream argument" strm))
+        ((not (and (integer? n) (>= n 0))) (error "stream-ref: invalid index" n))
+        (else (let loop ((strm strm) (n n))
+                (cond
+                  ((stream-null? strm) (error "stream-ref: index out of range"))
+                  ((zero? n) (stream-car strm))
+                  (else (loop (stream-cdr strm) (- n 1))))))))
+
+    (define (stream-reverse strm)
+      (define %stream-reverse
+        (stream-lambda (strm rev)
+          (if (stream-null? strm) rev (%stream-reverse (stream-cdr strm) (stream-cons (stream-car strm) rev)))))
+      (if (not (stream? strm)) (error "stream-reverse: non-stream argument" strm) (%stream-reverse strm stream-null)))
+
+    (define (stream-scan proc base strm)
+      (define %stream-scan
+        (stream-lambda (base strm)
+          (if (stream-null? strm)
+              (stream base)
+              (stream-cons base (%stream-scan (proc base (stream-car strm)) (stream-cdr strm))))))
+      (cond
+        ((not (procedure? proc)) (error "stream-scan: non-procedural argument" proc))
+        ((not (stream? strm)) (error "stream-scan: non-stream argument" strm))
+        (else (%stream-scan base strm))))
+
+    (define (stream-take-while pred? strm)
+      (define %stream-take-while
+        (stream-lambda (strm)
+          (cond
+            ((stream-null? strm) stream-null)
+            ((pred? (stream-car strm)) (stream-cons (stream-car strm) (%stream-take-while (stream-cdr strm))))
+            (else stream-null))))
+      (cond
+        ((not (stream? strm)) (error "stream-take-while: non-stream argument" strm))
+        ((not (procedure? pred?)) (error "stream-take-while: non-procedural argument" pred?))
+        (else (%stream-take-while strm))))
+
+    (define (stream-unfold mapper pred? generator base)
+      (define %stream-unfold
+        (stream-lambda (base)
+          (if (pred? base)
+              (stream-cons (mapper base) (%stream-unfold (generator base)))
+              stream-null)))
+      (cond
+        ((not (procedure? mapper)) (error "stream-unfold: non-procedural mapper" mapper))
+        ((not (procedure? pred?)) (error "stream-unfold: non-procedural pred?" pred?))
+        ((not (procedure? generator)) (error "stream-unfold: non-procedural generator" generator))
+        (else (%stream-unfold base))))
+
+    (define (stream-unfolds gen seed)
+      (define (%len-values gen seed)
+        (call-with-values (lambda () (gen seed)) (lambda vs (- (length vs) 1))))
+      (define %unfold-result-stream
+        (stream-lambda (gen seed)
+          (call-with-values
+           (lambda () (gen seed))
+           (lambda (next . results) (stream-cons results (%unfold-result-stream gen next))))))
+      (define %result-stream->output-stream
+        (stream-lambda (result-stream i)
+          (let ((result (list-ref (stream-car result-stream) (- i 1))))
+            (cond
+              ((pair? result) (stream-cons (car result) (%result-stream->output-stream (stream-cdr result-stream) i)))
+              ((not result) (%result-stream->output-stream (stream-cdr result-stream) i))
+              ((null? result) stream-null)
+              (else (error "stream-unfolds: can't happen"))))))
+      (define (%result-stream->output-streams result-stream)
+        (let loop ((i (%len-values gen seed)) (outputs '()))
+          (if (zero? i)
+              (apply values outputs)
+              (loop (- i 1) (cons (%result-stream->output-stream result-stream i) outputs)))))
+      (if (not (procedure? gen))
+          (error "stream-unfolds: non-procedural argument" gen)
+          (%result-stream->output-streams (%unfold-result-stream gen seed))))
+
+    (define (stream-zip . strms)
+      (define %stream-zip
+        (stream-lambda (strms)
+          (if (any stream-null? strms)
+              stream-null
+              (stream-cons (map stream-car strms) (%stream-zip (map stream-cdr strms))))))
+      (cond
+        ((null? strms) (error "stream-zip: no stream arguments"))
+        ((any (lambda (x) (not (stream? x))) strms) (error "stream-zip: non-stream argument"))
+        (else (%stream-zip strms))))
+
+    (define-syntax stream-let
+      (syntax-rules ()
+        ((_ tag ((name val) ...) body1 body2 ...)
+         ((letrec ((tag (stream-lambda (name ...) body1 body2 ...))) tag) val ...))))
+
+    (define (port->stream . port)
+      (define %port->stream
+        (stream-lambda (p)
+          (let ((c (read-char p)))
+            (if (eof-object? c) stream-null (stream-cons c (%port->stream p))))))
+      (let ((p (if (null? port) (current-input-port) (car port))))
+        (if (not (input-port? p)) (error "port->stream: non-input-port argument" p) (%port->stream p))))
+
+    ;; stream-match: ported using curry's own established syntax-rules
+    ;; wildcard idiom (literal `_`, matched before the general
+    ;; pattern-variable clause) rather than the reference's syntax-case
+    ;; version -- see the module header comment.
+    (define-syntax stream-match
+      (syntax-rules ()
+        ((_ strm-expr clause ...)
+         (let ((s strm-expr))
+           (cond
+             ((not (stream? s)) (error "stream-match: non-stream argument"))
+             ((stream-match-test s clause) => car)
+             ...
+             (else (error "stream-match: pattern failure")))))))
+
+    (define-syntax stream-match-test
+      (syntax-rules ()
+        ((_ strm (pattern fender expr)) (stream-match-pattern strm pattern () (and fender (list expr))))
+        ((_ strm (pattern expr)) (stream-match-pattern strm pattern () (list expr)))))
+
+    (define-syntax stream-match-pattern
+      (syntax-rules (_)
+        ((_ strm () (binding ...) body) (and (stream-null? strm) (let (binding ...) body)))
+        ((_ strm (_ . rest) (binding ...) body)
+         (and (stream-pair? strm)
+              (let ((strm (stream-cdr strm))) (stream-match-pattern strm rest (binding ...) body))))
+        ((_ strm (var . rest) (binding ...) body)
+         (and (stream-pair? strm)
+              (let ((temp (stream-car strm)) (strm (stream-cdr strm)))
+                (stream-match-pattern strm rest ((var temp) binding ...) body))))
+        ((_ strm _ (binding ...) body) (let (binding ...) body))
+        ((_ strm var (binding ...) body) (let ((var strm) binding ...) body))))))

--- a/lib/curry/modules/srfi/srfi-41.sld
+++ b/lib/curry/modules/srfi/srfi-41.sld
@@ -1,0 +1,15 @@
+(define-library (srfi srfi-41)
+  (import (srfi s41 streams))
+  (export
+    stream-null stream-cons stream? stream-null? stream-pair?
+    stream-car stream-cdr stream-lambda
+    define-stream list->stream stream stream->list
+    stream-filter stream-map stream-from stream-take
+    stream-append stream-concat stream-constant
+    stream-drop stream-drop-while stream-fold stream-for-each
+    stream-iterate stream-length stream-of stream-of-aux
+    stream-range stream-ref stream-reverse stream-scan
+    stream-take-while stream-unfold stream-unfolds stream-zip
+    stream-let port->stream stream-match
+    stream-match-test stream-match-pattern
+    %make-stream-pare))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ add_test(NAME websocket COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/
 add_test(NAME ros COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/ros_tests.scm)
 add_test(NAME srfi_95_78_212 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_95_78_212_tests.scm)
 add_test(NAME srfi_141 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_141_tests.scm)
+add_test(NAME srfi_41 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_41_tests.scm)
 if(BUILD_MPFR)
   add_test(NAME mpfr COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/mpfr_tests.scm)
 endif()

--- a/tests/srfi_41_tests.scm
+++ b/tests/srfi_41_tests.scm
@@ -1,0 +1,124 @@
+;;; srfi_41_tests.scm — SRFI-41 (Streams). Every derived procedure is
+;;; exercised at least once; a dedicated section verifies the whole
+;;; point of building this on curry's native delay-force (stack safety
+;;; on a long stream, not just correctness).
+
+(import (scheme base) (srfi s41 streams))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label result expected)
+  (if (equal? result expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " got ") (write result)
+             (display " expected ") (write expected)
+             (newline)
+             (set! fail (+ fail 1)))))
+
+;;; primitives
+
+(check "stream-null?" (stream-null? stream-null) #t)
+(define s123 (stream-cons 1 (stream-cons 2 (stream-cons 3 stream-null))))
+(check "stream-car" (stream-car s123) 1)
+(check "stream-cdr then stream-car" (stream-car (stream-cdr s123)) 2)
+(check "stream-pair? true" (stream-pair? s123) #t)
+(check "stream-pair? false" (stream-pair? stream-null) #f)
+
+;;; constructors / destructors
+
+(check "stream constructor macro" (stream->list (stream 1 2 3)) (list 1 2 3))
+(check "list->stream" (stream->list (list->stream (list 4 5 6))) (list 4 5 6))
+(check "stream->list with count" (stream->list 2 (stream-from 0)) (list 0 1))
+(check "stream-ref" (stream-ref (stream 10 20 30) 1) 20)
+(check "stream-length" (stream-length (stream 1 2 3)) 3)
+
+;;; transformations
+
+(check "stream-take" (stream->list (stream-take 3 (stream-from 10))) (list 10 11 12))
+(check "stream-map" (stream->list (stream-map + (stream 1 2 3) (stream 10 20 30))) (list 11 22 33))
+(check "stream-filter" (stream->list (stream-filter even? (stream 1 2 3 4 5 6))) (list 2 4 6))
+(check "stream-reverse" (stream->list (stream-reverse (stream 1 2 3))) (list 3 2 1))
+(check "stream-append" (stream->list (stream-append (stream 1 2) (stream 3 4))) (list 1 2 3 4))
+(check "stream-concat" (stream->list (stream-concat (stream (stream 1 2) (stream 3 4)))) (list 1 2 3 4))
+(check "stream-drop" (stream->list (stream-drop 2 (stream 1 2 3 4))) (list 3 4))
+(check "stream-drop-while" (stream->list (stream-drop-while even? (stream 2 4 5 6))) (list 5 6))
+(check "stream-take-while" (stream->list (stream-take-while even? (stream 2 4 5 6))) (list 2 4))
+(check "stream-scan" (stream->list (stream-scan + 0 (stream 1 2 3))) (list 0 1 3 6))
+(check "stream-zip" (stream->list (stream-zip (stream 1 2) (stream 'a 'b))) (list (list 1 'a) (list 2 'b)))
+
+;;; folding / iteration
+
+(check "stream-fold" (stream-fold + 0 (stream 1 2 3 4)) 10)
+(define %for-each-acc '())
+(stream-for-each (lambda (x) (set! %for-each-acc (cons x %for-each-acc))) (stream 1 2 3))
+(check "stream-for-each" (reverse %for-each-acc) (list 1 2 3))
+(check "stream-iterate" (stream->list (stream-take 4 (stream-iterate (lambda (x) (* x 2)) 1))) (list 1 2 4 8))
+
+;;; generators
+
+(check "stream-range" (stream->list (stream-range 0 5)) (list 0 1 2 3 4))
+(check "stream-range with step" (stream->list (stream-range 0 10 2)) (list 0 2 4 6 8))
+(check "stream-constant" (stream->list (stream-take 5 (stream-constant 1 2))) (list 1 2 1 2 1))
+(check "stream-unfold"
+       (stream->list (stream-unfold (lambda (x) (* x x)) (lambda (x) (< x 4)) (lambda (x) (+ x 1)) 0))
+       (list 0 1 4 9))
+
+;; stream-unfolds' generator returns (values next-seed result ...) per
+;; output stream, where each result is a one-element list to emit a
+;; value, #f to skip this round (NOT terminate -- an easy mistake, since
+;; the generator keeps getting called with the same seed forever if it
+;; never returns '() instead), or '() to end that output stream.
+(define (%unfolds-gen seed) (if (> seed 5) (values seed '()) (values (+ seed 1) (list seed))))
+(call-with-values
+ (lambda () (stream-unfolds %unfolds-gen 0))
+ (lambda (s) (check "stream-unfolds" (stream->list s) (list 0 1 2 3 4 5))))
+
+(define %port (open-input-string "abc"))
+(check "port->stream" (stream->list (port->stream %port)) (list #\a #\b #\c))
+
+;;; sugar
+
+(check "stream-let"
+       (stream->list (stream-let %loop ((n 0)) (if (= n 3) stream-null (stream-cons n (%loop (+ n 1))))))
+       (list 0 1 2))
+(define-stream (%nats n) (stream-cons n (%nats (+ n 1))))
+(check "define-stream" (stream->list (stream-take 3 (%nats 5))) (list 5 6 7))
+(check "stream-of" (stream->list (stream-of (* x x) (x in (stream 1 2 3)))) (list 1 4 9))
+(check "stream-of with guard"
+       (stream->list (stream-of x (x in (stream 1 2 3 4 5 6)) (even? x)))
+       (list 2 4 6))
+
+;;; stream-match
+
+(check "stream-match: empty vs non-empty wildcard"
+       (stream-match (stream 1 2 3) (() 'empty) ((_ . _) 'nonempty))
+       'nonempty)
+(check "stream-match: empty case"
+       (stream-match stream-null (() 'empty) ((_ . _) 'nonempty))
+       'empty)
+(check "stream-match: bindings, rest captured as a stream"
+       (stream-match (stream 1 2 3) ((a b . rest) (list a b (stream->list rest))))
+       (list 1 2 (list 3)))
+
+;;; Stack safety: the entire reason this port uses curry's native
+;;; delay-force for the cdr instead of plain delay is that a long
+;;; stream must not grow the VM's call stack per element. 100,000
+;;; elements is comfortably past the 256-frame guard a naive
+;;; non-tail-safe implementation would blow through.
+
+(check "stack-safe: stream-length over 100,000 elements" (stream-length (stream-range 0 100000)) 100000)
+(check "stack-safe: stream-fold over 1,000 elements" (stream-fold + 0 (stream-range 1 1001)) 500500)
+(check "stack-safe: stream-filter over 50,000 elements"
+       (stream-length (stream-filter even? (stream-range 0 50000)))
+       25000)
+
+;;; Summary
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/srfi_legacy_dashed_names_tests.scm
+++ b/tests/srfi_legacy_dashed_names_tests.scm
@@ -11,7 +11,7 @@
 (import (srfi srfi-125) (srfi srfi-128) (srfi srfi-170) (srfi srfi-227)
         (srfi srfi-9) (srfi srfi-31) (srfi srfi-45)
         (srfi srfi-95) (srfi srfi-78) (srfi srfi-212)
-        (srfi srfi-141))
+        (srfi srfi-141) (srfi srfi-41))
 
 (define pass 0)
 (define fail 0)
@@ -85,6 +85,10 @@
 ;;; (srfi srfi-141)
 (assert-equal "srfi-141 legacy shim exports euclidean-remainder"
        (euclidean-remainder -7 2) 1)
+
+;;; (srfi srfi-41)
+(assert-equal "srfi-41 legacy shim exports stream/stream->list"
+       (stream->list (stream 1 2 3)) (list 1 2 3))
 
 ;;; Summary
 


### PR DESCRIPTION
## Summary

Adds SRFI-41 (Streams) — lazy, memoizing streams, ~43 bindings — building directly on SRFI-45's `lazy`/`delay-force` shipped earlier this session.

The key design decision: SRFI-41's own reference implementation has to build its own memoizing lazy-promise machinery from scratch (it predates R7RS's `delay-force`). curry already has `delay`/`delay-force`/`force` natively with exactly the iterative, stack-safe chain-flattening the SRFI's own spec calls "vitally critical" — so this port represents a stream *as* a curry promise directly, rather than wrapping one in a distinct record.

**Disclosed tradeoff**: `stream?` really means "is this a promise", not "is this specifically a stream" — `(stream? (delay 5))` is `#t` here, `#f` in the reference. This is unavoidable while keeping the stack-safety property — a wrapper record would stop `delay-force`'s own chain-flattening from seeing through it, defeating the reason to build this on `delay-force` at all. Documented in both the module header and `docs/reference/srfi/s41.md`.

Most procedures are ported directly from the SRFI's own reference implementation; `stream-append` isn't in the spec's reference appendix and was derived by mirroring `stream-concat`'s structure. `stream-match` uses curry's own established `syntax-rules` literal-`_` wildcard idiom (matching `(curry matchable)`) instead of the reference's `syntax-case` version, since curry's macros are `syntax-rules` only.

## Bug found along the way

curry has no `case-lambda` at all (confirmed by an existing comment elsewhere in the codebase) — an initial draft of `stream->list` using it failed with a confusing "unbound variable: x" rather than a clean error. Rewritten using the reference implementation's own plain rest-arg dispatch instead.

## Test plan

- [x] 111/111 ctest suites pass, fresh `--clear-cache` run, rebuilt standalone on this branch off `origin/main`
- [x] `tests/srfi_41_tests.scm` — 40 checks covering every derived procedure plus a dedicated stack-safety section (100,000-element stream traversal)
- [x] `tests/srfi_legacy_dashed_names_tests.scm` extended for the new dashed shim
- [x] Independent code review (fresh subagent): verified the `delay-force` claim by reading `src/eval.c`/`builtins.c` directly, then stress-tested past the shipped suite — a 2,000,000-element `stream-filter` (chaining ~2M consecutive `delay-force` collapses in one `stream-car` call), `stream-append` edge cases (3+ streams, empty stream mid-list, single/zero-argument calls), and `stream-match`'s fender-guard form (untested in the shipped suite). No bugs found.

`docs/roadmap.md`'s SRFI section updated to move SRFI-41 from "parked follow-up work" to shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
