### PR TITLE
feat(websocket): add server role (ws-listen/ws-accept)

### DIFF
--- a/docs/reference/module-websocket.md
+++ b/docs/reference/module-websocket.md
@@ -2,9 +2,11 @@
 
 *unreleased*
 
-A plain (no TLS) RFC 6455 WebSocket client, pure Scheme — built entirely on curry's existing SRFI-106 sockets and `(curry crypto)`'s `sha1`/`base64-encode` for the handshake. No new C code, no external library.
+A plain (no TLS) RFC 6455 WebSocket client **and server**, pure Scheme — built entirely on curry's existing SRFI-106 sockets and `(curry crypto)`'s `sha1`/`base64-encode` for the handshake. No new C code, no external library.
 
-`ws://` only. `wss://` would need a TLS byte stream underneath the handshake and framing implemented here; SRFI-106 doesn't provide one. `(curry network)` has its own `tls-connect`, but it isn't wired into this module — a `wss://` client would mean layering this module's protocol logic over that instead of a plain socket.
+`ws://` only. `wss://` would need a TLS byte stream underneath the handshake and framing implemented here; SRFI-106 doesn't provide one. `(curry network)` has its own `tls-connect`, but it isn't wired into this module — a `wss://` client/server would mean layering this module's protocol logic over that instead of a plain socket.
+
+Client and server share every piece of frame-level machinery (masking, length encoding, fragmentation reassembly, ping/pong) — the only place the role actually matters is which direction masks: RFC 6455 §5.1 requires every client-to-server frame to be masked and forbids masking server-to-client frames, and requires a peer that receives a frame violating this to fail the connection (this is a real security requirement — defense against cache/protocol-confusion attacks via intermediaries that don't understand WebSocket framing — not just wire-format tidiness). `ws-recv!` enforces both directions: a server rejects an unmasked incoming frame, a client rejects a masked one, closing the connection and raising a clear error either way rather than silently tolerating the violation.
 
 ## Installation
 
@@ -16,7 +18,7 @@ No extra packages required. Always available — pure Scheme, no CMake flag.
 (import (curry websocket))
 ```
 
-## Procedures
+## Procedures — client
 
 ### `(ws-connect url)` → ws
 
@@ -48,6 +50,48 @@ Sends a close frame (if not already closed) and closes the underlying socket.
 ### `(ws-closed? ws)` → boolean
 
 ### `(ws? obj)` → boolean
+
+### `(ws-path ws)` → string | `#f`
+
+The request path a server-side connection was opened against (e.g. `"/live-data"`), for a server that wants to route by path. `#f` for a client-side connection — `ws-connect`'s own caller already knows the path it asked for, it doesn't need it echoed back.
+
+Returned verbatim from the request line — a query string, if the client sent one, stays attached (`GET /live-data?token=abc HTTP/1.1` gives `"/live-data?token=abc"`, not `"/live-data"`). Split it yourself if you're routing on the path alone.
+
+## Procedures — server
+
+### `(ws-listen port)` → listener
+
+Binds and listens on `port`. Doesn't block, doesn't accept anything yet — mirrors `(curry network)`'s own `tcp-listen`.
+
+### `(ws-accept listener)` → ws
+
+Blocks for the next incoming TCP connection and completes the RFC 6455 opening handshake on it (reads the client's `GET` request and headers, extracts `Sec-WebSocket-Key`, computes and sends `Sec-WebSocket-Accept`) before returning. By the time `ws-accept` returns, the connection is a fully negotiated WebSocket — `ws-send!`/`ws-recv!`/`ws-close!` all work on it exactly as they would on a `ws-connect` result. Raises if the request has no `Sec-WebSocket-Key` or a malformed request line, if the connection closes before the handshake completes, or if a single header line exceeds 8KB or the request has more than 100 header lines — a bounded-cost rejection of a connection that's misbehaving or attacking, rather than unbounded memory growth (an incoming connection is untrusted by construction, unlike `ws-connect`'s server, which the caller already chose to trust).
+
+### `(ws-listener? obj)` → boolean
+
+### `(ws-listener-close! listener)`
+
+Closes the listening socket. Doesn't affect any connections already accepted from it.
+
+## Example: a minimal echo server
+
+```scheme
+(import (curry websocket) (curry sync))
+
+(define listener (ws-listen 8080))
+
+(spawn (lambda ()
+         (let loop ()
+           (let ((conn (ws-accept listener)))
+             (spawn (lambda ()
+                      (let handle ()
+                        (let ((msg (ws-recv! conn)))
+                          (if (not (eof-object? msg))
+                              (begin (ws-send! conn msg) (handle)))))))
+             (loop)))))
+```
+
+One actor accepts connections in a loop; each accepted connection gets its own handler actor so slow or long-lived clients don't block new connections from being accepted. A client that disconnects abruptly mid-message raises inside `ws-recv!` (e.g. "connection closed mid-frame") — uncaught here, which only takes down that one handler actor (actors are isolated; the accept loop and every other connection are unaffected), but production code that wants to log or otherwise handle that gracefully should wrap the handler loop's body in `guard`.
 
 ## Thread safety
 

--- a/lib/curry/modules/curry/websocket.scm
+++ b/lib/curry/modules/curry/websocket.scm
@@ -1,18 +1,29 @@
-;;; (curry websocket) — a plain (no TLS) RFC 6455 WebSocket client, built
-;;; entirely on curry's existing SRFI-106 sockets and (curry crypto)'s
-;;; sha1/base64 -- no new C code. `ws://` only; `wss://` would need a TLS
-;;; stream underneath the handshake/framing here, which SRFI-106 doesn't
-;;; provide (see (curry network)'s own tls-connect for that piece, not yet
-;;; wired into this module).
+;;; (curry websocket) — a plain (no TLS) RFC 6455 WebSocket client AND
+;;; server, built entirely on curry's existing SRFI-106 sockets and
+;;; (curry crypto)'s sha1/base64 -- no new C code. `ws://` only; `wss://`
+;;; would need a TLS stream underneath the handshake/framing here, which
+;;; SRFI-106 doesn't provide (see (curry network)'s own tls-connect for
+;;; that piece, not yet wired into this module).
 ;;;
-;;; This exists primarily as the transport (curry ros) speaks rosbridge
-;;; over, but is a standalone, generally useful client on its own.
-
+;;; Client and server share every piece of frame-level machinery below
+;;; (masking, length encoding, fragmentation reassembly, ping/pong) --
+;;; the only place role actually matters is which direction masks:
+;;; client-to-server frames MUST be masked, server-to-client frames MUST
+;;; NOT be, per RFC 6455 section 5.1. %ws-write-frame! checks a
+;;; connection's own role and masks accordingly; %read-frame already
+;;; unmasks whenever a frame's mask bit is set regardless of which side
+;;; is reading, so it needed no change at all to support the server role.
+;;;
+;;; The client role exists primarily as the transport (curry ros) speaks
+;;; rosbridge over; the server role exists to let a curry process push
+;;; live data to a browser-side frontend (e.g. React/whatever) without
+;;; needing curry to also speak HTTP.
 (define-library (curry websocket)
   (import (scheme base) (scheme write) (srfi s106 sockets) (curry crypto) (curry sync))
   (export
     ws-connect ws-send! ws-send-binary! ws-recv! ws-close! ws-closed?
-    ws?)
+    ws? ws-path
+    ws-listen ws-accept ws-listener? ws-listener-close!)
   (begin
 
     ;; A GUID fixed by RFC 6455 itself -- concatenated with the client's
@@ -21,15 +32,25 @@
     (define %ws-guid "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
 
     (define-record-type <ws>
-      (%make-ws socket in out closed? send-mutex)
+      (%make-ws socket in out closed? send-mutex role path)
       ws?
       (socket %ws-socket)
       (in     %ws-in)
       (out    %ws-out)
       (closed? %ws-closed? %ws-set-closed?!)
-      (send-mutex %ws-send-mutex))
+      (send-mutex %ws-send-mutex)
+      (role %ws-role)
+      ;; The request path a server-side connection was opened against
+      ;; (e.g. "/live-data"), for callers that want to route by path;
+      ;; #f for a client-side connection (ws-connect already knows the
+      ;; path it asked for, it doesn't need it echoed back).
+      (path ws-path))
 
     (define (ws-closed? ws) (%ws-closed? ws))
+
+    (define-record-type <ws-listener>
+      (%make-ws-listener socket) ws-listener?
+      (socket %ws-listener-socket))
 
     ;; ---- URL parsing: "ws://host[:port][/path]" -> (values host port path)
 
@@ -63,17 +84,47 @@
               (begin (bytevector-u8-set! bv i (random-integer 256)) (loop (+ i 1)))))
         (base64-encode bv)))
 
+    ;; curry's core read-line has no line-length cap at all -- it grows an
+    ;; output-string buffer until it sees \n or EOF, unconditionally. That's
+    ;; fine for ws-connect (the peer is a server the caller already chose
+    ;; to trust), but ws-accept hands this the request line/headers of an
+    ;; arbitrary, untrusted incoming connection: a client that never sends
+    ;; \n (or sends unboundedly many header lines before the blank line
+    ;; that ends the request) can drive unbounded memory growth in a
+    ;; single connection -- confirmed directly during review with a 2MB
+    ;; unterminated line, still buffering with no error raised. Reading a
+    ;; char at a time with an explicit cap, rather than delegating to
+    ;; read-line, is the only way to actually bound this: checking a
+    ;; length after read-line returns doesn't help, since the unbounded
+    ;; blocking already happened before control comes back.
+    (define %ws-max-header-line-len 8192)
+    (define %ws-max-header-lines 100)
+
+    (define (%read-line-capped in)
+      (let loop ((chars '()) (n 0))
+        (let ((c (read-char in)))
+          (cond
+            ((eof-object? c) (if (null? chars) c (list->string (reverse chars))))
+            ((char=? c #\newline) (list->string (reverse chars)))
+            ((>= n %ws-max-header-line-len)
+             (error "ws: header line exceeds maximum length" %ws-max-header-line-len))
+            (else (loop (cons c chars) (+ n 1)))))))
+
     (define (%read-header-lines in)
       ;; Reads CRLF-terminated header lines up to (and consuming) the blank
-      ;; line that ends an HTTP response, returning the lines seen (status
-      ;; line first) with any trailing \r stripped. read-line's own notion
-      ;; of "line" already stops at \n, so only \r needs trimming here.
-      (let loop ((acc '()))
-        (let ((line (read-line in)))
-          (cond
-            ((eof-object? line) (error "ws-connect: connection closed during handshake"))
-            ((or (string=? line "") (string=? line "\r")) (reverse acc))
-            (else (loop (cons (%chomp-cr line) acc)))))))
+      ;; line that ends an HTTP request or response, returning the lines
+      ;; seen (request/status line first) with any trailing \r stripped.
+      ;; Shared by both ws-connect (reading the server's response) and
+      ;; ws-accept (reading the client's request) -- see %ws-max-header-*
+      ;; above for why this can't just delegate to plain read-line.
+      (let loop ((acc '()) (count 0))
+        (if (>= count %ws-max-header-lines)
+            (error "ws: too many header lines" %ws-max-header-lines)
+            (let ((line (%read-line-capped in)))
+              (cond
+                ((eof-object? line) (error "ws: connection closed during handshake"))
+                ((or (string=? line "") (string=? line "\r")) (reverse acc))
+                (else (loop (cons (%chomp-cr line) acc) (+ count 1))))))))
 
     (define (%chomp-cr s)
       (let ((n (string-length s)))
@@ -128,7 +179,7 @@
                  (error "ws-connect: server did not upgrade" status))
              (if (not (equal? accept expect))
                  (error "ws-connect: Sec-WebSocket-Accept mismatch" accept expect))
-             (%make-ws socket in out #f (make-mutex)))))))
+             (%make-ws socket in out #f (make-mutex) 'client path))))))
 
     (define (%string-contains s sub)
       (let ((sl (string-length s)) (bl (string-length sub)))
@@ -137,6 +188,51 @@
             ((> (+ i bl) sl) #f)
             ((string=? (substring s i (+ i bl)) sub) #t)
             (else (loop (+ i 1)))))))
+
+    ;; ---- Server: ws-listen / ws-accept
+
+    (define (ws-listen port) (%make-ws-listener (make-server-socket port)))
+
+    (define (ws-listener-close! listener) (socket-close (%ws-listener-socket listener)))
+
+    ;; Blocks for the next incoming TCP connection and completes the
+    ;; RFC 6455 opening handshake on it before returning -- by the time
+    ;; ws-accept returns, the connection is a fully negotiated WebSocket,
+    ;; usable with ws-send!/ws-recv!/ws-close! exactly like a ws-connect
+    ;; result (the role difference is internal, see the module header).
+    (define (ws-accept listener)
+      (let* ((socket (socket-accept (%ws-listener-socket listener)))
+             (in (socket-input-port socket))
+             (out (socket-output-port socket))
+             (path (%server-handshake! in out)))
+        (%make-ws socket in out #f (make-mutex) 'server path)))
+
+    (define (%server-handshake! in out)
+      (let* ((lines (%read-header-lines in))
+             (request-line (car lines))
+             (path (%request-path request-line))
+             (key (%header-value lines "Sec-WebSocket-Key")))
+        (if (not key) (error "ws-accept: request has no Sec-WebSocket-Key" request-line))
+        (let ((accept (base64-encode (sha1 (string->utf8 (string-append key %ws-guid))))))
+          (write-string
+           (string-append
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            "Sec-WebSocket-Accept: " accept "\r\n"
+            "\r\n")
+           out)
+          (flush-output-port out)
+          path)))
+
+    ;; "GET /some/path HTTP/1.1" -> "/some/path"
+    (define (%request-path request-line)
+      (let ((sp1 (%string-index request-line #\space)))
+        (if (not sp1) (error "ws-accept: malformed request line" request-line))
+        (let* ((rest (substring request-line (+ sp1 1) (string-length request-line)))
+               (sp2 (%string-index rest #\space)))
+          (if (not sp2) (error "ws-accept: malformed request line" request-line))
+          (substring rest 0 sp2))))
 
     ;; ---- Framing (RFC 6455 section 5)
 
@@ -159,44 +255,51 @@
             (begin (bytevector-u8-set! bv (+ start i) (bitwise-and n 255))
                    (loop (- i 1) (arithmetic-shift n -8))))))
 
-    ;; Always masked -- every client-to-server frame MUST be masked per
-    ;; RFC 6455; curry's own WebSocket client has no server role.
+    ;; Masked iff this connection is playing the client role -- RFC 6455
+    ;; section 5.1 requires every client-to-server frame to be masked
+    ;; and forbids masking server-to-client frames. Both roles share
+    ;; this one procedure since everything else about frame writing is
+    ;; identical; only the mask bit and whether a mask key follows the
+    ;; header differ.
     ;;
-    ;; A frame is written as three separate port writes (header, mask key,
-    ;; payload); curry ports have no built-in per-write atomicity across
-    ;; threads, so two actors calling ws-send!/ws-send-binary!/ws-close!
-    ;; concurrently on the same connection (the normal (curry ros) usage
-    ;; pattern -- one reader actor plus arbitrarily many publisher actors)
-    ;; could otherwise interleave their frame bytes on the wire and
-    ;; corrupt the stream for both. with-mutex serializes the whole
-    ;; three-write sequence per connection.
+    ;; A frame is written as up to three separate port writes (header,
+    ;; mask key if present, payload); curry ports have no built-in
+    ;; per-write atomicity across threads, so two actors calling
+    ;; ws-send!/ws-send-binary!/ws-close! concurrently on the same
+    ;; connection (the normal (curry ros) usage pattern -- one reader
+    ;; actor plus arbitrarily many publisher actors) could otherwise
+    ;; interleave their frame bytes on the wire and corrupt the stream
+    ;; for both. with-mutex serializes the whole write sequence per
+    ;; connection, for both roles.
     (define (%ws-write-frame! ws opcode payload)
       (with-mutex (%ws-send-mutex ws)
         (lambda ()
           (let* ((out (%ws-out ws))
+                 (mask? (eq? (%ws-role ws) 'client))
                  (len (bytevector-length payload))
-                 (key (%mask-key))
+                 (key (if mask? (%mask-key) #f))
+                 (len-byte1 (lambda (v) (if mask? (bitwise-or #x80 v) v)))
                  (header
                   (cond
                     ((< len 126) (let ((h (make-bytevector 2 0)))
                                    (bytevector-u8-set! h 0 (bitwise-or #x80 opcode))
-                                   (bytevector-u8-set! h 1 (bitwise-or #x80 len))
+                                   (bytevector-u8-set! h 1 (len-byte1 len))
                                    h))
                     ((< len 65536) (let ((h (make-bytevector 4 0)))
                                      (bytevector-u8-set! h 0 (bitwise-or #x80 opcode))
-                                     (bytevector-u8-set! h 1 (bitwise-or #x80 126))
+                                     (bytevector-u8-set! h 1 (len-byte1 126))
                                      (%write-be h 2 2 len)
                                      h))
                     (else (let ((h (make-bytevector 10 0)))
                             (bytevector-u8-set! h 0 (bitwise-or #x80 opcode))
-                            (bytevector-u8-set! h 1 (bitwise-or #x80 127))
+                            (bytevector-u8-set! h 1 (len-byte1 127))
                             (%write-be h 2 8 len)
                             h))))
-                 (masked (bytevector-copy payload)))
-            (%mask! masked key)
+                 (out-payload (if mask? (bytevector-copy payload) payload)))
+            (if mask? (%mask! out-payload key))
             (write-bytevector header out)
-            (write-bytevector key out)
-            (write-bytevector masked out)
+            (if mask? (write-bytevector key out))
+            (write-bytevector out-payload out)
             (flush-output-port out)))))
 
     (define (ws-send! ws string)
@@ -225,6 +328,22 @@
     ;; process can survive raising a clean error over.
     (define %ws-max-frame-len 67108864)
 
+    ;; RFC 6455 section 5.1 is unambiguous: every client-to-server frame
+    ;; MUST be masked, every server-to-client frame MUST NOT be -- and a
+    ;; peer that receives a frame violating this MUST fail the
+    ;; connection. This exists for a real security reason (defense
+    ;; against cache/protocol-confusion attacks via naive intermediaries
+    ;; that don't understand WebSocket framing), not just wire-format
+    ;; tidiness, so it's enforced here rather than tolerated -- an
+    ;; earlier version of this code silently unmasked/accepted a
+    ;; wrongly-masked frame either direction, which round-trips fine
+    ;; against a well-behaved peer but doesn't actually reject the
+    ;; violation the spec requires rejecting.
+    (define (%ws-protocol-error! ws msg)
+      (%ws-set-closed?! ws #t)
+      (socket-close (%ws-socket ws))
+      (error (string-append "ws: protocol error: " msg)))
+
     ;; Returns (values opcode fin? payload-bytevector), or (values 'eof #t #f).
     (define (%read-frame ws)
       (let* ((in (%ws-in ws)) (b0 (read-u8 in)))
@@ -240,19 +359,21 @@
                          (len (cond ((= len7 126) (%read-be in 2))
                                     ((= len7 127) (%read-be in 8))
                                     (else len7))))
-                    (if (> len %ws-max-frame-len)
-                        (error "ws-recv!: frame length exceeds maximum" len %ws-max-frame-len)
-                        (let* ((key (if masked? (read-bytevector 4 in) #f))
-                               (payload (if (> len 0) (read-bytevector len in) (bytevector))))
-                          (if (or (eof-object? payload) (and key (eof-object? key)))
-                              (values 'eof #t #f)
-                              (begin
-                                ;; A conformant server never masks; unmask
-                                ;; anyway if it did, rather than silently
-                                ;; misreading the payload against a spec
-                                ;; violation.
-                                (if masked? (%mask! payload key))
-                                (values opcode fin? payload)))))))))))
+                    (cond
+                      ((> len %ws-max-frame-len)
+                       (error "ws-recv!: frame length exceeds maximum" len %ws-max-frame-len))
+                      ((and (eq? (%ws-role ws) 'server) (not masked?))
+                       (%ws-protocol-error! ws "received an unmasked frame from a client"))
+                      ((and (eq? (%ws-role ws) 'client) masked?)
+                       (%ws-protocol-error! ws "received a masked frame from a server"))
+                      (else
+                       (let* ((key (if masked? (read-bytevector 4 in) #f))
+                              (payload (if (> len 0) (read-bytevector len in) (bytevector))))
+                         (if (or (eof-object? payload) (and key (eof-object? key)))
+                             (values 'eof #t #f)
+                             (begin
+                               (if masked? (%mask! payload key))
+                               (values opcode fin? payload))))))))))))
 
     ;; Reassembles fragmented messages (continuation frames), answers
     ;; pings with pongs, and swallows pongs -- all transparently to the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ add_test(NAME srfi_s210_multiple_values COMMAND curry --clear-cache ${CMAKE_CURR
 add_test(NAME srfi_s54_cat COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_s54_cat_tests.scm)
 add_test(NAME srfi_9_31_45 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_9_31_45_tests.scm)
 add_test(NAME websocket COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/websocket_tests.scm)
+add_test(NAME websocket_server COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/websocket_server_tests.scm)
 add_test(NAME ros COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/ros_tests.scm)
 add_test(NAME srfi_95_78_212 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_95_78_212_tests.scm)
 add_test(NAME srfi_141 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_141_tests.scm)

--- a/tests/websocket_server_tests.scm
+++ b/tests/websocket_server_tests.scm
@@ -1,0 +1,251 @@
+;;; websocket_server_tests.scm — (curry websocket)'s SERVER role
+;;; (ws-listen/ws-accept) tested against a hand-rolled, independent
+;;; RFC 6455 CLIENT implementation.
+;;;
+;;; websocket_tests.scm proves the CLIENT role (ws-connect) is wire-
+;;; compatible with an independent server. This file proves the reverse:
+;;; the independent peer here plays the client (masks outgoing frames,
+;;; expects unmasked incoming ones, does its own handshake key/accept
+;;; computation) and deliberately does NOT reuse ws-connect or any
+;;; framing code from lib/curry/modules/curry/websocket.scm -- the point
+;;; is to prove ws-listen/ws-accept genuinely speak RFC 6455 to any
+;;; compliant client, not just to curry's own.
+
+(import (scheme base) (curry network) (curry sync) (curry crypto) (curry websocket))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define test-port 17988)
+(define ws-guid "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+
+;;; ---- minimal from-scratch client-side handshake + framing ----
+
+(define (chomp-cr s)
+  (let ((n (string-length s)))
+    (if (and (> n 0) (char=? (string-ref s (- n 1)) #\return)) (substring s 0 (- n 1)) s)))
+
+(define (string-index s ch)
+  (let loop ((i 0))
+    (cond ((= i (string-length s)) #f)
+          ((char=? (string-ref s i) ch) i)
+          (else (loop (+ i 1))))))
+
+(define (header-value lines name)
+  (let loop ((ls lines))
+    (cond
+      ((null? ls) #f)
+      (else
+       (let* ((line (car ls)) (colon (string-index line #\:)))
+         (if (and colon (string=? (substring line 0 colon) name))
+             (substring line (+ colon 2) (string-length line))
+             (loop (cdr ls))))))))
+
+(define (read-handshake in)
+  (let loop ((acc '()))
+    (let ((line (chomp-cr (read-line in))))
+      (if (string=? line "") (reverse acc) (loop (cons line acc))))))
+
+(define (mask! bv key)
+  (let ((n (bytevector-length bv)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin (bytevector-u8-set! bv i (bitwise-xor (bytevector-u8-ref bv i)
+                                                        (bytevector-u8-ref key (modulo i 4))))
+                 (loop (+ i 1)))))))
+
+;; Client frames MUST be masked.
+(define (client-write-frame! out opcode fin? payload)
+  (let* ((len (bytevector-length payload))
+         (key (bytevector (random-integer 256) (random-integer 256)
+                           (random-integer 256) (random-integer 256)))
+         (masked (bytevector-copy payload)))
+    (mask! masked key)
+    (write-u8 (bitwise-or (if fin? #x80 0) opcode) out)
+    (cond
+      ((< len 126) (write-u8 (bitwise-or #x80 len) out))
+      ((< len 65536)
+       (write-u8 (bitwise-or #x80 126) out)
+       (write-u8 (bitwise-and (arithmetic-shift len -8) 255) out)
+       (write-u8 (bitwise-and len 255) out))
+      (else (error "client-write-frame!: test client doesn't support >64KB payloads")))
+    (write-bytevector key out)
+    (write-bytevector masked out)
+    (flush-output-port out)))
+
+;; Reads one server frame; server frames MUST NOT be masked -- checked,
+;; not just assumed, since ws-listen/ws-accept genuinely never masking
+;; is exactly the property this whole file exists to verify.
+(define (client-read-frame! in)
+  (let* ((b0 (read-u8 in)))
+    (if (eof-object? b0)
+        (values 'eof #t #f)
+        (let* ((fin? (not (zero? (bitwise-and b0 #x80))))
+               (opcode (bitwise-and b0 #x0f))
+               (b1 (read-u8 in))
+               (masked? (not (zero? (bitwise-and b1 #x80))))
+               (len7 (bitwise-and b1 #x7f))
+               (len (cond ((= len7 126) (+ (* 256 (read-u8 in)) (read-u8 in)))
+                          ((= len7 127) (error "client-read-frame!: 64-bit lengths not needed by this test"))
+                          (else len7)))
+               (payload (if (> len 0) (read-bytevector len in) (bytevector))))
+          (set! pass (if masked? pass (+ pass 1)))
+          (if masked?
+              (begin (display "FAIL: server frame was masked (must never be)") (newline)
+                     (set! fail (+ fail 1))))
+          (values opcode fin? payload)))))
+
+;;; ---- the real server under test: ws-listen / ws-accept ----
+
+(define listener (ws-listen test-port))
+
+(define server-thread
+  (spawn (lambda ()
+           (let ((conn (ws-accept listener)))
+             (set! pass (if (equal? (ws-path conn) "/live-data") (+ pass 1) pass))
+             (if (not (equal? (ws-path conn) "/live-data"))
+                 (begin (display "FAIL: ws-path mismatch: ") (display (ws-path conn)) (newline)
+                        (set! fail (+ fail 1))))
+
+             ;; echo one message
+             (ws-send! conn (ws-recv! conn))
+
+             ;; echo a binary message
+             (ws-send-binary! conn (ws-recv! conn))
+
+             ;; expect a close frame; ws-recv! itself replies in kind and
+             ;; marks the connection closed, matching the client role's
+             ;; own close-handshake behavior in websocket_tests.scm
+             (ws-recv! conn)
+             (ws-close! conn)))))
+
+;;; ---- drive an independent hand-rolled client against it ----
+
+(define client-socket (make-client-socket "127.0.0.1" test-port))
+(define cin (socket-input-port client-socket))
+(define cout (socket-output-port client-socket))
+
+(define %key "dGhlIHNhbXBsZSBub25jZQ==") ; fixed test key, same one RFC 6455 itself uses as an example
+
+(write-string
+ (string-append "GET /live-data HTTP/1.1\r\n"
+                 "Host: 127.0.0.1\r\n"
+                 "Upgrade: websocket\r\n"
+                 "Connection: Upgrade\r\n"
+                 "Sec-WebSocket-Key: " %key "\r\n"
+                 "Sec-WebSocket-Version: 13\r\n\r\n")
+ cout)
+(flush-output-port cout)
+
+(define %response-lines (read-handshake cin))
+(check "server responds 101" (car %response-lines) "HTTP/1.1 101 Switching Protocols")
+(define %expect-accept (base64-encode (sha1 (string->utf8 (string-append %key ws-guid)))))
+(check "Sec-WebSocket-Accept matches RFC 6455's own worked example"
+       (header-value %response-lines "Sec-WebSocket-Accept")
+       %expect-accept)
+;; RFC 6455 section 1.3 gives this exact key/accept pair as its worked example.
+(check "Sec-WebSocket-Accept is the RFC's own documented value"
+       %expect-accept "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
+
+(client-write-frame! cout #x1 #t (string->utf8 "hello server"))
+(call-with-values (lambda () (client-read-frame! cin))
+  (lambda (opcode fin? payload)
+    (check "echo round-trip" (utf8->string payload) "hello server")))
+
+(client-write-frame! cout #x2 #t (bytevector 9 8 7 6))
+(call-with-values (lambda () (client-read-frame! cin))
+  (lambda (opcode fin? payload)
+    (check "binary echo round-trip" payload (bytevector 9 8 7 6))))
+
+(client-write-frame! cout #x8 #t (bytevector))
+(call-with-values (lambda () (client-read-frame! cin))
+  (lambda (opcode fin? payload)
+    (check "server replies to a close frame in kind" opcode #x8)))
+
+(close-port cin) (close-port cout) (socket-close client-socket)
+(ws-listener-close! listener)
+
+;;; ---- regressions from independent review ----
+
+;; 1. An unbounded header line/count must not be able to drive ws-accept
+;; into unbounded memory growth or a hang -- a client that sends a huge
+;; unterminated "line" (or, separately, unboundedly many header lines)
+;; must get a clean, bounded-cost rejection instead.
+(define cap-listener (ws-listen 17987))
+(define cap-done (make-semaphore 0))
+(define cap-result #f)
+
+(define cap-acceptor
+  (spawn (lambda ()
+           (guard (e (#t (set! cap-result (list 'raised (error-object-message e)))))
+             (let ((conn (ws-accept cap-listener)))
+               (set! cap-result (list 'no-error conn))))
+           (sem-post! cap-done))))
+
+(let* ((sock (make-client-socket "127.0.0.1" 17987))
+       (out (socket-output-port sock)))
+  ;; 20,000 bytes, no newline at all -- well past the per-line cap,
+  ;; with the connection kept open so a missing cap would hang forever
+  ;; waiting for more input rather than erroring.
+  (write-string (make-string 20000 #\a) out)
+  (flush-output-port out))
+
+(sem-wait! cap-done)
+(check "ws-accept rejects an oversized unterminated header line"
+       (car cap-result) 'raised)
+(ws-listener-close! cap-listener)
+
+;; 2. RFC 6455 5.1: a server MUST reject an unmasked frame from a
+;; client (masking is a security requirement, not wire-format
+;; decoration -- see the module's own comment on %ws-protocol-error!).
+(define mask-listener (ws-listen 17986))
+(define mask-done (make-semaphore 0))
+(define mask-result #f)
+
+(define mask-acceptor
+  (spawn (lambda ()
+           (guard (e (#t (set! mask-result (list 'raised (error-object-message e)))))
+             (let ((conn (ws-accept mask-listener)))
+               (set! mask-result (list 'no-error (ws-recv! conn)))))
+           (sem-post! mask-done))))
+
+(let* ((sock (make-client-socket "127.0.0.1" 17986))
+       (in (socket-input-port sock))
+       (out (socket-output-port sock))
+       (key "dGhlIHNhbXBsZSBub25jZQ=="))
+  (write-string
+   (string-append "GET / HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\n"
+                   "Connection: Upgrade\r\nSec-WebSocket-Key: " key "\r\n"
+                   "Sec-WebSocket-Version: 13\r\n\r\n")
+   out)
+  (flush-output-port out)
+  (let loop () (let ((l (read-line in))) (if (not (string=? l "\r")) (loop))))
+  ;; a text frame with the mask bit deliberately clear -- a protocol
+  ;; violation only a client is allowed to commit (servers must never
+  ;; mask; clients must always mask)
+  (write-u8 #x81 out)
+  (write-u8 5 out)
+  (write-bytevector (string->utf8 "hello") out)
+  (flush-output-port out))
+
+(sem-wait! mask-done)
+(check "ws-accept's connection rejects an unmasked client frame"
+       (car mask-result) 'raised)
+(ws-listener-close! mask-listener)
+
+;;; Summary
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/websocket_tests.scm
+++ b/tests/websocket_tests.scm
@@ -187,6 +187,34 @@
 
 (tcp-close listener)
 
+;;; ---- regression from independent review: RFC 6455 5.1 masking
+;;; direction is a MUST-reject, not a tolerate-either-way convenience.
+;;; A server-to-client frame with the mask bit set is a protocol
+;;; violation the client must reject, not silently unmask and accept.
+
+(define mask-test-port 17995)
+(define mask-listener (tcp-listen mask-test-port))
+
+(define mask-server-thread
+  (spawn (lambda ()
+           (let* ((conn (tcp-accept mask-listener)) (in (car conn)) (out (cdr conn)))
+             (server-accept! in out)
+             ;; a text frame with the mask bit deliberately SET, plus a
+             ;; (bogus, but present) mask key -- only a client may ever
+             ;; legitimately send a masked frame; a server never should.
+             (write-u8 #x81 out)
+             (write-u8 (bitwise-or #x80 5) out)
+             (write-bytevector (bytevector 1 2 3 4) out) ; mask key
+             (write-bytevector (string->utf8 "hello") out)
+             (flush-output-port out)
+             (close-port in) (close-port out)))))
+
+(define mask-ws (ws-connect (string-append "ws://127.0.0.1:" (number->string mask-test-port) "/")))
+(check "ws-recv! rejects a masked frame from a server"
+       (guard (e (#t 'raised)) (ws-recv! mask-ws))
+       'raised)
+(tcp-close mask-listener)
+
 ;;; Summary
 
 (newline)


### PR DESCRIPTION
## Summary

Adds the server role to `(curry websocket)`, which previously only had a client (`ws-connect`). New: `ws-listen`, `ws-accept`, `ws-listener?`, `ws-listener-close!`, and a `ws-path` accessor for routing.

Client and server share every piece of frame-level machinery via one `<ws>` record now carrying a `role` field — the only place it matters is which direction masks, per RFC 6455 §5.1 (client→server frames MUST be masked, server→client frames MUST NOT be).

Tested against an independent hand-rolled RFC 6455 client (not reusing any of this module's own code) driving the real server — same wire-compatibility philosophy the existing client-side test already established, applied to the new server role. The handshake is verified against RFC 6455 §1.3's own worked example key/accept pair, not just a self-generated one.

## Findings from independent review, both fixed

This is now server code accepting arbitrary untrusted input (unlike the client, which talks to a server the caller already chose to trust), so review focused on security:

1. **Unbounded header growth** — `%read-header-lines` delegated to core `read-line`, which has no line-length cap. Confirmed live with a 2MB unterminated line still buffering with no error. A single connection could drive unbounded memory growth. Fixed with an explicit capped reader (8KB/line, 100 lines/request).
2. **Masking direction wasn't enforced** — `%read-frame` silently accepted a frame regardless of which direction it came from, correct for round-tripping against a well-behaved peer but not RFC 6455's actual MUST-reject requirement (masking direction is a real security control, not wire-format decoration). Both directions now raise and close on a violation.

Both fixes verified against the built binary and locked in as regression tests.

## Test plan

- [x] 112/112 ctest suites pass, fresh `--clear-cache` run, rebuilt standalone on this branch off `origin/main`
- [x] `tests/websocket_server_tests.scm` (new, 12 checks) — independent client, handshake against RFC's own worked example, echo/binary/close, plus regressions for both review findings
- [x] `tests/websocket_tests.scm` (existing client test, +1 check for the client-side masking-direction rejection)
- [x] Independent code review (fresh subagent, security-focused): traced the security-relevant claims by reading `src/port.c`/`modules/network/srfi106.c` directly, ran both test suites plus 6 adversarial scenarios against the built binary. Two real findings, both fixed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
