### PR TITLE
fix(builtins): floor-quotient/floor-remainder/floor/ reject non-integer arguments

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -500,8 +500,33 @@ static val_t prim_atanh(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return 
 static val_t prim_cot(int ac, val_t *av, void *ud)   {(void)ac;(void)ud; return num_cot(av[0]);}
 static val_t prim_sec(int ac, val_t *av, void *ud)   {(void)ac;(void)ud; return num_sec(av[0]);}
 static val_t prim_csc(int ac, val_t *av, void *ud)   {(void)ac;(void)ud; return num_csc(av[0]);}
-static val_t prim_floor_quotient(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return num_floor(num_div(av[0],av[1]));}
-static val_t prim_floor_remainder(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return num_sub(av[0],num_mul(prim_floor_quotient(ac,av,ud),av[1]));}
+/* quotient/remainder (and their truncate-* aliases) already reject a
+ * non-integer argument correctly -- they route through numeric.c's
+ * to_mpz(), which raises exactly this message. floor-quotient/
+ * floor-remainder/floor/ don't go anywhere near to_mpz() (they're built
+ * from num_floor(num_div(...)), generic real-number arithmetic that
+ * "succeeds" on a rational or flonum instead of rejecting it), so they
+ * need their own copy of the same check to match R7RS's actual
+ * precondition for these procedures. See GH issue #88. */
+static void check_exact_integer(val_t v, const char *who) {
+    if (vis_fixnum(v) || vis_bignum(v)) return;
+    scm_raise(V_FALSE, "%s: exact integer required, got %s", who,
+              vis_rational(v) ? "rational" :
+              vis_flonum(v)   ? "inexact real" :
+              vis_complex(v)  ? "complex" : "non-numeric value");
+}
+static val_t prim_floor_quotient(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    check_exact_integer(av[0], "floor-quotient");
+    check_exact_integer(av[1], "floor-quotient");
+    return num_floor(num_div(av[0],av[1]));
+}
+static val_t prim_floor_remainder(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    check_exact_integer(av[0], "floor-remainder");
+    check_exact_integer(av[1], "floor-remainder");
+    return num_sub(av[0],num_mul(prim_floor_quotient(ac,av,ud),av[1]));
+}
 static val_t prim_numerator(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
     if (vis_rational(av[0])) { mpz_t z; mpz_init_set(z, mpq_numref(as_rat(av[0])->q)); val_t r=make_big_from_mpz(z); mpz_clear(z); return r; }
@@ -3221,6 +3246,8 @@ static val_t prim_profiling_report(int ac, val_t *av, void *ud) {(void)ac;(void)
 static val_t prim_profiling_reset(int ac, val_t *av, void *ud)  {(void)ac;(void)av;(void)ud; profiling_reset(); return V_VOID;}
 static val_t prim_floor_div(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
+    check_exact_integer(av[0], "floor/");
+    check_exact_integer(av[1], "floor/");
     val_t q=prim_floor_quotient(ac,av,ud), r2=num_sub(av[0],num_mul(q,av[1]));
     Values *mv=(Values *)gc_alloc(sizeof(Values)+2*sizeof(val_t));
     mv->hdr.type=T_VALUES; mv->hdr.flags=0; mv->count=2; mv->vals[0]=q; mv->vals[1]=r2;

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -669,6 +669,24 @@
   (lambda (q r) (check "floor/ quotient" q 3)
                 (check "floor/ remainder" r 1)))
 
+;; Regression for GH issue #88: floor-quotient/floor-remainder/floor/
+;; used to silently accept a non-integer argument and return a
+;; plausible-but-wrong result instead of raising, unlike
+;; quotient/remainder/truncate-quotient/truncate-remainder, which
+;; already correctly rejected one via numeric.c's to_mpz().
+(check "floor-quotient rejects a rational argument"
+       (guard (exn (#t 'raised)) (floor-quotient 15/2 2)) 'raised)
+(check "floor-remainder rejects an inexact argument"
+       (guard (exn (#t 'raised)) (floor-remainder 7.5 2)) 'raised)
+(check "floor/ rejects a rational argument"
+       (guard (exn (#t 'raised))
+         (call-with-values (lambda () (floor/ 15/2 2)) (lambda (q r) 'no-error))) 'raised)
+;; floor and truncate agree when both operands are positive, so this
+;; checks the fix didn't disturb the bignum path at all, via a value
+;; already known correct (quotient) rather than a hand-derived one.
+(check "floor-quotient still works on bignums after the fix"
+       (floor-quotient (expt 2 100) 7) (quotient (expt 2 100) 7))
+
 ;;; Numeric: numerator / denominator
 (check "numerator"   (numerator 3/4) 3)
 (check "denominator" (denominator 3/4) 4)


### PR DESCRIPTION
## Summary

Fixes #88: `floor-quotient`/`floor-remainder`/`floor/` silently accepted a non-integer argument and returned a plausible-but-wrong result instead of raising, unlike `quotient`/`remainder`/`truncate-quotient`/`truncate-remainder`, which already correctly reject one.

Root cause: the truncate family routes through `numeric.c`'s `to_mpz()`, which validates. The floor family is built from `num_floor(num_div(a,b))` — generic real-number arithmetic that "succeeds" on a rational or flonum instead of rejecting it:

```scheme
(floor-quotient 15/2 2)   ; => 3        (should raise: 15/2 is not an integer)
(floor-remainder 7.5 2)   ; => 1.5      (should raise: 7.5 is not an integer)
```

This was found during an earlier session's SRFI-141 (Integer Division) work — its `ceiling`/`round`/`euclidean`/`balanced` families are all built on `floor-quotient`/`floor-remainder`, so the gap silently propagated.

## Fix

A new `check_exact_integer` helper matches `to_mpz`'s exact classification order, called at the top of all three primitives — each with its own correct procedure name in the error message, since `floor-remainder`/`floor/` both delegate to `floor-quotient` internally and a shared check there alone would misattribute the error.

## Test plan

- [x] 112/112 ctest suites pass, fresh `--clear-cache` run, rebuilt standalone on this branch off `origin/main`
- [x] 4 new regression tests in `tests/r7rs_tests.scm`: both exact repros from the issue, `floor/`'s multi-value form, and a bignum sanity check confirming the fix didn't disturb the working path
- [x] Independent code review (fresh subagent): verified live against a built binary — both repros, bignums at 2^200 scale, rejection on either argument position, and complex-number classification (`(floor-quotient 3+4i 2)` → "got complex") — plus confirmed no other call site of the shared internal helper was missed. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
