### PR TITLE
docs(language): document core hash tables and the ref-thunk gotcha

### DIFF
--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -17,6 +17,7 @@ Curry is an R7RS Scheme interpreter with a numeric tower that extends through th
 - [Strings and characters](#strings-and-characters)
 - [Lists and pairs](#lists-and-pairs)
 - [Vectors and bytevectors](#vectors)
+- [Hash tables](#hash-tables)
 - [I/O](#input--output)
 - [Continuations](#tail-calls-and-continuations)
 - [Parallel map, reduce, and for-each](#parallel-map-reduce-and-for-each)
@@ -939,6 +940,44 @@ Bytevectors (`#u8(...)`) store raw bytes (0–255):
 (utf8->string bv)          ; decode UTF-8 bytes to string
 (string->utf8 str)         ; encode string to UTF-8 bytevector
 ```
+
+---
+
+## Hash tables
+
+```scheme
+(make-hash-table)               ; equal?-keyed by default
+(make-hash-table mode)           ; 0 = eq?, 1 = eqv?, 2 = equal? -- raw integers,
+                                 ; no named Scheme-level constant for these;
+                                 ; (srfi s125 hash-tables)'s own make-hash-table
+                                 ; takes a real SRFI-128 comparator object instead
+(hash-table? obj)
+(hash-table-set! t key val)
+(hash-table-ref t key default) ; see the callout below -- NOT a failure thunk
+(hash-table-exists? t key)
+(hash-table-delete! t key)
+(hash-table-keys t)
+(hash-table-values t)
+(hash-table->alist t)
+(hash-table-size t)
+```
+
+**`hash-table-ref`'s third argument is a plain default *value*, not a failure thunk.** This is the one place curry's core API doesn't follow the convention its own name suggests — R7RS-adjacent SRFIs (SRFI-69, SRFI-125) specify `hash-table-ref`'s third argument as a *thunk*, called only on a miss, precisely so a default requiring real work isn't computed on every call. curry's core primitive takes a plain value instead:
+
+```scheme
+(hash-table-ref t "missing-key" '())   ; correct: returns '() on a miss
+(hash-table-ref t "missing-key" (lambda () '()))
+; WRONG (a genuine, easy mistake): returns the closure itself, uncalled,
+; not '() -- (curry ros)'s subscription bookkeeping hit exactly this
+; while under active development, and passing that closure straight into
+; append crashed the whole process rather than raising a clean error
+; (see GH issue #84 -- the crash itself is fixed, `append` now raises
+; "append: not a list" on a non-pair, non-nil argument instead of
+; segfaulting, but the underlying value-vs-thunk mismatch this section
+; documents is exactly what makes that mistake so easy to hit).
+```
+
+If you want genuine SRFI-69/125 thunk semantics (and the `hash-table-ref/default` name for the plain-value case, matching the convention those specs actually define), `(import (srfi s69 hash-tables))` or `(import (srfi s125 hash-tables))` — both wrap this core primitive with the corrected semantics rather than replacing it, so `(hash-table-ref t key)` (no default) raises on a miss, `(hash-table-ref t key thunk)` calls `thunk` only on a miss, and `(hash-table-ref/default t key value)` is the plain-value form under its own, unambiguous name. See [`docs/reference/srfi/s69-s90.md`](srfi/s69-s90.md) or [`docs/reference/srfi/s125-s126.md`](srfi/s125-s126.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Closes out the remaining thread on #84. The crash itself was already fixed (PR #85 — `append` raises a clean error on a non-list argument instead of segfaulting), but the issue's "Suggested fix" section also flagged a possible naming-consistency gap: `docs/reference/module-s3.md` references `hash-table-ref/default` as if it exists.

Checked it directly — it does exist, correctly, in the SRFI-69/SRFI-125 shims (which also correctly re-implement `hash-table-ref` itself with real failure-thunk semantics, wrapping the core primitive). The doc reference was accurate all along; there's no gap to fix there.

What actually was missing: **core hash tables had zero reference documentation anywhere**, including the exact value-vs-thunk mismatch between core `hash-table-ref` (plain default value) and the SRFI-69/125 convention its own name suggests (a failure thunk) — which is the root cause that made the original append-crash mistake so easy to hit in the first place.

## Change

Adds a "Hash tables" section to `docs/reference/language.md`:
- The real core API (`make-hash-table`, `hash-table-ref`, `hash-table-set!`, etc.)
- The value-vs-thunk gotcha, called out explicitly with the exact failure mode
- `make-hash-table`'s comparator-mode argument (a raw `0`/`1`/`2` integer with no named Scheme-level constant — not an SRFI-128 comparator object, which is what SRFI-125's own `make-hash-table` takes instead over the same core primitive)
- Pointers to SRFI-69/SRFI-125 for real thunk semantics + `hash-table-ref/default`

Every example in the new section was run against a live build before being written down.

Docs-only change; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
