### PR TITLE
fix(build): _Thread_local is C11-only, breaks LLVM backend build on GCC (Raspberry Pi)

### DIFF
--- a/src/actors.c
+++ b/src/actors.c
@@ -12,7 +12,7 @@
 #include <time.h>
 #include <assert.h>
 
-_Thread_local Actor *current_actor = NULL;
+CURRY_THREAD_LOCAL Actor *current_actor = NULL;
 
 static _Atomic uint64_t next_actor_id = 1;
 

--- a/src/actors.h
+++ b/src/actors.h
@@ -51,6 +51,6 @@ val_t    actor_stats(val_t actor);   /* alist of profiling counters */
 val_t    actors_list(void);          /* list of all live-or-just-exited actors */
 
 /* Thread-local current actor (NULL in main thread) */
-extern _Thread_local Actor *current_actor;
+extern CURRY_THREAD_LOCAL Actor *current_actor;
 
 #endif /* CURRY_ACTORS_H */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -85,8 +85,8 @@
 
 /* ── Compiler lifecycle ──────────────────────────────────────────────── */
 
-static _Thread_local const char *g_compile_source_name = NULL;
-static _Thread_local val_t       g_compile_target_env   = V_VOID;
+static CURRY_THREAD_LOCAL const char *g_compile_source_name = NULL;
+static CURRY_THREAD_LOCAL val_t       g_compile_target_env   = V_VOID;
 /* Set by compile_let's named-let branch right before compiling the loop
  * lambda's own body, consumed-and-cleared by init_compiler below the same
  * way g_compile_target_env is -- see Compiler::self_tail_name's own
@@ -98,8 +98,8 @@ static _Thread_local val_t       g_compile_target_env   = V_VOID;
  * and read/cleared here by init_compiler; also read by ir_emit's own
  * IR_LET/IR_LETREC named-let handling (ir_emit.c), which sets it the same
  * way compile_let does for its own child Compiler. */
-_Thread_local val_t g_compile_self_tail_name    = V_FALSE;
-_Thread_local bool  g_compile_self_tail_mutated = false;
+CURRY_THREAD_LOCAL val_t g_compile_self_tail_name    = V_FALSE;
+CURRY_THREAD_LOCAL bool  g_compile_self_tail_mutated = false;
 
 /* Tier 2.3: guards against mutual/indirect recursion inlining itself
  * arbitrarily deep. body_contains_symbol (ir_lower.c) only rejects DIRECT
@@ -118,8 +118,8 @@ _Thread_local bool  g_compile_self_tail_mutated = false;
  * in compiler_internal.h (MAX_INLINE_DEPTH lives there too, since the
  * array's declared size must match between this definition and ir_emit.c's
  * own bounds check). */
-_Thread_local val_t g_inlining_bodies[MAX_INLINE_DEPTH];
-_Thread_local int   g_inlining_depth = 0;
+CURRY_THREAD_LOCAL val_t g_inlining_bodies[MAX_INLINE_DEPTH];
+CURRY_THREAD_LOCAL int   g_inlining_depth = 0;
 
 bool currently_inlining(val_t body) {
     for (int i = 0; i < g_inlining_depth; i++)

--- a/src/compiler_classic.c
+++ b/src/compiler_classic.c
@@ -57,7 +57,7 @@
  * Set/cleared by compile_classic (below), never anywhere else -- see its
  * own comment for why compiler_ir_self_check/compiler_ir_optimize_check
  * need this now that compile() itself routes through the IR. */
-static _Thread_local bool g_force_classic_compile = false;
+static CURRY_THREAD_LOCAL bool g_force_classic_compile = false;
 
 static void compile_lambda(Compiler *parent, val_t params, val_t body,
                             const char *name, int line) {

--- a/src/compiler_internal.h
+++ b/src/compiler_internal.h
@@ -159,13 +159,13 @@ typedef enum {
 
 /* Set by compile_let's named-let branch right before compiling the loop
  * lambda's own body, consumed-and-cleared by init_compiler. */
-extern _Thread_local val_t g_compile_self_tail_name;
-extern _Thread_local bool  g_compile_self_tail_mutated;
+extern CURRY_THREAD_LOCAL val_t g_compile_self_tail_name;
+extern CURRY_THREAD_LOCAL bool  g_compile_self_tail_mutated;
 
 /* Tier 2.3: guards against mutual/indirect recursion inlining itself
  * arbitrarily deep -- see currently_inlining's own comment in compiler.c. */
-extern _Thread_local val_t g_inlining_bodies[MAX_INLINE_DEPTH];
-extern _Thread_local int   g_inlining_depth;
+extern CURRY_THREAD_LOCAL val_t g_inlining_bodies[MAX_INLINE_DEPTH];
+extern CURRY_THREAD_LOCAL int   g_inlining_depth;
 
 /* ── compiler.c: lifecycle / emit / scope / locals / upvalues ──────────── */
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -163,8 +163,8 @@ static val_t eval_call_cc(val_t proc) {
  * non-tail recursion to depth ~1,000,000 previously segfaulted
  * immediately (define-library bodies are tree-walked, not compiled --
  * see modules.c's define_library_clause). */
-static _Thread_local void   *eval_stack_base  = NULL;
-static _Thread_local size_t  eval_stack_limit = 0;
+static CURRY_THREAD_LOCAL void   *eval_stack_base  = NULL;
+static CURRY_THREAD_LOCAL size_t  eval_stack_limit = 0;
 
 /* Real per-thread stack size, queried once and cached alongside
  * eval_stack_base. A fixed byte budget here (e.g. "assume ~8MB, leave
@@ -1211,7 +1211,7 @@ tail:
                 /* Level 2+: sacrifice TCO for named closures to get wall-clock
                  * timing.  Skip when re-entering the same closure (self-tail-
                  * recursive loops) — otherwise the stack grows without bound. */
-                static _Thread_local val_t prof2_current = 0;
+                static CURRY_THREAD_LOCAL val_t prof2_current = 0;
                 if (proc != prof2_current) {
                     val_t saved = prof2_current;
                     prof2_current = proc;

--- a/src/eval.h
+++ b/src/eval.h
@@ -65,7 +65,7 @@ typedef struct WindFrame {
 extern "C" WindFrame **curry_current_wind_ptr(void);
 #define current_wind (*curry_current_wind_ptr())
 #else
-extern _Thread_local WindFrame *current_wind;
+extern CURRY_THREAD_LOCAL WindFrame *current_wind;
 #endif
 
 /* ---- Exception system ---- */
@@ -111,13 +111,13 @@ typedef struct ExnHandler {
  * binary (which compiles eval.c as C), so the dynamic lookup resolves to null
  * and the first SCM_PROTECT in a .so crashes at 0x0. */
 #ifdef __cplusplus
-/* current_handler is a C _Thread_local defined in eval.c.  The C++ TLS
+/* current_handler is a C CURRY_THREAD_LOCAL defined in eval.c.  The C++ TLS
  * wrapper (__ZTW...) is NOT exported from the main binary, so C++ dylibs
  * must access it via this plain C function instead. */
 extern "C" ExnHandler **curry_current_handler_ptr(void);
 #define current_handler (*curry_current_handler_ptr())
 #else
-extern _Thread_local ExnHandler *current_handler;
+extern CURRY_THREAD_LOCAL ExnHandler *current_handler;
 #endif
 
 /* JIT call depth guard — defined in eval.c, C-linkage helpers used by jit.cpp
@@ -133,7 +133,7 @@ extern "C" {
     void jit_depth_restore(int saved);
 }
 #else
-extern _Thread_local int g_jit_call_depth;
+extern CURRY_THREAD_LOCAL int g_jit_call_depth;
 int  jit_depth_save(void);
 void jit_depth_restore(int saved);
 #define JIT_CALL_DEPTH_LIMIT 512
@@ -162,8 +162,8 @@ typedef struct RestartFrame {
 } RestartFrame;
 
 #ifndef __cplusplus
-extern _Thread_local CondHandler  *current_cond_handler;
-extern _Thread_local RestartFrame *current_restart_frame;
+extern CURRY_THREAD_LOCAL CondHandler  *current_cond_handler;
+extern CURRY_THREAD_LOCAL RestartFrame *current_restart_frame;
 #endif
 
 /* Walk the non-unwinding CondHandler chain; called by scm_raise_val and
@@ -259,7 +259,7 @@ void load_dir_release(int mark);
  * directory-context stack, then load_dir_adopt_snapshot() on the new
  * actor thread (before it runs any Scheme code) to seed its own
  * thread-local stack from that snapshot -- otherwise a freshly-spawned
- * thread's _Thread_local stack starts empty and its own relative loads
+ * thread's CURRY_THREAD_LOCAL stack starts empty and its own relative loads
  * silently fall back to cwd instead of inheriting context. */
 char **load_dir_snapshot(int *out_count);
 void   load_dir_adopt_snapshot(char **snap, int count);

--- a/src/gc.c
+++ b/src/gc.c
@@ -74,7 +74,7 @@ gc_ops_t *gc_ops = &gc_boehm_ops;
 
 /* ── Per-thread nursery ─────────────────────────────────────────────────── */
 
-_Thread_local GcNursery gc_nursery = { NULL, NULL, NULL };
+CURRY_THREAD_LOCAL GcNursery gc_nursery = { NULL, NULL, NULL };
 
 void   *gc_alloc_trace[GC_ALLOC_TRACE_N];
 size_t  gc_alloc_trace_idx;
@@ -84,17 +84,17 @@ size_t  gc_alloc_trace_sz[GC_ALLOC_TRACE_N];
  * NULL when no eval() frame is active (e.g. at top level between expressions).
  * Under Boehm this is never read by the GC; it exists so that GC_AUTOFRAME
  * in eval.c compiles cleanly and a debug assertion can verify balance. */
-_Thread_local GcFrame *gc_shadow_stack = NULL;
+CURRY_THREAD_LOCAL GcFrame *gc_shadow_stack = NULL;
 
 /* Counter for gc_inhibit_minor() / gc_resume_minor().
  * > 0 means we're inside compiler/reader/other unsafe C code;
  * gc_nursery_refill falls back to Boehm instead of triggering minor GC. */
-_Thread_local int gc_inhibit_count = 0;
+CURRY_THREAD_LOCAL int gc_inhibit_count = 0;
 
 /* Deferred minor GC flag.  Set by gc_nursery_refill() when the nursery
  * overflowed but minor GC couldn't fire (shadow stack non-NULL or inhibited).
  * Cleared and acted on by eval() at the next tail-call safe point. */
-_Thread_local bool gc_minor_pending = false;
+CURRY_THREAD_LOCAL bool gc_minor_pending = false;
 
 /* Card table globals — retained for backwards compat; all stay NULL/0.
  * The write barrier no longer writes to the card table; it uses gc_dirty_slots. */

--- a/src/gc.h
+++ b/src/gc.h
@@ -40,6 +40,10 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "value.h" /* val_t, and CURRY_THREAD_LOCAL used by gc_nursery etc. below --
+                     * moved here from further down in this file (it used to be
+                     * included lazily right before its first use) because
+                     * CURRY_THREAD_LOCAL now needs to be visible far earlier */
 
 /* ── GC vtable ────────────────────────────────────────────────────────────── */
 
@@ -116,7 +120,7 @@ typedef struct {
 } GcNursery;
 
 #ifndef __cplusplus
-extern _Thread_local GcNursery gc_nursery;
+extern CURRY_THREAD_LOCAL GcNursery gc_nursery;
 #endif
 
 /*
@@ -238,8 +242,9 @@ void gc_roots_unlock(void);
 /* val_t-taking pin/unpin for FFI use: C extensions call these to protect
  * Scheme values they hold in heap-allocated structs across GC points.
  * Under Boehm these are no-ops (conservative scan finds them anyway).
- * Under a moving GC they prevent the referenced object from being relocated. */
-#include "value.h"
+ * Under a moving GC they prevent the referenced object from being relocated.
+ * (value.h itself is now included up top, not here -- see that include's
+ * own comment.) */
 /* gc_register_root_val(slot, v) stores v into *slot and registers it as a root
  * in one atomic step (under g_roots_lock).  Preferred over a bare store +
  * gc_register_root() when the caller may race with concurrent minor GC. */
@@ -330,7 +335,7 @@ static inline void gc_ss_register_ext_scanner(void (*cb)(void)) {
  * Thread-local so each thread manages its own nursery independently.
  */
 #ifndef __cplusplus
-extern _Thread_local bool gc_minor_pending;
+extern CURRY_THREAD_LOCAL bool gc_minor_pending;
 #endif
 
 typedef struct GcFrame {
@@ -340,7 +345,7 @@ typedef struct GcFrame {
 } GcFrame;
 
 #ifndef __cplusplus
-extern _Thread_local GcFrame *gc_shadow_stack;
+extern CURRY_THREAD_LOCAL GcFrame *gc_shadow_stack;
 #endif
 
 #ifndef __cplusplus
@@ -365,7 +370,7 @@ static inline void gc_pop_frame(GcFrame **fp) {
  * Calls are nestable and balanced.
  */
 #ifndef __cplusplus
-extern _Thread_local int gc_inhibit_count;
+extern CURRY_THREAD_LOCAL int gc_inhibit_count;
 #endif
 
 static inline void gc_inhibit_minor(void) {

--- a/src/ir_emit.c
+++ b/src/ir_emit.c
@@ -70,7 +70,7 @@
  * misread as this one's. Entirely local to this file: both the one write
  * (IR_LAMBDA's case) and the two reads (IR_DEFINE's case, ir_emit_
  * inline_call's own eligibility check) live here. */
-static _Thread_local int g_last_lambda_upval_count = -1;
+static CURRY_THREAD_LOCAL int g_last_lambda_upval_count = -1;
 
 /* Tier 2.3 local inliner: splices a known-closed candidate's raw
  * `params`/`body` directly into the CALLING Compiler `c`'s own

--- a/src/mpfr_num.c
+++ b/src/mpfr_num.c
@@ -12,8 +12,8 @@
 #include <stdlib.h>
 
 /* Thread-local precision/rounding context. */
-_Thread_local mpfr_prec_t tl_mpfr_prec = 0;
-_Thread_local mpfr_rnd_t  tl_mpfr_rnd  = MPFR_RNDN;
+CURRY_THREAD_LOCAL mpfr_prec_t tl_mpfr_prec = 0;
+CURRY_THREAD_LOCAL mpfr_rnd_t  tl_mpfr_rnd  = MPFR_RNDN;
 
 /* ---------------------------------------------------------------------- */
 /* GC finalizer — releases the mpfr_t limb storage.                       */

--- a/src/mpfr_num.h
+++ b/src/mpfr_num.h
@@ -8,8 +8,8 @@
 #include <stdbool.h>
 
 /* Thread-local precision context.  0 = not active (use double). */
-extern _Thread_local mpfr_prec_t tl_mpfr_prec;
-extern _Thread_local mpfr_rnd_t  tl_mpfr_rnd;
+extern CURRY_THREAD_LOCAL mpfr_prec_t tl_mpfr_prec;
+extern CURRY_THREAD_LOCAL mpfr_rnd_t  tl_mpfr_rnd;
 
 #define MPFR_DEFAULT_PREC 128
 

--- a/src/reader.c
+++ b/src/reader.c
@@ -652,7 +652,7 @@ static val_t read_datum(val_t port) {
 /* Line the most recent top-level scm_read() call's datum started on
    (1-based; after skipping leading whitespace/comments). Read by the
    compiler to stamp backtrace line numbers on freshly-read forms. */
-_Thread_local int g_reader_last_line = 0;
+CURRY_THREAD_LOCAL int g_reader_last_line = 0;
 
 val_t scm_read(val_t port) {
     gc_inhibit_minor();

--- a/src/reader.h
+++ b/src/reader.h
@@ -31,7 +31,7 @@ val_t scm_read(val_t port);
 /* Line the most recent scm_read() call's datum started on (1-based).
    Valid immediately after scm_read() returns; used by the compiler to
    stamp backtrace line numbers on freshly-read top-level forms. */
-extern _Thread_local int g_reader_last_line;
+extern CURRY_THREAD_LOCAL int g_reader_last_line;
 
 /* Read from a C string (convenience) */
 val_t scm_read_cstr(const char *src);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -70,10 +70,10 @@ bool is_definition(val_t form) {
 
 /* ---- Exception handling and dynamic wind ---- */
 
-_Thread_local ExnHandler  *current_handler      = NULL;
-_Thread_local WindFrame   *current_wind         = NULL;
-_Thread_local CondHandler *current_cond_handler = NULL;
-_Thread_local RestartFrame *current_restart_frame = NULL;
+CURRY_THREAD_LOCAL ExnHandler  *current_handler      = NULL;
+CURRY_THREAD_LOCAL WindFrame   *current_wind         = NULL;
+CURRY_THREAD_LOCAL CondHandler *current_cond_handler = NULL;
+CURRY_THREAD_LOCAL RestartFrame *current_restart_frame = NULL;
 
 /* C accessors for TLS vars — used by C++ dylibs (eval.h) to avoid the
  * C++ TLS wrappers (__ZTW...) which are not exported from the main binary. */
@@ -366,7 +366,7 @@ extern val_t scm_cons(val_t, val_t);
  * This prevents stack overflow for deeply-recursive functions that hit the
  * JIT threshold before the recursion unwinds. */
 #define JIT_CALL_DEPTH_LIMIT 512
-_Thread_local int g_jit_call_depth = 0;
+CURRY_THREAD_LOCAL int g_jit_call_depth = 0;
 
 /* C-linkage wrappers for jit.cpp — avoids C++ TLS wrapper ABI mismatch. */
 void jit_depth_push(void) { g_jit_call_depth++; }
@@ -607,7 +607,7 @@ val_t eval_body(val_t exprs, val_t env) {
  * too, not just files reached via -l/(include ...)/module loading.
  */
 
-/* _Thread_local, matching current_handler/current_wind/g_jit_call_depth
+/* CURRY_THREAD_LOCAL, matching current_handler/current_wind/g_jit_call_depth
  * above -- curry's actor system runs each actor in its own detached
  * POSIX thread (src/actors.c), any of which can call scm_load/
  * load_scheme_module concurrently. A plain (non-thread-local) static
@@ -619,8 +619,8 @@ val_t eval_body(val_t exprs, val_t env) {
  * loading relative to" is inherently per-thread call-stack context
  * anyway, the same way current_handler's exception-handler chain is. */
 #define MAX_LOAD_DEPTH 64
-static _Thread_local char *load_dir_stack[MAX_LOAD_DEPTH];
-static _Thread_local int   load_dir_depth = 0;
+static CURRY_THREAD_LOCAL char *load_dir_stack[MAX_LOAD_DEPTH];
+static CURRY_THREAD_LOCAL int   load_dir_depth = 0;
 
 static char *dir_of(const char *path) {
     const char *slash = strrchr(path, '/');
@@ -645,7 +645,7 @@ void load_push_dir(const char *path) {
 }
 
 /* A freshly-spawned actor thread otherwise starts with an *empty*
- * load_dir_stack (that's the whole point of it being _Thread_local --
+ * load_dir_stack (that's the whole point of it being CURRY_THREAD_LOCAL --
  * no cross-thread sharing) -- so an actor's own (load "relative.scm")
  * would silently fall back to cwd instead of inheriting whatever
  * directory context the thread that spawned it was in. Confirmed by

--- a/src/stm.c
+++ b/src/stm.c
@@ -65,7 +65,7 @@ typedef struct TxState {
     jmp_buf *retry_jmp;    /* longjmp target for stm_retry() inside atomically */
 } TxState;
 
-static _Thread_local TxState *current_tx = NULL;
+static CURRY_THREAD_LOCAL TxState *current_tx = NULL;
 
 /* ---- TxState helpers ---- */
 

--- a/src/syntax_rules.c
+++ b/src/syntax_rules.c
@@ -59,7 +59,7 @@ typedef struct {
  * locals/upvalues) -- V_FALSE here means exactly that "not currently
  * tracked, must be the compiled path" case, and sr_compile_fn maps it to
  * GLOBAL_ENV directly, so no separate handling is needed on that path. */
-static _Thread_local val_t sr_current_env = V_FALSE;
+static CURRY_THREAD_LOCAL val_t sr_current_env = V_FALSE;
 
 val_t sr_get_current_env(void) { return sr_current_env; }
 void  sr_set_current_env(val_t env) { sr_current_env = env; }
@@ -79,7 +79,7 @@ void  sr_set_current_env(val_t env) { sr_current_env = env; }
  * relevant local macro name(s) (unioned with whatever was already set,
  * so nested let-syntax blocks see outer local macros too) around each
  * compile_time_eval call, save/restore-style. */
-static _Thread_local val_t sr_current_local_macros = V_NIL;
+static CURRY_THREAD_LOCAL val_t sr_current_local_macros = V_NIL;
 
 val_t sr_get_current_local_macros(void) { return sr_current_local_macros; }
 void  sr_set_current_local_macros(val_t names) { sr_current_local_macros = names; }

--- a/src/value.h
+++ b/src/value.h
@@ -19,6 +19,21 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* _Thread_local is a C11 keyword, not a C++ one -- g++ (confirmed on
+ * Raspberry Pi / Linaro ARM GCC) rejects it outright with "does not name a
+ * type", unlike Clang, which accepts it in C++ mode too as a compatibility
+ * extension (why this never surfaced building on macOS). The LLVM JIT
+ * backend's .cpp files (under src/llvm) are C++ and transitively include every header
+ * below that declares thread-local externs (vm.h, gc.h, eval.h, actors.h,
+ * compiler_internal.h, reader.h, mpfr_num.h, workpool.h), so this macro
+ * belongs in value.h -- the one header all of them already include -- not
+ * duplicated ad hoc in each one. */
+#ifdef __cplusplus
+#define CURRY_THREAD_LOCAL thread_local
+#else
+#define CURRY_THREAD_LOCAL _Thread_local
+#endif
+
 typedef uintptr_t val_t;
 
 /* ---- Tag constants ---- */

--- a/src/vm.c
+++ b/src/vm.c
@@ -209,7 +209,7 @@
 
 /* ── Global VM state ─────────────────────────────────────────────────── */
 
-_Thread_local VM *vm = NULL;
+CURRY_THREAD_LOCAL VM *vm = NULL;
 
 __attribute__((noreturn)) void vm_stack_overflow(void) {
     fprintf(stderr, "[vm] vm_stack_overflow: sp=%p stack_end=%p\n",
@@ -256,7 +256,7 @@ val_t vm_capture_backtrace(void) {
 
 void vm_init(void) {
     /* Use GC_MALLOC_UNCOLLECTABLE so Boehm GC never frees the VM struct even
-     * though the only reference is a _Thread_local pointer (TLS is not scanned
+     * though the only reference is a CURRY_THREAD_LOCAL pointer (TLS is not scanned
      * as a GC root).  GC still scans the struct's interior for live val_t refs. */
     vm = (VM *)GC_MALLOC_UNCOLLECTABLE(sizeof(VM));
     vm->sp = vm->stack;

--- a/src/vm.h
+++ b/src/vm.h
@@ -103,7 +103,7 @@ typedef struct VM {
 } VM;
 
 /* Per-thread VM instance — each thread must call vm_init() before use */
-extern _Thread_local VM *vm;
+extern CURRY_THREAD_LOCAL VM *vm;
 
 /* Lifecycle */
 void vm_init(void);

--- a/src/workpool.c
+++ b/src/workpool.c
@@ -89,7 +89,7 @@ static WorkItem *deque_steal(WSDeque *d) {
 
 static WorkPool *global_pool = NULL;
 
-_Thread_local bool pool_is_worker = false;
+CURRY_THREAD_LOCAL bool pool_is_worker = false;
 
 static void execute_item(WorkItem *item) {
     ExnHandler h;

--- a/src/workpool.h
+++ b/src/workpool.h
@@ -67,7 +67,7 @@ void pool_init(void);
  * Used by prim_map / prim_reduce to avoid nested parallel dispatch, which
  * would deadlock: all workers blocked waiting on nested work items that
  * can never run because every worker is already occupied. */
-extern _Thread_local bool pool_is_worker;
+extern CURRY_THREAD_LOCAL bool pool_is_worker;
 
 /* Number of logical CPUs (same value the pool uses for its thread count). */
 int pool_hw_concurrency(void);


### PR DESCRIPTION
## Summary

Fixes a Raspberry Pi build failure reported building with `-DBUILD_LLVM=ON`:

```
/home/yvain/src/curry/src/llvm/../vm.h:106:8: error: '_Thread_local' does not name a type
extern _Thread_local VM *vm;
```

`_Thread_local` is a C11 keyword, not a C++ one. GCC's C++ frontend
rejects it outright; Clang's tolerates it as a compatibility extension,
which is why this never surfaced building on macOS. The LLVM JIT backend
(`src/llvm/*.cpp`) is C++ and transitively includes every header that
declares a thread-local extern (`vm.h`, `gc.h`, `eval.h`, `actors.h`,
`compiler_internal.h`, `reader.h`, `mpfr_num.h`).

## Fix

New `CURRY_THREAD_LOCAL` macro in `value.h` (the one header everything
already includes), expanding to `thread_local` under `__cplusplus` and
`_Thread_local` otherwise. Replaced all 47 raw `_Thread_local` occurrences
across headers and their `.c` definitions for one consistent spelling.

Also fixed a real header-ordering bug the macro surfaced: `gc.h` declared
`CURRY_THREAD_LOCAL`-using externs at line 119 but didn't include
`value.h` (where the macro now lives) until line 242 further down the
same file — moved the include to the top.

## Verification

Reproduced the Pi's exact error locally against **real GCC** (Homebrew
`g++-16`, not Apple's clang-in-a-trenchcoat `/usr/bin/g++`) before this
fix, confirmed clean compilation after — used the actual reported error
message as the test oracle rather than reasoning from first principles
alone.

- [x] `g++-16` compiles `vm.h` (and the other six affected headers)
  standalone, clean, after the fix; reproduces the exact reported error
  before it
- [x] Full LLVM backend build (`-DBUILD_LLVM=ON`) compiles and links clean
  with Clang, including `src/llvm/jit.cpp`
- [x] 113/113 `ctest` suites pass (fresh `--clear-cache` run, LLVM off)

Filed #99 for an unrelated, pre-existing issue found while verifying this:
this machine's current Homebrew `llvm` (23.1.0) crashes the JIT tier at
*runtime* with an LLVM assertion, reproducing identically on unmodified
`main` — unrelated to this build-portability fix and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
