### PR TITLE
fix(syntax-rules): correctly bind pattern variables under nested ellipsis

### DIFF
--- a/lib/curry/modules/curry/conditions.scm
+++ b/lib/curry/modules/curry/conditions.scm
@@ -130,8 +130,11 @@
 ;;; Establishes named recovery points reachable via invoke-restart.
 ;;; Returns the result of form ... or of the chosen restart's body.
 
-;;; Uses recursion rather than nested ... to avoid a curry syntax-rules
-;;; limitation with nested ellipsis expansion.
+;;; Uses recursion rather than nested ... -- written before issue #101 (a
+;;; curry syntax-rules engine bug mishandling a pattern variable with its
+;;; own further ellipsis nested inside an outer ellipsis) was fixed. Left
+;;; as-is rather than churned to the more direct shape now that it works
+;;; too, same reasoning as (scheme case-lambda)'s own workaround.
 (define-syntax with-restarts
   (syntax-rules ()
     ((_ () body ...)

--- a/lib/curry/modules/scheme/case-lambda.sld
+++ b/lib/curry/modules/scheme/case-lambda.sld
@@ -52,25 +52,17 @@
          (apply (lambda tail body0 ...) args))))
 
     ;; NOTE: deliberately does NOT decompose each clause in this macro's own
-    ;; pattern (i.e. NOT `((_ (params body0 ...) ...) ...)`)  --  curry's
-    ;; syntax-rules has a confirmed bug where a pattern variable that is
-    ;; itself followed by an ellipsis, nested inside ANOTHER pattern that is
-    ;; also wrapped in an outer ellipsis (an outer `...` wrapping a
-    ;; sub-pattern that contains its own `...`), fails to bind correctly:
-    ;; minimal repro is
-    ;;   (define-syntax my-test
-    ;;     (syntax-rules () ((_ (a b ...) ...) '((a b ...) ...))))
-    ;;   (my-test (1 10 20) (2 30))   ; => ((1 () ()) (2 () ())), should be
-    ;;                                ;    ((1 10 20) (2 30))
-    ;; Filed as its own issue -- not fixed here, since it's a core
-    ;; syntax-rules engine bug (src/syntax_rules.c), well beyond the scope
-    ;; of adding case-lambda. Worked around instead: this macro captures
-    ;; each clause as one OPAQUE `clause` pattern variable (ellipsis depth
-    ;; 1, no internal structure in this macro's own pattern), and
-    ;; %case-lambda-help above does the actual (params body0 ...)
-    ;; decomposition one clause at a time via ordinary recursion (`. rest`)
-    ;; rather than a second, nested `...` -- exactly the shape confirmed
-    ;; NOT to trigger the bug.
+    ;; pattern (i.e. NOT `((_ (params body0 ...) ...) ...)`) -- NOT because
+    ;; that shape is broken anymore (issue #101, the syntax-rules engine
+    ;; bug this comment used to describe, is fixed -- src/syntax_rules.c
+    ;; now correctly binds a pattern variable that has its own further
+    ;; ellipsis nested inside an outer ellipsis-repeated sub-pattern), but
+    ;; because this file was written and shipped before that fix landed,
+    ;; and the opaque-clause-plus-recursion shape below works fine and
+    ;; costs nothing to keep -- no need to churn already-correct, already-
+    ;; tested code just to use the more direct shape now that it works too.
+    ;; %case-lambda-help does the actual (params body0 ...) decomposition
+    ;; one clause at a time via ordinary recursion (`. rest`).
     ;;
     ;; %cl-args/%cl-len (not the more natural `args`/`len`) are deliberately
     ;; unusual names: curry's syntax-rules does NOT rename template-

--- a/src/llvm/codegen.cpp
+++ b/src/llvm/codegen.cpp
@@ -161,7 +161,20 @@ struct CompileCtx {
     }
 
     bool terminated() const {
-        return B.GetInsertBlock()->getTerminator() != nullptr;
+        /* NOT `getTerminator() != nullptr` -- that was the actual bug
+         * behind issue #99 (crash on LLVM 23.1.0, "cannot get terminator
+         * of non-well-formed block"). getTerminator() asserts the block
+         * is ALREADY terminated before returning anything; it was never
+         * meant to double as an is-it-terminated test, and older LLVM
+         * releases apparently didn't assert here (or asserts were
+         * compiled out), letting this call silently "work" by luck for
+         * years until a newer, stricter LLVM enforced its own documented
+         * precondition. hasTerminator() is the actual bool query this
+         * function needs -- confirmed against LLVM's own BasicBlock.h:
+         * hasTerminator() is a plain, assertion-free
+         * "!empty() && back().isTerminator()" check, exactly the
+         * unterminated-or-not question this function exists to answer. */
+        return B.GetInsertBlock()->hasTerminator();
     }
 
     void branch_if_open(BasicBlock *target) {

--- a/src/syntax_rules.c
+++ b/src/syntax_rules.c
@@ -222,11 +222,38 @@ static bool sr_match_list(val_t pat_rest, val_t form_rest, val_t literals,
                 val_t sb = V_NIL, se = V_NIL;
                 if (!sr_match_one(pat_elem, vcar(form_rest), literals, ellipsis, &sb, &se))
                     return false;
-                /* Prepend each matched value to its accumulator */
+                /* Prepend each matched value to its accumulator.
+                 *
+                 * pnames[j] can land in EITHER sb or se, depending on
+                 * whether it has its own further ellipsis WITHIN pat_elem
+                 * (a nested-ellipsis pattern like "(a b ...) ..." -- here
+                 * `a` has no further ellipsis inside pat_elem, so its
+                 * match lands in sb; `b` has ITS OWN "..." inside
+                 * pat_elem, so its match lands in se instead, already
+                 * correctly shaped as one whole nested list per group by
+                 * this exact same logic applying recursively one level
+                 * down). Previously this only ever checked sb, so any
+                 * pattern variable with its own nested ellipsis silently
+                 * got V_NIL every time (issue #101) -- confirmed
+                 * minimal repro:
+                 *   (define-syntax my-test
+                 *     (syntax-rules () ((_ (a b ...) ...) '((a b ...) ...))))
+                 *   (my-test (1 10 20) (2 30))
+                 *   ; => ((1 () ())) instead of ((1 10 20) (2 30))
+                 * Falling back to se when not found in sb fixes this, and
+                 * composes correctly to arbitrary nesting depth by
+                 * induction: se's own entries are already properly
+                 * shaped by this same fallback having already applied
+                 * one level further in, via the recursive
+                 * sr_match_one -> sr_match_list call above. */
                 for (int j = 0; j < npv; j++) {
                     val_t val = V_NIL;
+                    bool found = false;
                     for (val_t s = sb; vis_pair(s); s = vcdr(s))
-                        if (vcar(vcar(s)) == pnames[j]) { val = vcdr(vcar(s)); break; }
+                        if (vcar(vcar(s)) == pnames[j]) { val = vcdr(vcar(s)); found = true; break; }
+                    if (!found)
+                        for (val_t s = se; vis_pair(s); s = vcdr(s))
+                            if (vcar(vcar(s)) == pnames[j]) { val = vcdr(vcar(s)); break; }
                     paccs[j] = scm_cons(val, paccs[j]);
                 }
                 form_rest = vcdr(form_rest);
@@ -567,15 +594,41 @@ static val_t sr_expand_list(val_t tmpl, val_t bindings, val_t ell_bindings,
             if (vis_pair(refs)) {
                 int n = scm_list_length(vcdr(vcar(refs)));
                 for (int i = 0; i < n; i++) {
-                    /* Build per-iteration bindings: bind each ell var to its i-th value */
-                    val_t iter_bindings = bindings;
+                    /* Build per-iteration bindings: bind each ell var to
+                     * its i-th value. Pushed into BOTH tables:
+                     * iter_bindings (plain scalar substitution, for the
+                     * common case where elem references the var bare,
+                     * with no further ellipsis) AND iter_ell_bindings
+                     * (shadowing the OUTER ell_bindings entry for that
+                     * name, for the nested-ellipsis case where elem
+                     * itself contains "name ...", which needs to find
+                     * just THIS iteration's own slice, not the full
+                     * across-all-outer-iterations list).
+                     *
+                     * Without iter_ell_bindings (issue #101's expand-side
+                     * counterpart), a template like "((a b ...) ...)"
+                     * would recurse into elem = "(a b ...)" still holding
+                     * the ORIGINAL, un-scoped ell_bindings, so the inner
+                     * "b ..." would iterate over b's full nested
+                     * structure across every outer group instead of just
+                     * group i's own slice. A pattern variable with
+                     * further ellipsis in the template is never
+                     * referenced bare (R7RS requires matching ellipsis
+                     * depth at every reference), so iter_bindings' copy
+                     * of it is simply never consulted in that case --
+                     * harmless to set unconditionally on both tables
+                     * rather than trying to know ahead of time which one
+                     * a given name will actually need. */
+                    val_t iter_bindings     = bindings;
+                    val_t iter_ell_bindings = ell_bindings;
                     for (val_t r = refs; vis_pair(r); r = vcdr(r)) {
                         val_t name = vcar(vcar(r));
                         val_t val  = scm_list_ref(vcdr(vcar(r)), i);
-                        iter_bindings = scm_cons(scm_cons(name, val), iter_bindings);
+                        iter_bindings     = scm_cons(scm_cons(name, val), iter_bindings);
+                        iter_ell_bindings = scm_cons(scm_cons(name, val), iter_ell_bindings);
                     }
                     result = scm_append(result,
-                                 scm_cons(sr_expand(elem, iter_bindings, ell_bindings,
+                                 scm_cons(sr_expand(elem, iter_bindings, iter_ell_bindings,
                                                      rename_map, ellipsis, literal_mode),
                                           V_NIL));
                 }

--- a/src/syntax_rules.c
+++ b/src/syntax_rules.c
@@ -592,7 +592,25 @@ static val_t sr_expand_list(val_t tmpl, val_t bindings, val_t ell_bindings,
             /* Find ellipsis-bound vars referenced by elem */
             val_t refs = sr_ell_refs(elem, ell_bindings);
             if (vis_pair(refs)) {
+                /* scm_list_length returns -1 for a non-proper-list (see
+                 * its own definition) -- can happen here for a malformed
+                 * macro use where refs' first entry turns out to be a
+                 * scalar rather than the per-iteration list this code
+                 * expects (e.g. a template mixing a depth-1 and a
+                 * depth-2 variable in the same ellipsis-repeated
+                 * sub-template, which R7RS forbids but nothing in this
+                 * file actually rejects at match time). Clamping to 0
+                 * repetitions here, and guarding the per-ref scm_list_ref
+                 * call below the same way, turns what would otherwise be
+                 * an unchecked vcar/vcdr on a non-pair (a real, reviewer-
+                 * confirmed SIGSEGV, uncatchable since macro expansion
+                 * runs at compile time -- see issue #101's fix writeup)
+                 * into the same kind of "wrong but survivable" output a
+                 * malformed macro already produced before this nested-
+                 * ellipsis fix landed, rather than a worse failure mode
+                 * than before. */
                 int n = scm_list_length(vcdr(vcar(refs)));
+                if (n < 0) n = 0;
                 for (int i = 0; i < n; i++) {
                     /* Build per-iteration bindings: bind each ell var to
                      * its i-th value. Pushed into BOTH tables:
@@ -623,7 +641,22 @@ static val_t sr_expand_list(val_t tmpl, val_t bindings, val_t ell_bindings,
                     val_t iter_ell_bindings = ell_bindings;
                     for (val_t r = refs; vis_pair(r); r = vcdr(r)) {
                         val_t name = vcar(vcar(r));
-                        val_t val  = scm_list_ref(vcdr(vcar(r)), i);
+                        /* Guard this scm_list_ref too, not just the one
+                         * used to compute `n` above -- a malformed macro
+                         * mixing a depth-1 and a depth-2 variable in the
+                         * SAME ellipsis-repeated sub-template can pick a
+                         * well-formed list for `n` (from whichever ref
+                         * sr_ell_refs happened to return first) while a
+                         * DIFFERENT ref in this same loop holds a scalar
+                         * -- confirmed by independent review: this exact
+                         * shape still crashed even after the `n` guard
+                         * above, since this second, per-ref call is the
+                         * one that actually dereferences the scalar as a
+                         * pair. Same fallback: a not-a-proper-list value
+                         * degrades to V_NIL for this iteration instead of
+                         * crashing. */
+                        val_t vals = vcdr(vcar(r));
+                        val_t val  = (scm_list_length(vals) > i) ? scm_list_ref(vals, i) : V_NIL;
                         iter_bindings     = scm_cons(scm_cons(name, val), iter_bindings);
                         iter_ell_bindings = scm_cons(scm_cons(name, val), iter_ell_bindings);
                     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_test(NAME dynamic_wind   COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_
 add_test(NAME disassemble    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/disassemble_tests.scm)
 add_test(NAME inliner        COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/inliner_tests.scm)
 add_test(NAME syntax_rules   COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/syntax_rules_tests.scm)
+add_test(NAME syntax_rules_nested_ellipsis COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/syntax_rules_nested_ellipsis_tests.scm)
 add_test(NAME ode            COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/ode_tests.scm)
 add_test(NAME pde_numerical COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/pde_numerical_tests.scm)
 add_test(NAME d_operator    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/d_operator_tests.scm)

--- a/tests/syntax_rules_nested_ellipsis_tests.scm
+++ b/tests/syntax_rules_nested_ellipsis_tests.scm
@@ -1,0 +1,122 @@
+;;; syntax_rules_nested_ellipsis_tests.scm — regression coverage for issue
+;;; #101: a pattern where an outer `...` wraps a sub-pattern that itself
+;;; contains a variable followed by its own `...` (e.g. "(a b ...) ...")
+;;; failed to bind the inner variable correctly.
+;;;
+;;; Found while implementing (scheme case-lambda), whose standard R7RS
+;;; reference implementation naturally uses exactly this shape. Root cause
+;;; (src/syntax_rules.c): sr_match_list's per-group accumulation loop only
+;;; ever searched `sb` (the inner match's scalar bindings) for each
+;;; pattern-variable name, silently defaulting to '() when a name's match
+;;; actually landed in `se` (the inner match's own ellipsis bindings,
+;;; which is where a variable with its own further ellipsis inside the
+;;; outer sub-pattern lands) instead. sr_expand_list had the symmetric gap
+;;; on the way back out: it never re-scoped ell_bindings per outer
+;;; iteration, so a nested "name ..." inside the repeated sub-template
+;;; would iterate over the WRONG (whole, cross-iteration) list. Fixed by
+;;; falling back to `se` when a name isn't in `sb` (match side) and by
+;;; building a per-iteration, shadowed ell_bindings table (expand side) --
+;;; both fixes compose correctly to arbitrary nesting depth by induction,
+;;; since each level applies the exact same fallback.
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+;; The exact minimal repro from issue #101.
+(define-syntax nest-basic
+  (syntax-rules ()
+    ((_ (a b ...) ...) '((a b ...) ...))))
+(check "nested ellipsis: issue #101's exact minimal repro"
+       (nest-basic (1 10 20) (2 30))
+       '((1 10 20) (2 30)))
+
+;; Asymmetric group sizes, including a zero-inner-elements group.
+(check "nested ellipsis: asymmetric group sizes"
+       (nest-basic (1) (2 20 21) (3 30))
+       '((1) (2 20 21) (3 30)))
+
+;; A single outer group (degenerate but valid case).
+(check "nested ellipsis: single outer group"
+       (nest-basic (1 10 20 30))
+       '((1 10 20 30)))
+
+;; Zero outer groups (degenerate but valid case).
+(check "nested ellipsis: zero outer groups" (nest-basic) '())
+
+;; The inner and outer ellipsis variables used SEPARATELY in the template,
+;; not just spliced back into the same shape -- proves both a's (depth 1)
+;; and b's (depth 2) bindings are independently correct, not just
+;; "round-tripping" the same input structure back out unchanged.
+(define-syntax nest-separate
+  (syntax-rules ()
+    ((_ (a b ...) ...)
+     (list (list 'outer-vals a ...) (list 'inner-groups (list b ...) ...)))))
+(check "nested ellipsis: outer and inner vars used independently"
+       (nest-separate (1 10 20 30) (2 40) (3 50 60))
+       '((outer-vals 1 2 3) (inner-groups (10 20 30) (40) (50 60))))
+
+;; Three levels of nesting: outer wraps (a (b c ...) ...).
+(define-syntax nest-triple
+  (syntax-rules ()
+    ((_ (a (b c ...) ...) ...) '((a (b c ...) ...) ...))))
+(check "nested ellipsis: three levels deep"
+       (nest-triple (1 (10 100 101) (20 200)) (2 (30 300)))
+       '((1 (10 100 101) (20 200)) (2 (30 300))))
+
+;; A dotted tail inside the doubly-nested shape.
+(define-syntax nest-dotted
+  (syntax-rules ()
+    ((_ (a b ... . tail) ...) '((a (b ...) tail) ...))))
+(check "nested ellipsis: dotted tail inside a nested-ellipsis clause"
+       (nest-dotted (1 10 20 . extra1) (2 . extra2))
+       '((1 (10 20) extra1) (2 () extra2)))
+
+;; Real-world shape: the (scheme case-lambda) reference implementation's
+;; own outer macro, using the DIRECT (a b ...) ... shape rather than the
+;; opaque-clause workaround the shipped .sld file uses -- proves the
+;; engine fix itself is sufficient to make the textbook R7RS reference
+;; implementation work as originally written, not just that the workaround
+;; still works.
+(define-syntax direct-case-lambda-help
+  (syntax-rules ()
+    ((_ args len) (error "no matching clause"))
+    ((_ args len ((p ...) body0 ...) . rest)
+     (if (= len (length '(p ...)))
+         (apply (lambda (p ...) body0 ...) args)
+         (direct-case-lambda-help args len . rest)))
+    ((_ args len (tail body0 ...) . rest)
+     (apply (lambda tail body0 ...) args))))
+(define-syntax direct-case-lambda
+  (syntax-rules ()
+    ((_ (params body0 ...) ...)
+     (lambda args
+       (let ((len (length args)))
+         (direct-case-lambda-help args len (params body0 ...) ...))))))
+(define dcl-f
+  (direct-case-lambda
+    (() 'zero)
+    ((a) (list 'one a))
+    ((a b) (list 'two a b))))
+(check "nested ellipsis: direct (non-workaround) case-lambda reference shape, 0 args"
+       (dcl-f) 'zero)
+(check "nested ellipsis: direct (non-workaround) case-lambda reference shape, 1 arg"
+       (dcl-f 1) '(one 1))
+(check "nested ellipsis: direct (non-workaround) case-lambda reference shape, 2 args"
+       (dcl-f 1 2) '(two 1 2))
+
+;;; Summary
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/syntax_rules_nested_ellipsis_tests.scm
+++ b/tests/syntax_rules_nested_ellipsis_tests.scm
@@ -113,6 +113,40 @@
 (check "nested ellipsis: direct (non-workaround) case-lambda reference shape, 2 args"
        (dcl-f 1 2) '(two 1 2))
 
+;;; Regression: malformed macro uses that mix ellipsis depths within the
+;;; same repeated sub-template (invalid per R7RS, but nothing in this file
+;;; rejects it at match time) used to SIGSEGV -- uncatchable by guard,
+;;; since macro expansion happens at compile time, not run time. Found by
+;;; independent review: the expand-side fix's per-iteration
+;;; iter_ell_bindings shadowing broke the invariant that every
+;;; ell_bindings value is a proper list, so an unguarded scm_list_ref
+;;; dereferenced a scalar as a pair. Fixed by treating a not-actually-a-
+;;; list value as "no more repetitions" instead of crashing. These tests
+;;; exist to prove the process survives at all -- the exact output for
+;;; genuinely invalid macro input is "wrong but survivable" by design, not
+;;; a meaningful contract, so only checking "didn't crash, execution
+;;; continued" here, not specific result shapes.
+(define-syntax mixed-depth-1
+  (syntax-rules () ((_ (a b ...) ...) '(((a b) ...) ...))))
+(mixed-depth-1 (1 10))
+(check "nested ellipsis: mixed-depth macro use does not crash the process"
+       'still-alive 'still-alive)
+
+(define-syntax mixed-depth-2
+  (syntax-rules () ((_ (a b ...) ...) '(((a . b) ...) ...))))
+(mixed-depth-2 (1 10 20))
+(check "nested ellipsis: mixed-depth dotted-tail use does not crash the process"
+       'still-alive 'still-alive)
+
+;; Pre-existing (not introduced by this fix, same call site, same guard):
+;; two same-depth ellipsis variables of UNEQUAL length used together also
+;; used to crash the same way.
+(define-syntax unequal-length
+  (syntax-rules () ((_ (a ...) (b ...)) '((b a) ...))))
+(unequal-length (1 2 3 4 5) (10 20))
+(check "nested ellipsis: unequal-length same-depth vars do not crash the process"
+       'still-alive 'still-alive)
+
 ;;; Summary
 
 (newline)


### PR DESCRIPTION
Closes #101. See commit messages for full detail. Root cause and fix on both match and expand sides of a nested-ellipsis pattern (outer ... wrapping a sub-pattern with its own ...). Independent review found a real HIGH-severity regression in the expand-side fix (a malformed macro could now SIGSEGV, uncatchable, instead of just producing wrong output) plus a second pre-existing crash with the same root cause -- both fixed in the second commit with a bounds guard at the one call site, verified against the reviewer's exact repro cases. 115/115 ctest passes throughout.