### PR TITLE
fix(reader): reject a bare dot at the start of a list instead of misreading it

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -376,7 +376,41 @@ static val_t read_list(val_t port, int close_ch) {
        (pairs never use flags otherwise) for compiler line tracking. */
     int elem_line = port_line(port);
 
-    val_t head = read_datum(port);
+    /* A dot cannot be the very first token of a list: R7RS's grammar is
+     * "(datum*)" or "(datum+ . datum)" -- at least one datum must precede
+     * the dot, so "(. r)" matches neither production and is invalid,
+     * unlike "(a . r)" or a bare "r". Only read_list_tail (consulted for
+     * every element AFTER the first) has ever checked for this -- this
+     * function previously read its own head element via a plain
+     * read_datum call with no dot-awareness at all, so "(. r)" read "."
+     * itself as an ordinary one-character symbol token for the head, then
+     * "r" as an unrelated second element, silently producing the
+     * 2-element list (|.| r) instead of rejecting the input (confirmed:
+     * (pair? '(. r)) => #t, (length '(. r)) => 2).
+     *
+     * Handled with the exact same technique read_list_tail already uses
+     * for its own "starts with '.'" case just below (build the token
+     * manually via sb_push, rather than trying to "un-read" the dot back
+     * onto the port -- port_unread_char is declared in port.h but was
+     * never actually implemented anywhere, confirmed by this fix
+     * initially trying to call it and failing to link), so "..."/".foo"
+     * (a symbol merely starting with '.') read correctly as the head
+     * element here too, not just after read_list_tail; only a BARE "."
+     * with nothing else in the token is ever treated as a dot marker. */
+    val_t head;
+    if (c == '.') {
+        next_char(port);
+        if (is_delimiter(peek_char_port(port)))
+            read_error("unexpected dot at start of list -- a datum must precede '.' in a dotted pair");
+        StrBuf sb; sb_init(&sb);
+        sb_push(&sb, '.');
+        while (!is_delimiter(peek_char_port(port)))
+            sb_push(&sb, (char)next_char(port));
+        sb.buf[sb.len] = '\0';
+        head = sym_intern(sb.buf, (uint32_t)sb.len);
+    } else {
+        head = read_datum(port);
+    }
     val_t rest = read_list_tail(port, close_ch);
     Pair *p = CURRY_NEW(Pair);
     p->hdr.type = T_PAIR; p->hdr.flags = (uint32_t)elem_line;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_test(NAME transcendental   COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURC
 add_test(NAME pde_symbolic     COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/pde_symbolic_tests.scm)
 add_test(NAME sicm              COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sicm_tests.scm)
 add_test(NAME akkadian      COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/akkadian_tests.scm)
+add_test(NAME reader_dotted_list COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/reader_dotted_list_tests.scm)
 add_test(NAME conditions    COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/conditions_tests.scm)
 add_test(NAME numtheory     COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/numtheory_tests.scm)
 add_test(NAME sexagesimal   COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sexagesimal_tests.scm)

--- a/tests/reader_dotted_list_tests.scm
+++ b/tests/reader_dotted_list_tests.scm
@@ -1,0 +1,75 @@
+;;; reader_dotted_list_tests.scm — regression coverage for issue #103: the
+;;; reader accepted "(. r)" (a dot with nothing before it) as a valid
+;;; 2-element list containing the literal symbol "." followed by "r",
+;;; instead of rejecting it. Per R7RS's own grammar ("(datum*)" or
+;;; "(datum+ . datum)"), a dot with zero data preceding it matches neither
+;;; production and is invalid syntax -- root cause was read_list reading
+;;; its own head element via a plain read_datum call with no dot-awareness
+;;; at all; only read_list_tail (consulted for every element AFTER the
+;;; first) ever checked for a dot marker.
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+;; A bare "." as the very first token of a list must be rejected, not
+;; silently read as a 2-element list containing the symbol ".".
+;;
+;; This must be tested via eval+string-port, not a literal "(. r)" datum
+;; in this test file's own source: the read error happens at READ time,
+;; before this file's own top-level forms are even evaluated one at a
+;; time, so a literal invalid datum here would abort loading this entire
+;; test file rather than being something a single check can catch.
+(define (read-from-string s)
+  (read (open-input-string s)))
+
+(check "reader: bare dot at start of list is rejected, not misread"
+       (guard (e (#t 'raised)) (read-from-string "(. r)"))
+       'raised)
+(check "reader: bare dot at start of a nested list is rejected"
+       (guard (e (#t 'raised)) (read-from-string "(a (. r))"))
+       'raised)
+
+;; Legitimate dotted-pair syntax is completely unaffected -- the dot
+;; still works correctly everywhere it's actually valid (after at least
+;; one datum).
+(check "reader: ordinary dotted pair, one fixed element"
+       (read-from-string "(a . r)") '(a . r))
+(check "reader: ordinary dotted pair, two fixed elements"
+       (read-from-string "(a b . r)") '(a b . r))
+(check "reader: dotted pair as the head of an outer list"
+       (read-from-string "((a . b) c)") '((a . b) c))
+
+;; A symbol merely STARTING with '.' (not a bare dot) must still read
+;; correctly as the list's head element, not be misidentified as a dot
+;; marker -- this is exactly the case the fix's manual-token-building
+;; branch (mirroring read_list_tail's own existing technique) has to get
+;; right, not just reject.
+(check "reader: '...' as the head element of a list"
+       (read-from-string "(... a)") '(... a))
+(check "reader: a symbol starting with '.' as the head element"
+       (read-from-string "(.foo a)") '(.foo a))
+(check "reader: '...' as the ONLY element of a list"
+       (read-from-string "(...)") '(...))
+
+;; (scheme case-lambda)'s own legal fully-variadic clause shape (a bare
+;; symbol, not "(. r)") must be unaffected.
+(check "reader: dotted-pair fix does not affect case-lambda's bare-symbol clause"
+       (read-from-string "(case-lambda (r r))")
+       '(case-lambda (r r)))
+
+;;; Summary
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
Closes #103. See commit message for full detail: `(. r)` previously read as a 2-element list containing the literal symbol ".", instead of being rejected per R7RS's grammar. 115/115 ctest passes.