### PR TITLE
fix(llvm): drop hasTerminator() dependency, breaks build on LLVM 15

### DIFF
--- a/src/llvm/codegen.cpp
+++ b/src/llvm/codegen.cpp
@@ -165,16 +165,18 @@ struct CompileCtx {
          * behind issue #99 (crash on LLVM 23.1.0, "cannot get terminator
          * of non-well-formed block"). getTerminator() asserts the block
          * is ALREADY terminated before returning anything; it was never
-         * meant to double as an is-it-terminated test, and older LLVM
-         * releases apparently didn't assert here (or asserts were
-         * compiled out), letting this call silently "work" by luck for
-         * years until a newer, stricter LLVM enforced its own documented
-         * precondition. hasTerminator() is the actual bool query this
-         * function needs -- confirmed against LLVM's own BasicBlock.h:
-         * hasTerminator() is a plain, assertion-free
-         * "!empty() && back().isTerminator()" check, exactly the
-         * unterminated-or-not question this function exists to answer. */
-        return B.GetInsertBlock()->hasTerminator();
+         * meant to double as an is-it-terminated test.
+         *
+         * NOT `hasTerminator()` either (a prior version of this fix used
+         * it): that member is a newer addition to BasicBlock, present on
+         * the Homebrew LLVM used during that fix but absent from LLVM 15
+         * -- the project's own documented minimum -- causing a hard build
+         * break there. Inline the same check hasTerminator() itself
+         * performs (`!empty() && back().isTerminator()`), which only
+         * depends on BasicBlock::empty()/back() and Instruction::
+         * isTerminator(), all long-stable across LLVM releases. */
+        BasicBlock *bb = B.GetInsertBlock();
+        return !bb->empty() && bb->back().isTerminator();
     }
 
     void branch_if_open(BasicBlock *target) {


### PR DESCRIPTION
## Summary
- `BasicBlock::hasTerminator()` doesn't exist in LLVM 15 (this project's documented minimum), only in newer LLVM releases — broke the build with the exact error reported: `codegen.cpp:177:36: error: 'class llvm::BasicBlock' has no member named 'hasTerminator'`
- Replaced with the inline equivalent (`!empty() && back().isTerminator()`), which only depends on long-stable BasicBlock/Instruction APIs present across all supported LLVM versions
- Verified against real Homebrew LLVM 23.1.0 (confirms the original issue #99 crash this code exists to fix stays fixed) and the full LLVM-enabled ctest suite
- Independent review confirmed exact equivalence to `hasTerminator()`'s own implementation, no call-site drift, no null-pointer exposure

Separately, while verifying against a working LLVM build, found and filed #111: the LLVM JIT tier silently miscompiles hot functions containing macro invocations or unimplemented special forms. Unrelated in cause to this fix, tracked separately.

## Test plan
- [x] `BUILD_LLVM=ON` build against Homebrew LLVM 23.1.0 succeeds
- [x] Full ctest suite passes under the LLVM-enabled build (`build-llvm`)
- [x] Independent code review (fresh subagent, no shared context) confirmed correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
