### PR TITLE
ci: add a BUILD_LLVM=ON job so the JIT backend gets any CI coverage at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,63 @@ jobs:
       - name: Test
         working-directory: build
         run: ctest --output-on-failure -j$(getconf _NPROCESSORS_ONLN)
+
+  build-and-test-llvm:
+    # Separate job (not folded into build-and-test's matrix) so the default
+    # BUILD_LLVM=OFF matrix isn't doubled in cost -- this exists specifically
+    # to give the LLVM JIT backend (src/llvm/*.cpp, dormant unless
+    # -DBUILD_LLVM=ON) any CI coverage at all. It previously had none: issue
+    # #111 (the JIT silently miscompiling macro calls/unimplemented special
+    # forms) and the hasTerminator()-vs-LLVM-15 build break it was found
+    # alongside (#106 fixed it for one LLVM version, PR #112 fixed the
+    # LLVM-15 regression that same fix introduced) both went undetected by
+    # CI for exactly this reason. Debug-only, one build_type, since the
+    # point is catching JIT-tier regressions, not duplicating the full
+    # os x build_type matrix above.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgc-dev libgmp-dev cmake build-essential pkg-config \
+            libssl-dev libsqlite3-dev libcurl4-openssl-dev \
+            libpng-dev libjpeg-dev libgit2-dev libplplot-dev \
+            redis-server mosquitto llvm-18-dev
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install bdw-gc gmp cmake pkg-config \
+            openssl sqlite libgit2 libpng jpeg-turbo plplot \
+            redis mosquitto llvm
+
+      - name: Configure (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_LLVM=ON \
+            -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm
+
+      - name: Configure (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_LLVM=ON \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix llvm)"
+
+      - name: Build
+        run: cmake --build build -j$(getconf _NPROCESSORS_ONLN)
+
+      - name: Test
+        working-directory: build
+        run: ctest --output-on-failure -j$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
## Summary
- Adds a new `build-and-test-llvm` CI job (Ubuntu + macOS, Debug) that configures with `-DBUILD_LLVM=ON`, matching CLAUDE.md's documented LLVM build instructions exactly (`llvm-18-dev` on Ubuntu, `brew install llvm` on macOS)
- Previously CI never compiled `src/llvm/*.cpp` at all, since `BUILD_LLVM` defaults to `OFF` — the JIT backend had zero CI coverage
- Two real bugs slipped through as a direct result and were only found this session by manually building `-DBUILD_LLVM=ON` locally: the `hasTerminator()`-vs-LLVM-15 build break (#106/#112) and #111 (the JIT silently miscompiling macro calls/unimplemented special forms)
- Kept as a separate job rather than folded into the existing `build-and-test` matrix, to avoid doubling that matrix's cost — Debug-only, since the goal here is catching JIT-tier regressions, not full os × build_type duplication

Note: this doesn't itself make the new job a *required* status check — that's a branch-protection setting, not something a workflow-file commit can change.

## Test plan
- [x] YAML validated
- [ ] Confirm the new `build-and-test-llvm (ubuntu-latest)` / `(macos-latest)` checks actually run and pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
