### PR TITLE
fix(llvm): decline JIT promotion for macro calls and unimplemented special forms

### DIFF
--- a/src/llvm/codegen.cpp
+++ b/src/llvm/codegen.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #include "../env.h"
 #include "../builtins.h"
 #include "../gc.h"
+#include "../lang_registry.h"
 }
 
 #include <llvm/IR/IRBuilder.h>
@@ -956,7 +957,17 @@ static Value *emit_expr(CompileCtx &cc, val_t expr) {
     if (!vis_pair(expr))
         return emit_literal(cc, expr);
 
-    val_t op  = as_pair(expr)->car;
+    /* Translate an Akkadian/cuneiform special-form synonym to its
+     * canonical English symbol before any dispatch below, exactly as
+     * eval() does (compiler_classic.c's classify_head does too). Without
+     * this, a supported form spelled in Akkadian (e.g. šumma for "if")
+     * matched none of the string comparisons below and fell all the way
+     * through to the macro/unsupported-form guard and then emit_call,
+     * getting silently miscompiled the same way an actual macro call
+     * did before that guard existed (issue #111) -- lang_translate() is a
+     * no-op for symbols with no registered synonym, including plain
+     * English ones, so this is safe to apply unconditionally. */
+    val_t op  = lang_translate(as_pair(expr)->car);
     val_t rst = as_pair(expr)->cdr;
 
     /* ---- (quote datum) ---- */
@@ -1293,6 +1304,60 @@ static Value *emit_expr(CompileCtx &cc, val_t expr) {
     /* ---- (do var-specs (test result...) body...) ---- */
     if (vis_symbol(op) && op == S("do"))
         return emit_do(cc, rst);
+
+    /* ---- Bail out on macros / unimplemented special forms (issue #111) ----
+     * The forms above are everything this codegen understands. Anything
+     * else falling through to "procedure call" below either (a) is a user
+     * macro invocation -- the operator position holds a T_SYNTAX
+     * transformer, not a callable value -- or (b) is a special form
+     * curry's own bytecode compiler knows about (compiler_internal.h's
+     * SF_* enum) that this JIT tier has simply never implemented
+     * (quasiquote, let-values, case-lambda, ...). Compiling either as an
+     * ordinary call silently produces wrong results with misleading
+     * errors ("apply: not a procedure", "unbound variable") instead of
+     * declining JIT promotion, since maybe_jit_bcc compiles a chunk's raw,
+     * un-macro-expanded src_lambda with no eligibility check at all.
+     * Throwing here is caught by curry_llvm_jit_compile, which stores
+     * V_FALSE into jit_val -- permanently and safely pinning the closure
+     * to the bytecode interpreter, exactly the same fallback already used
+     * a few lines above maybe_jit_bcc's own call site for the unrelated
+     * target_env/define-library bailout (runtime.c). */
+    if (vis_symbol(op) && !cc.lookup(as_sym(op)->data)) {
+        static const std::unordered_set<std::string> UNSUPPORTED_FORMS = {
+            "quasiquote", "unquote", "unquote-splicing",
+            "let-values", "let*-values", "define-values",
+            "delay", "delay-force",
+            "parameterize", "guard", "with-exception-handler",
+            "receive", "define-record-type",
+            "define-syntax", "let-syntax", "letrec-syntax",
+            "syntax-rules", "cond-expand", "case-lambda",
+            "symbolic", "with-assumptions",
+            "defined?", "define-rule", "define-ruleset", "define-algebra",
+        };
+        const char *name = as_sym(op)->data;
+        if (UNSUPPORTED_FORMS.count(name))
+            throw std::runtime_error(
+                std::string("JIT: unsupported special form '") + name + "'");
+
+        /* GLOBAL_ENV-only lookup is a known, NOT fully closed gap (see
+         * issue #111's follow-up discussion): a macro introduced by a
+         * let-syntax/letrec-syntax that lexically encloses this closure
+         * -- e.g. (let-syntax ((m ...)) (lambda (n) (m n))) -- has no
+         * GLOBAL_ENV binding, and the closure's own src_lambda is just
+         * the inner (lambda (n) (m n)); the enclosing let-syntax form
+         * itself is never part of that captured AST, so it never trips
+         * the "let-syntax" entry in UNSUPPORTED_FORMS above either. A
+         * correct fix needs the bytecode compiler to record, per-chunk,
+         * whether compilation ever resolved a name via a lexical
+         * syntax_locals scope (compiler_internal.h), and maybe_jit_bcc
+         * (runtime.c) to refuse promotion for such chunks -- deeper than
+         * this fix's scope; tracked separately rather than attempted
+         * here. */
+        val_t *slot = env_lookup_slot(GLOBAL_ENV, S(name));
+        if (slot && vis_syntax(*slot))
+            throw std::runtime_error(
+                std::string("JIT: macro invocation '") + name + "' not supported");
+    }
 
     /* ---- procedure call ---- */
     return emit_call(cc, op, rst);

--- a/tests/jit_tests.scm
+++ b/tests/jit_tests.scm
@@ -181,6 +181,77 @@
 (check "jit-call-depth does not leak across parameterize"
        (jit-call-depth) 0)
 
+;;; 15. Macro invocations inside a hot function must not be miscompiled ────────
+;;; Regression coverage for issue #111: maybe_jit_bcc JIT-compiles a chunk's
+;;; raw, un-macro-expanded src_lambda, and codegen.cpp's emit_expr only
+;;; understands ~18 core forms -- anything else (a macro call; a special
+;;; form the JIT tier doesn't implement) used to fall through to the
+;;; generic "procedure call" path and get compiled as an ordinary call to
+;;; whatever the head symbol happened to resolve to, silently producing
+;;; wrong results ("apply: not a procedure", "unbound variable") once the
+;;; function got hot enough to JIT-promote, instead of declining promotion
+;;; and staying on the bytecode interpreter.
+(define-syntax jit-macro-inc
+  (syntax-rules () ((_ x) (+ x 1))))
+(define (jit-macro-user n) (jit-macro-inc n))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT bailout: hot function using a user macro stays correct"
+           (jit-macro-user i) (+ i 1))
+    (loop (+ i 1))))
+
+;;; The exact case that surfaced #111: (scheme case-lambda)'s own expansion
+;;; leaves its internal %case-lambda-help helper call unexpanded in
+;;; src_lambda, and case-lambda itself is a special form this JIT tier has
+;;; never implemented.
+(import (scheme case-lambda))
+(define jit-cl-count
+  (case-lambda
+    ((n) (jit-cl-count n 0))
+    ((n acc) (if (= n 0) acc (jit-cl-count (- n 1) (+ acc 1))))))
+(check "JIT bailout: case-lambda self-recursive dispatch, 1000 iterations"
+       (jit-cl-count 1000) 1000)
+
+;;; A handful of the other unimplemented special forms named in issue #111,
+;;; each driven past JIT_THRESHOLD (50 calls) to force auto-JIT promotion.
+(define (jit-qq-user n) `(a ,n b))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT bailout: quasiquote stays correct when hot"
+           (jit-qq-user i) (list 'a i 'b))
+    (loop (+ i 1))))
+
+(define (jit-lv-user n)
+  (let-values (((q r) (floor/ n 3))) (+ q r)))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT bailout: let-values stays correct when hot"
+           (jit-lv-user i) (+ (quotient i 3) (remainder i 3)))
+    (loop (+ i 1))))
+
+;;; codegen.cpp didn't call lang_translate before matching an operator's
+;;; name against its own special-form dispatch, so a supported form spelled
+;;; in Akkadian never matched any branch and fell through to the same
+;;; miscompile path as an unrecognized form -- found by independent review
+;;; of the #111 fix. šumma is Akkadian for "if".
+(define (jit-akk-user n) (šumma (> n 0) (+ n 1) 0))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT bailout: Akkadian special-form synonym stays correct when hot"
+           (jit-akk-user i) (if (> i 0) (+ i 1) 0))
+    (loop (+ i 1))))
+
+;;; defined? (SF_DEFINED_P) was missing from the unsupported-forms list --
+;;; also found by independent review -- and has no GLOBAL_ENV binding of
+;;; its own, so it fell through the same way.
+(define jit-dp-target 1)
+(define (jit-dp-user n) (if (defined? jit-dp-target) (+ n 1) 0))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT bailout: defined? stays correct when hot"
+           (jit-dp-user i) (+ i 1))
+    (loop (+ i 1))))
+
 ;;; Summary ─────────────────────────────────────────────────────────────────────
 (newline)
 (display pass) (display " passed, ") (display fail) (display " failed")


### PR DESCRIPTION
## Summary
Fixes #111. The LLVM JIT tier compiles a hot closure from its raw, un-macro-expanded source S-expression, and its expression compiler only recognizes ~18 core forms — anything else (a macro call, or a special form the bytecode compiler supports but this JIT tier doesn't) silently got compiled as an ordinary procedure call, producing wrong results with misleading errors once the function got hot enough to JIT-promote.

Fixed with a guard that declines JIT promotion (falls back safely to the bytecode interpreter, the same existing mechanism already used for an unrelated bailout in the same function) for any call whose operator resolves to a macro transformer or a known-unimplemented special form.

Strengthened per two independent reviews (code + security, parallel, no shared context) before opening this PR:
- `emit_expr` now runs the operator through `lang_translate()` first, closing a real bypass where a *supported* form spelled in Akkadian/cuneiform evaded every check
- Added `defined?`, `define-rule`, `define-ruleset`, `define-algebra` to the unsupported-forms list (same failure mode, missing from the first cut)
- Documented (not silently left open) one confirmed-unclosed gap: a `let-syntax`/`letrec-syntax`-local macro — filed as #114, needs deeper per-chunk compiler bookkeeping
- Filed #115 for an unrelated pre-existing bug the review surfaced: the arithmetic fast path ignores local shadowing of `+`/`-`/etc., silently wrong (no error) once hot — worse failure mode than #111, different code path, not fixed here

Both reviews confirmed: exactly one call site reaches the vulnerable fallthrough; local bindings correctly take precedence; the throw is exception-safe; and the pre-fix bug was never a memory-safety issue (confirmed live: a `T_SYNTAX` object passed as a callee raises a clean, catchable error, never crashes).

## Test plan
- [x] Full ctest suite passes under `BUILD_LLVM=ON` (118/118, `jit` suite 564/564 checks) and the default `BUILD_LLVM=OFF` build (117/117)
- [x] Reviewer-confirmed repro cases (Akkadian `if`, `defined?`, original macro/case-lambda repros) manually re-verified fixed
- [x] Known-remaining gap (`let-syntax`-local macro) manually re-verified still fails cleanly, as documented, tracked as #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
