### PR TITLE
fix(llvm): close three local-shadowing/scoping gaps in the JIT tier

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -138,6 +138,7 @@ Chunk *chunk_new(void) {
     c->src_lambda  = V_VOID;
     c->upval_names = NULL;
     c->target_env  = V_VOID;
+    c->uses_local_macro = false;
     return c;
 }
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -128,6 +128,31 @@ typedef struct {
      * must be resolved before Track 2 relies on .scc caching for
      * define-library bodies. */
     val_t  target_env;
+
+    /* Set by resolve_syntax_local (compiler.c) whenever compiling this
+     * chunk's body -- or a lambda nested textually inside it, arbitrarily
+     * many levels deep -- resolves a macro use via a let-syntax/letrec-
+     * syntax-local binding, as opposed to one bound by top-level
+     * define-syntax (visible in GLOBAL_ENV, and already safely detected
+     * there by the LLVM JIT's own codegen.cpp guard). A let-syntax-local
+     * macro's binding is invisible outside the lexical form that
+     * introduced it, so it has no GLOBAL_ENV entry for that guard to
+     * find -- and the enclosing let-syntax form itself is never part of
+     * a nested lambda's own src_lambda (just above; the let-syntax
+     * wrapper is evaluated once at define time to produce the closure,
+     * then discarded), so codegen.cpp's unsupported-forms name list
+     * can't catch it by string-matching the AST either. Marked on every
+     * enclosing chunk up to the one owning the macro, not just the
+     * innermost one actually referencing it, because codegen.cpp's
+     * emit_lambda compiles a nested lambda literal INLINE into its
+     * enclosing closure's own native code rather than through that
+     * nested lambda's independent maybe_jit_bcc gate -- an unmarked
+     * outer chunk would still get JIT-promoted and inline-compile
+     * straight through, missing the correctly-set inner flag entirely.
+     * maybe_jit_bcc (runtime.c) checks this flag and permanently
+     * declines JIT promotion for such a chunk, the same way it already
+     * does for target_env above -- see issue #114. */
+    bool   uses_local_macro;
 } Chunk;
 
 /* Allocate a fresh empty chunk */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -287,12 +287,38 @@ int add_syntax_local(Compiler *c, val_t name, val_t transformer) {
 /* Walk this compiler's local macro table, then each enclosing compiler in
  * turn (a nested lambda sees its parent's local macros, same as upvalues).
  * Inner bindings shadow outer ones. Returns false (not found) if no local
- * macro matches — the caller should then fall back to a GLOBAL_ENV lookup. */
+ * macro matches — the caller should then fall back to a GLOBAL_ENV lookup.
+ *
+ * On a match, also marks Chunk::uses_local_macro (chunk.h) on every
+ * compiler from `c` up to and including the one whose own syntax_locals
+ * table actually owns the match — not just `c->chunk` itself. This
+ * matters because the LLVM JIT tier (src/llvm/codegen.cpp's emit_lambda)
+ * compiles a nested lambda literal INLINE into its enclosing function's
+ * native code, rather than through that nested lambda's own chunk's
+ * independent maybe_jit_bcc gate — so if only c->chunk were marked, an
+ * outer closure embedding this exact nested lambda body would still get
+ * JIT-promoted and inline-compile straight through the unmarked outer
+ * chunk, miscompiling the very same local-macro call the inner chunk's
+ * own (correctly set, but never independently consulted in that case)
+ * flag was meant to guard against. Marking every level from `c` to the
+ * owning `cc` covers every chunk whose own JIT promotion could pull this
+ * macro use in, however many lambdas deep the reference is (issue #114's
+ * fix was originally only chunk-local and missed this). Every caller of
+ * resolve_syntax_local gets this for free rather than needing its own
+ * copy of this logic, including callers (expr_mentions_set_target,
+ * ir_lower.c's head_is_macro) that only use the boolean result for
+ * unrelated analysis -- harmless, since a true result there means the
+ * same head position will also be classify_head'd for real compilation
+ * of the very same body. */
 bool resolve_syntax_local(Compiler *c, val_t name, val_t *out_transformer) {
     for (Compiler *cc = c; cc; cc = cc->enclosing) {
         for (int i = cc->syntax_local_count - 1; i >= 0; i--)
             if (cc->syntax_locals[i].name == name) {
                 *out_transformer = cc->syntax_locals[i].transformer;
+                for (Compiler *m = c; m; m = m->enclosing) {
+                    m->chunk->uses_local_macro = true;
+                    if (m == cc) break;
+                }
                 return true;
             }
     }

--- a/src/compiler_classic.c
+++ b/src/compiler_classic.c
@@ -2195,6 +2195,13 @@ SpecialForm classify_head(Compiler *c, val_t head, val_t args,
         return SF_TREE_EVAL;
     if (vis_symbol(head)) {
         val_t transformer;
+        /* A match here means Chunk::uses_local_macro (chunk.h) is now set
+         * on every chunk from c up to the one whose syntax_locals table
+         * owns the macro -- resolve_syntax_local (compiler.c) does the
+         * marking itself, since the LLVM JIT tier inlines nested lambdas
+         * into their enclosing closure's native code and every one of
+         * those enclosing chunks needs the flag, not just c->chunk. See
+         * maybe_jit_bcc (runtime.c) for why -- closes issue #114. */
         bool is_macro = resolve_syntax_local(c, head, &transformer);
         if (!is_macro && c->chunk->target_env != V_VOID) {
             val_t macro = env_lookup_or_false(c->chunk->target_env, head);

--- a/src/llvm/codegen.cpp
+++ b/src/llvm/codegen.cpp
@@ -93,6 +93,28 @@ struct Binding {
     AllocaInst *slot;
     bool        is_mutable;
     bool        is_cell;   /* slot holds a GC cell address (i64), not a direct value */
+    /* Sentinel entry (slot == nullptr) bound under the loop's own name at
+     * the same scope as its loop variables, purely so ordinary scope
+     * lookup -- already correct, battle-tested shadowing logic -- can
+     * answer "does a call to this name mean the loop itself, or does some
+     * OTHER binding of the same name shadow it here" without a parallel,
+     * error-prone scope-depth bookkeeping scheme. See emit_call's named-
+     * let self-call check (issue #117) for how this is used. Every OTHER
+     * site that can dereference a Binding's slot (emit_expr's symbol
+     * reference, set!, internal define, and emit_lambda's capture-array
+     * fill -- collect_free_vars recurses into a call's operator position
+     * too, so a nested lambda merely calling the loop's own name lists it
+     * as needing capture) checks is_named_let first and throws instead:
+     * referencing a named let's own name as a value (rather than calling
+     * it) has no real slot to load, and was already unsupported before
+     * this sentinel existed -- the bytecode VM has no notion of it as a
+     * first-class value either -- but used to at least compile to
+     * something (a global lookup that raised a clean "unbound variable")
+     * rather than a null AllocaInst reaching LLVM's IR builder. Found by
+     * independent review: a null slot passed silent-but-invalid IR past
+     * verifyModule on an assertions-disabled LLVM build; an assertions-
+     * enabled one would have asserted inside LoadInst's own constructor. */
+    bool        is_named_let = false;
 };
 
 /* Tracks an active named-let loop so self-calls emit backedges instead of
@@ -150,7 +172,13 @@ struct CompileCtx {
 
     void bind(const std::string &name, AllocaInst *slot, bool mut = true, bool cell = false) {
         if (scopes.empty()) scopes.emplace_back();
-        scopes.back()[name] = Binding{slot, mut, cell};
+        scopes.back()[name] = Binding{slot, mut, cell, false};
+    }
+
+    /* See Binding::is_named_let's comment. */
+    void bind_named_let(const std::string &name) {
+        if (scopes.empty()) scopes.emplace_back();
+        scopes.back()[name] = Binding{nullptr, false, false, true};
     }
 
     AllocaInst *alloc_root(const std::string &name = "") {
@@ -331,10 +359,31 @@ static const std::unordered_map<std::string, const char *> ARITH1 = {
 
 static Value *emit_call(CompileCtx &cc, val_t fn_expr, val_t args) {
 
-    /* ---- Named-let self-call → loop backedge ---- */
+    /* ---- Named-let self-call → loop backedge ----
+     * Gated on cc.lookup(nm) resolving to the loop's OWN sentinel binding
+     * (Binding::is_named_let, bound into the loop's own scope by emit_let's
+     * named-let branch) rather than some OTHER binding of the same name.
+     * A first attempt at this fix used a blanket `!cc.lookup(nm)` check,
+     * which broke the opposite direction: a named let's own name correctly
+     * shadows an ENCLOSING binding of the same name (e.g. `(let ((loop ...))
+     * (let loop ((i 0)) ... (loop ...)))` must still self-recurse), but
+     * `cc.lookup` alone can't distinguish "found the enclosing real
+     * binding" from "found nothing" -- both looked like "not shadowed" or
+     * "shadowed" incorrectly depending on scope ordering. Consulting the
+     * sentinel instead of a bare null-check reuses the scope stack's own
+     * already-correct inner-shadows-outer resolution: a REAL binding
+     * introduced inside the loop body (deeper scope) is found first and
+     * has is_named_let == false (ordinary call, issue #117's actual
+     * repro); an enclosing same-named binding sits in a shallower scope
+     * than the loop's own sentinel, so the sentinel is still found first
+     * (correct self-call, the regression the first attempt introduced);
+     * and with nothing bound at all, lookup returns nullptr (also
+     * correctly falls through, though this can't happen for the loop's
+     * own name specifically since bind_named_let always registers it). */
     if (vis_symbol(fn_expr) && !cc.named_lets.empty()) {
         std::string nm = as_sym(fn_expr)->data;
-        for (int i = (int)cc.named_lets.size() - 1; i >= 0; --i) {
+        Binding *b = cc.lookup(nm);
+        for (int i = (int)cc.named_lets.size() - 1; b && b->is_named_let && i >= 0; --i) {
             if (cc.named_lets[i].name == nm) {
                 NamedLetCtx &nlet = cc.named_lets[i];
                 /* Evaluate all new argument values BEFORE storing (avoid
@@ -350,8 +399,23 @@ static Value *emit_call(CompileCtx &cc, val_t fn_expr, val_t args) {
         }
     }
 
-    /* ---- Direct arithmetic (skip global lookup + apply dispatch) ---- */
-    if (vis_symbol(fn_expr)) {
+    /* ---- Direct arithmetic (skip global lookup + apply dispatch) ----
+     * Gated on !cc.lookup(op_nm): without this, a hot function that
+     * locally shadows +, -, *, / etc (e.g. `(let ((+ (lambda (a b) 99)))
+     * (+ 1 2))`) had the shadow silently ignored -- this fast path matched the
+     * name directly against the builtin table with no regard for local
+     * scope, unlike the macro/unsupported-form guard following this
+     * function (added for #111) and the named-let backedge check just
+     * above (added for #117), which both check cc.lookup first. Silently
+     * wrong numeric results with no error at all once the function got
+     * hot enough to JIT-promote (issue #115), a worse failure mode than
+     * #111's, since that one at least raised a catchable error. Note
+     * emit_expr's own special-form dispatch (if/let/cond/set!/etc, above
+     * this function) does NOT check cc.lookup either, but shadowing one
+     * of those keywords is R7RS-nonconformant on the plain interpreter
+     * tier too (no tier-specific divergence) -- a separate, pre-existing
+     * question, not a JIT-only bug like this one. */
+    if (vis_symbol(fn_expr) && !cc.lookup(as_sym(fn_expr)->data)) {
         std::string op_nm = as_sym(fn_expr)->data;
 
         /* Variadic fold: (+), (*) → identity; (- x) → negate; (op a b c…) → fold */
@@ -671,8 +735,18 @@ static Value *emit_lambda(CompileCtx &cc, val_t params_val, val_t body_val) {
                                       ConstantInt::get(cc.i32_t, (int)captured.size()),
                                       "caps");
         for (int i = 0; i < (int)captured.size(); ++i) {
-            auto *cv = cc.B.CreateLoad(cc.i64_t, cc.lookup(captured[i])->slot,
-                                        captured[i]);
+            Binding *cb = cc.lookup(captured[i]);
+            /* See emit_expr's symbol-reference case for why a named let's
+             * own sentinel binding (Binding::is_named_let) must never be
+             * treated as a real, storable slot -- collect_free_vars'
+             * default case recurses into a call's operator position too,
+             * so a nested lambda merely CALLING an enclosing named let's
+             * own name (rather than being the loop body itself) can list
+             * that name as something needing capture. */
+            if (cb->is_named_let)
+                throw std::runtime_error(
+                    "JIT: a named let's own name cannot be captured by a nested lambda");
+            auto *cv = cc.B.CreateLoad(cc.i64_t, cb->slot, captured[i]);
             cc.B.CreateStore(cv, cc.B.CreateGEP(cc.i64_t, caps_ptr,
                                                   ConstantInt::get(cc.i32_t, i)));
         }
@@ -942,6 +1016,24 @@ static Value *emit_expr(CompileCtx &cc, val_t expr) {
     if (vis_symbol(expr)) {
         const char *name = as_sym(expr)->data;
         if (Binding *b = cc.lookup(name)) {
+            /* A named let's own name (Binding::is_named_let) has no real
+             * slot -- it exists purely so emit_call's self-call check can
+             * ask "does this call mean the loop itself" via ordinary
+             * scope-shadowing lookup. Referencing it as a plain VALUE
+             * (not calling it) was already unsupported before this
+             * sentinel existed -- the bytecode VM has no notion of the
+             * loop name as a first-class value either, since curry
+             * compiles named-let purely as a backedge construct, never
+             * allocating a real closure for the loop name -- but it used
+             * to at least compile to SOMETHING (a global-variable lookup
+             * that then raised a clean "unbound variable"). Bailing out
+             * of JIT compilation entirely here, rather than dereferencing
+             * a null slot into invalid IR, preserves that same clean
+             * failure mode instead of relying on verifyModule to catch a
+             * malformed load. */
+            if (b->is_named_let)
+                throw std::runtime_error(
+                    "JIT: a named let's own name cannot be used as a value");
             if (b->is_cell) {
                 Value *cell_addr = cc.B.CreateLoad(cc.i64_t, b->slot,
                                                    std::string(name) + "_cell");
@@ -1147,6 +1239,12 @@ static Value *emit_expr(CompileCtx &cc, val_t expr) {
             return emit_global_define(cc, S(nm.c_str()), val_v);
         } else {
             if (Binding *b = cc.lookup(nm)) {
+                /* See emit_expr's symbol-reference case for why a named
+                 * let's own sentinel binding (Binding::is_named_let) must
+                 * never be treated as a real, storable slot. */
+                if (b->is_named_let)
+                    throw std::runtime_error(
+                        "JIT: a named let's own name cannot be redefined");
                 if (b->is_cell) {
                     Value *cell_addr = cc.B.CreateLoad(cc.i64_t, b->slot);
                     Value *cell_ptr  = cc.B.CreateIntToPtr(cell_addr, cc.ptr_t);
@@ -1193,12 +1291,36 @@ static Value *emit_expr(CompileCtx &cc, val_t expr) {
             auto *exit_bb    = BasicBlock::Create(cc.llvm_ctx, "nlet_exit",   cc.fn);
             auto *result_slot = cc.alloc_root("nlet_result");
 
+            /* Compute every init expression BEFORE the loop's own scope
+             * (and its is_named_let sentinel, below) exists -- a named
+             * let's inits are evaluated in the ENCLOSING scope, same as
+             * an ordinary `let`, so one legitimately referencing an
+             * outer binding that happens to share the loop's own name
+             * (e.g. `(let ((loop f)) (let loop ((i (loop 5))) ...))`)
+             * must still resolve to that outer binding, not to a
+             * not-yet-real sentinel for the loop being defined. Emitting
+             * these after push_scope/bind_named_let (an earlier version
+             * of this fix did) let such an init resolve to the sentinel
+             * instead -- a Binding with slot == nullptr -- corrupting
+             * the generated IR (caught only by verifyModule/an
+             * assertions-disabled LLVM; would segfault inside
+             * LoadInst's constructor on an assertions-enabled build).
+             * Found by independent review. */
+            SmallVector<Value *, 8> init_vals;
+            for (int i = 0; i < (int)init_exprs.size(); ++i)
+                init_vals.push_back(emit_expr(cc, init_exprs[i]));
+
             cc.push_scope();
+            /* Bind the loop's own name into its own scope as a sentinel
+             * (see Binding::is_named_let) -- this makes ordinary,
+             * already-correct scope-lookup shadowing rules the single
+             * source of truth for emit_call's self-call check below,
+             * instead of a second, parallel bookkeeping scheme. */
+            cc.bind_named_let(loop_nm);
             std::vector<AllocaInst *> var_slots;
             for (int i = 0; i < (int)var_names.size(); ++i) {
-                Value *iv   = emit_expr(cc, init_exprs[i]);
-                auto  *slot = cc.alloc_root(var_names[i]);
-                cc.B.CreateStore(iv, slot);
+                auto *slot = cc.alloc_root(var_names[i]);
+                cc.B.CreateStore(init_vals[i], slot);
                 cc.bind(var_names[i], slot);
                 var_slots.push_back(slot);
             }
@@ -1289,6 +1411,12 @@ static Value *emit_expr(CompileCtx &cc, val_t expr) {
         const char *vn   = as_sym(as_pair(rst)->car)->data;
         Value     *val_v = emit_expr(cc, as_pair(as_pair(rst)->cdr)->car);
         if (Binding *b = cc.lookup(vn)) {
+            /* See emit_expr's symbol-reference case for why a named let's
+             * own sentinel binding (Binding::is_named_let) must never be
+             * treated as a real, storable slot. */
+            if (b->is_named_let)
+                throw std::runtime_error(
+                    "JIT: a named let's own name cannot be set!");
             if (b->is_cell) {
                 Value *cell_addr = cc.B.CreateLoad(cc.i64_t, b->slot);
                 Value *cell_ptr  = cc.B.CreateIntToPtr(cell_addr, cc.ptr_t);
@@ -1339,20 +1467,20 @@ static Value *emit_expr(CompileCtx &cc, val_t expr) {
             throw std::runtime_error(
                 std::string("JIT: unsupported special form '") + name + "'");
 
-        /* GLOBAL_ENV-only lookup is a known, NOT fully closed gap (see
-         * issue #111's follow-up discussion): a macro introduced by a
+        /* GLOBAL_ENV-only lookup here is fine: a macro introduced by a
          * let-syntax/letrec-syntax that lexically encloses this closure
          * -- e.g. (let-syntax ((m ...)) (lambda (n) (m n))) -- has no
          * GLOBAL_ENV binding, and the closure's own src_lambda is just
          * the inner (lambda (n) (m n)); the enclosing let-syntax form
          * itself is never part of that captured AST, so it never trips
-         * the "let-syntax" entry in UNSUPPORTED_FORMS above either. A
-         * correct fix needs the bytecode compiler to record, per-chunk,
-         * whether compilation ever resolved a name via a lexical
-         * syntax_locals scope (compiler_internal.h), and maybe_jit_bcc
-         * (runtime.c) to refuse promotion for such chunks -- deeper than
-         * this fix's scope; tracked separately rather than attempted
-         * here. */
+         * the "let-syntax" entry in UNSUPPORTED_FORMS above either. That
+         * gap (issue #114) is closed at the bytecode-compiler level
+         * instead, upstream of codegen ever running: resolve_syntax_local
+         * (compiler.c) marks Chunk::uses_local_macro (chunk.h) on every
+         * chunk from a local-macro reference up to the one owning it, and
+         * maybe_jit_bcc (runtime.c) refuses JIT promotion for such a
+         * chunk before curry_llvm_jit_compile is ever called -- this
+         * function never sees a let-syntax-local macro call at all. */
         val_t *slot = env_lookup_slot(GLOBAL_ENV, S(name));
         if (slot && vis_syntax(*slot))
             throw std::runtime_error(

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -419,6 +419,18 @@ void maybe_jit_bcc(BcClosure *cl) {
      * bodies no longer tree-walked); JIT promotion on top of that is a
      * further tier this specific case simply doesn't get yet. */
     if (cl->chunk->target_env != V_VOID) return;
+    /* A let-syntax/letrec-syntax-local macro use has no GLOBAL_ENV binding
+     * for codegen.cpp's own macro guard to find, and the enclosing
+     * let-syntax form itself is never part of this chunk's own src_lambda
+     * (it's evaluated once at define time to produce the closure, then
+     * discarded) -- so codegen.cpp can silently compile a call to such a
+     * macro's name as an ordinary procedure call with no way to catch it
+     * from the AST alone. classify_head (compiler_classic.c) sets this
+     * flag whenever compiling this chunk resolved a name via
+     * resolve_syntax_local; bailing out here, same as target_env just
+     * above, is the only place with the compile-time information needed
+     * to catch it. See issue #114. */
+    if (cl->chunk->uses_local_macro) return;
     if (cl->upval_count > 0 && !cl->chunk->upval_names) return;
     /* Skip JIT for self-referencing closures (named-let loops that capture
      * themselves as an upvalue).  The bytecode tail-call reuse gives O(1)

--- a/src/scc.c
+++ b/src/scc.c
@@ -43,7 +43,34 @@
 /* ── Format constants ───────────────────────────────────────────────────── */
 
 #define SCC_MAGIC       "CURRYBC"   /* 7 bytes, no NUL */
-#define SCC_FMT_VER     '\x07'   /* v7: OP_TAIL_APPLY inserted into the opcode
+#define SCC_FMT_VER     '\x08'   /* v8: persist Chunk.uses_local_macro (issue
+                                    #114 -- a let-syntax/letrec-syntax-local
+                                    macro use has no GLOBAL_ENV binding and
+                                    isn't textually present in src_lambda, so
+                                    maybe_jit_bcc (runtime.c) needs this flag,
+                                    set by classify_head at compile time, to
+                                    know to decline JIT promotion for such a
+                                    chunk. Not persisting it would silently
+                                    lose the #114 fix's protection on the
+                                    very next run of the same script once its
+                                    .scc cache exists. Contrast the pre-
+                                    existing, still-unpersisted target_env
+                                    field a few lines below in Chunk
+                                    (chunk.h): that one IS reached by ordinary
+                                    define-library bodies today (modules.c
+                                    compiles them against a real non-GLOBAL_ENV
+                                    target_env), but harmlessly so for .scc
+                                    purposes specifically, since library-body
+                                    chunks are compiled at runtime via vm_eval
+                                    and never pass through this file's
+                                    read/write path at all (only main.c's
+                                    top-level-script and -c paths do) --
+                                    uses_local_macro has no equivalent escape:
+                                    an ordinary hot top-level function using
+                                    let-syntax goes straight through the
+                                    normal script-caching path this file
+                                    implements.
+                                  v7: OP_TAIL_APPLY inserted into the opcode
                                     enum (issue #102 -- apply is now tail-
                                     callable), shifting every subsequent
                                     opcode's numeric value. Same bytecode-
@@ -366,6 +393,9 @@ static bool write_chunk(FILE *f, const Chunk *c) {
      * that up. */
     if (!write_const(f, c->src_lambda)) return false;
 
+    /* uses_local_macro (v8+): see SCC_FMT_VER's comment. */
+    if (!wb(f, (uint8_t)c->uses_local_macro)) return false;
+
     return true;
 }
 
@@ -642,6 +672,11 @@ static bool read_chunk(FILE *f, Chunk *c) {
 
     /* Source lambda form (v6+) */
     if (!read_const(f, &c->src_lambda)) return false;
+
+    /* uses_local_macro (v8+): see SCC_FMT_VER's comment. */
+    uint8_t local_macro;
+    if (!rb(f, &local_macro)) return false;
+    c->uses_local_macro = (bool)local_macro;
 
     return true;
 }

--- a/tests/jit_tests.scm
+++ b/tests/jit_tests.scm
@@ -252,6 +252,163 @@
            (jit-dp-user i) (+ i 1))
     (loop (+ i 1))))
 
+;;; 16. Locally shadowing an arithmetic operator must not be ignored ───────────
+;;; Regression coverage for issue #115: emit_call's ARITH2/ARITH1 fast paths
+;;; matched an operator's name directly against a builtin table with no
+;;; regard for local lexical scope, unlike every other name-dispatch in
+;;; codegen.cpp. A hot function shadowing +/-/*// etc. silently got the
+;;; builtin operator instead of its own local binding, with no error at
+;;; all -- a worse failure mode than #111's (that one at least raised a
+;;; catchable error).
+(define (jit-shadow-plus n) (let ((+ (lambda (a b) 99))) (+ n 1)))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT: locally shadowed + is not silently ignored when hot"
+           (jit-shadow-plus i) 99)
+    (loop (+ i 1))))
+
+(define (jit-shadow-minus n) (let ((- (lambda (a b) 77))) (- n 1)))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT: locally shadowed - is not silently ignored when hot"
+           (jit-shadow-minus i) 77)
+    (loop (+ i 1))))
+
+;;; Same bug class, found during review of the #115 fix above (issue #117):
+;;; the named-let self-call backedge matched the loop's name with no
+;;; cc.lookup check either -- a local binding shadowing the loop name
+;;; compiled to a backedge instead of an ordinary call, corrupting the loop
+;;; variable and hanging forever once JIT-promoted (worse than #115's
+;;; silently-wrong-answer outcome: an actual infinite loop). The named let
+;;; compiles inline into its enclosing function's own chunk (it isn't a
+;;; separate closure), so it's jit-shadow-loop itself -- not the inner
+;;; loop -- that needs to cross JIT_THRESHOLD for this to matter; each call
+;;; runs the loop to completion first regardless of tier, so this can't
+;;; hang indefinitely even pre-fix on a single call, only across repeated
+;;; calls once the enclosing closure gets promoted.
+(define (jit-shadow-loop n)
+  (let loop ((i 0))
+    (if (< i 5)
+        (loop (+ i 1))
+        (let ((loop (lambda (x) 7))) (loop 5)))))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT: locally shadowed named-let loop name is not silently ignored"
+           (jit-shadow-loop i) 7)
+    (loop (+ i 1))))
+
+;;; A first attempt at the #117 fix (a blanket "any local binding of this
+;;; name suppresses the backedge" check) overcorrected: a named let's own
+;;; name must still shadow an ENCLOSING binding of the same name and
+;;; self-recurse normally -- only a binding introduced INSIDE the loop
+;;; body (the case above) should suppress it. Found by independent review
+;;; of that first attempt, before it was ever merged.
+(define (jit-enclosing-shadow-loop n)
+  (let ((loop (lambda (x) 'outer)))
+    (let loop ((i 0))
+      (if (< i n) (loop (+ i 1)) i))))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT: named-let name correctly shadows an enclosing binding"
+           (jit-enclosing-shadow-loop 3) 3)
+    (loop (+ i 1))))
+
+;;; The sentinel fix itself (Binding::is_named_let) initially bound the
+;;; loop's own name into scope BEFORE its init expressions were compiled,
+;;; so an init expression legitimately referencing an ENCLOSING binding
+;;; sharing the loop's name resolved to the not-yet-real sentinel instead
+;;; -- a Binding with a null slot, corrupting the generated LLVM IR
+;;; (caught only by verifyModule on an assertions-disabled LLVM build,
+;;; would have asserted inside LoadInst's constructor on an assertions-
+;;; enabled one, rather than the clean "JIT failed, fell back to
+;;; bytecode" this now-fixed shape used to produce). Fixed by computing
+;;; every init value before the loop's own scope (and its sentinel)
+;;; exists, matching a named let's inits being evaluated in the ENCLOSING
+;;; scope, same as an ordinary `let`.
+;;;
+;;; This exact reordering also independently closes issue #119 (a
+;;; separate LLVM-JIT-only bug, filed then fixed within this same
+;;; commit): named-let init expressions were getting let*-style scoping
+;;; -- init i could see loop variables 0..i-1 bound by earlier iterations
+;;; of the same binding loop -- instead of R7RS's let-style "every init
+;;; sees only the enclosing scope". curry-jit-eval is used directly
+;;; (rather than driving a wrapper past JIT_THRESHOLD) so the asserted
+;;; value is unambiguously the JIT tier's own answer, not whichever tier
+;;; happened to run for a given call count.
+(check "JIT: named-let init expr resolves an enclosing shadow, not the sentinel"
+       (curry-jit-eval
+        '((lambda (n)
+            (let ((loop (lambda (x) (* x 10))))
+              (let loop ((i (loop n))) i)))
+          5))
+       50)
+
+;;; #119's own repro, confirming the fix generalizes beyond the specific
+;;; shadow-of-the-loop's-own-name case above: plain let* -> let scoping
+;;; for two ordinary loop variables (b's init `a` must see the outer
+;;; global, not the loop variable `a` bound moments earlier by the same
+;;; named let), no local-macro or shadowing involved at all.
+(define jit-119-a 100)
+(check "JIT: named-let init exprs use let (not let*) scoping"
+       (curry-jit-eval
+        '((lambda (n) (let loop ((jit-119-a 1) (b jit-119-a)) b)) 1))
+       100)
+
+;;; Referencing a named let's own name as a plain VALUE (not calling it)
+;;; has no real slot for the sentinel to provide -- this was already
+;;; unsupported before the sentinel existed (curry compiles named-let
+;;; purely as a backedge construct, never allocating a real closure for
+;;; the loop name), but used to at least compile to a global-variable
+;;; lookup that raised a clean "unbound variable" rather than reaching
+;;; LLVM's IR builder with a null operand. Must decline JIT promotion
+;;; cleanly (falls back to the bytecode interpreter, which is where this
+;;; correctly-consistent #t answer actually comes from at every call
+;;; count, not just below JIT_THRESHOLD) rather than crash.
+(define (jit-value-ref-loop n)
+  (let loop ((i 0)) (if (< i n) (loop (+ i 1)) (procedure? loop))))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT: named-let name used as a value declines promotion cleanly"
+           (jit-value-ref-loop 3) #t)
+    (loop (+ i 1))))
+
+;;; 17. A let-syntax/letrec-syntax-local macro must not be miscompiled ─────────
+;;; Regression coverage for issue #114, a residual gap in #111's fix: the
+;;; JIT's macro guard only checks GLOBAL_ENV, and a let-syntax-local macro
+;;; has no GLOBAL_ENV binding -- worse, the enclosing let-syntax form is
+;;; evaluated once at define time to produce the closure and is never part
+;;; of the closure's own src_lambda, so it can't be caught by string-
+;;; matching the AST either. Fixed at the bytecode-compiler level instead:
+;;; classify_head now marks Chunk::uses_local_macro whenever compiling a
+;;; chunk resolves a name via resolve_syntax_local, and maybe_jit_bcc
+;;; refuses JIT promotion for such a chunk, the same way it already does
+;;; for target_env.
+(define jit-ls-user
+  (let-syntax ((m (syntax-rules () ((_ x) (+ x 1)))))
+    (lambda (n) (m n))))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT bailout: let-syntax-local macro stays correct when hot"
+           (jit-ls-user i) (+ i 1))
+    (loop (+ i 1))))
+
+;;; The first attempt at this fix only marked the innermost chunk actually
+;;; referencing the macro, but codegen.cpp's emit_lambda compiles a nested
+;;; lambda literal INLINE into its enclosing closure's own native code --
+;;; so an unmarked OUTER chunk still got JIT-promoted and inline-compiled
+;;; straight through, missing the correctly-set inner chunk's flag
+;;; entirely. Found by two independent reviews before this ever merged.
+;;; resolve_syntax_local now marks every chunk from the reference point up
+;;; to the one owning the macro, not just the innermost one.
+(define jit-ls-nested-user
+  (let-syntax ((m (syntax-rules () ((_ x) (+ x 1)))))
+    (lambda (n) ((lambda () (m n))))))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT bailout: let-syntax-local macro stays correct one lambda deeper"
+           (jit-ls-nested-user i) (+ i 1))
+    (loop (+ i 1))))
+
 ;;; Summary ─────────────────────────────────────────────────────────────────────
 (newline)
 (display pass) (display " passed, ") (display fail) (display " failed")

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -472,7 +472,7 @@ printf 'CURRYBC\x03garbage-not-a-real-v3-body' > "$CACHEVER_SCC"
 out=$("$CURRY" "$CACHEVER_SCM")
 check "cache: stale/wrong-version .scc rejected cleanly, recompiles" "$out" "42"
 ver_byte=$(od -An -tx1 -j 7 -N 1 "$CACHEVER_SCC" | tr -d ' \n')
-check "cache: stale .scc rewritten in the current format version" "$ver_byte" "07"
+check "cache: stale .scc rewritten in the current format version" "$ver_byte" "08"
 
 # Regression: Chunk.src_lambda (procedure-lambda/procedure-arglist's data
 # source) used to never be written to .scc at all, so a script's SECOND run


### PR DESCRIPTION
## Summary
Fixes #114, #115, #117. Three related bugs in the LLVM JIT tier, all found via review of the #111 fix, all the same root cause: a codegen fast path resolving a name by string/table match before checking whether it's locally shadowed.

- **#115**: arithmetic operator fast path (`+`/`-`/`*`/`/` etc.) ignored local shadowing — silently wrong results, no error.
- **#117**: named-let self-call backedge had the same bug — a local binding shadowing the loop's own name got compiled as a backedge instead of an ordinary call, hanging forever.
- **#114**: a `let-syntax`/`letrec-syntax`-local macro (as opposed to top-level `define-syntax`) evaded the #111 guard entirely — no `GLOBAL_ENV` binding to find, and the enclosing `let-syntax` form is never part of the closure's own captured source AST. Fixed at the bytecode-compiler level (`Chunk::uses_local_macro`, persisted through `.scc`).

This fix went through **four rounds of independent review** (parallel code+security reviews, no shared context) before merging — three real regressions were caught and fixed along the way, all confirmed via live repros:
1. First #117 attempt overcorrected, breaking a named let whose name is shadowed by an *enclosing* binding. Fixed with a `Binding::is_named_let` sentinel that reuses the scope stack's own correct shadowing resolution instead of ad-hoc depth bookkeeping.
2. That sentinel was bound before its own init expressions were compiled, corrupting LLVM IR for a specific shape (masked by `verifyModule` on this Mac's assertions-disabled LLVM; would've asserted on an assertions-enabled build). Fixed by reordering — which also independently closed a separate bug, #119.
3. Fourth review confirmed the fix correct and complete, but caught one regression test asserting `number?` instead of an exact value (vacuous — passed whether or not the fix actually worked). Replaced with exact-value assertions, verified to actually catch the regression when reverted.

Filed separately, not fixed here: #118 (global rebinding of an arithmetic operator still ignored by the JIT) and #120 (the bytecode VM, not the JIT, has its own bug making a named let's own name visible during its own init expressions).

## Test plan
- [x] Full ctest suite passes under `BUILD_LLVM=ON` (118/118, `jit` suite 986/986 checks) and the default `BUILD_LLVM=OFF` build (117/117)
- [x] Every repro case from all four review rounds manually re-verified fixed, including #117's hang (via explicit timeout wrapper) and #114's `.scc` cache-hit round-trip
- [x] Regression tests confirmed to actually fail when the underlying fixes are reverted (not vacuous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
