### PR TITLE
fix(llvm): deoptimize JIT-compiled closures on global arithmetic redefinition

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -4077,4 +4077,9 @@ void builtins_register(val_t env) {
             for (int f = 0; f < nforms; f++) env_define(env, forms[f], v);
         }
     }
+
+    /* Snapshot the arithmetic operator names the LLVM JIT open-codes
+     * (issue #118) -- must run LAST, after every one of them is
+     * guaranteed bound to its real builtin value by everything above. */
+    jit_arith_snapshot_init();
 }

--- a/src/env.c
+++ b/src/env.c
@@ -343,13 +343,17 @@ val_t env_extend(val_t parent) {
 }
 
 void env_define(val_t env, val_t sym, val_t val) {
+    if (env == GLOBAL_ENV) jit_maybe_taint_global_arith(sym, val);
     frame_define(as_env(env), sym, val);
 }
 
 bool env_set(val_t env, val_t sym, val_t val) {
     EnvFrame *f = as_env(env);
     while (f) {
-        if (frame_set(f, sym, val)) return true;
+        if (frame_set(f, sym, val)) {
+            if (vptr(f) == GLOBAL_ENV) jit_maybe_taint_global_arith(sym, val);
+            return true;
+        }
         f = f->parent;
     }
     return false;

--- a/src/env.h
+++ b/src/env.h
@@ -66,6 +66,31 @@ val_t env_bind_arr(val_t parent_env, val_t params, int argc, val_t *argv);
 /* The global (top-level) environment */
 extern val_t GLOBAL_ENV;
 
+/* Implemented in runtime.c; a real body only when BUILD_LLVM is on
+ * (a cheap no-op otherwise), kept declared unconditionally so env.c's
+ * call sites need no #ifdef of their own. Called by env_define/env_set
+ * whenever GLOBAL_ENV specifically (not some other environment) is the
+ * one actually being mutated. Detects a global redefinition of one of
+ * the arithmetic operator names (+, -, *, /, <, ...) the LLVM JIT
+ * assumes are stable when open-coding them directly rather than doing a
+ * real global-variable lookup + call (see src/llvm/codegen.cpp's ARITH2/
+ * ARITH1 tables) -- see issue #118. Once any such redefinition is
+ * detected, permanently taints ALL future arithmetic fast-pathing
+ * (checked by codegen.cpp before ever taking the fast path, and by
+ * apply_arr's/vm.c's already-JIT-compiled-closure dispatch, which
+ * additionally deoptimizes any closure that was compiled and fast-
+ * pathed before the taint occurred: the taint check simply stops that
+ * dispatch from ever invoking the closure's now-permanently-wrong
+ * native code again -- jit_val itself is deliberately left as-is, not
+ * reset, since the taint is permanent and there's nothing to gain from
+ * ever recompiling that closure -- so it falls back to the bytecode
+ * interpreter every time instead, which always reads the
+ * CURRENT GLOBAL_ENV binding correctly). Global and one-way rather than
+ * per-symbol/per-closure: this kind of redefinition is expected to be
+ * extremely rare, so a coarse, simple, definitely-correct invalidation
+ * is preferred over a more precise but far more complex one. */
+void jit_maybe_taint_global_arith(val_t sym, val_t new_val);
+
 void env_init(void);
 
 #endif /* CURRY_ENV_H */

--- a/src/eval.h
+++ b/src/eval.h
@@ -136,6 +136,16 @@ extern "C" {
 extern CURRY_THREAD_LOCAL int g_jit_call_depth;
 int  jit_depth_save(void);
 void jit_depth_restore(int saved);
+
+/* Arithmetic-fast-path deopt (issue #118) -- see runtime.c's own comment
+ * above their definitions for the full design. jit_arith_snapshot_init()
+ * must be called exactly once, at the very end of builtins_register()
+ * (builtins.c), after every watched arithmetic name is guaranteed bound
+ * to its real builtin. jit_arith_tainted() is also declared to
+ * src/llvm/codegen.cpp's extern "C" block, so its signature here must
+ * stay C-compatible. */
+void jit_arith_snapshot_init(void);
+bool jit_arith_tainted(void);
 #define JIT_CALL_DEPTH_LIMIT 512
 #endif
 

--- a/src/llvm/codegen.cpp
+++ b/src/llvm/codegen.cpp
@@ -40,6 +40,13 @@ extern "C" {
 #include "../builtins.h"
 #include "../gc.h"
 #include "../lang_registry.h"
+/* Declared directly rather than pulling in the much larger eval.h (its
+ * actual home, runtime.c) -- matches how vm.c forward-declares
+ * maybe_jit_bcc locally instead of a full-header include. See eval.h's
+ * own comment and runtime.c's definition for the full design (issue
+ * #118): once true, permanently, ARITH2/ARITH1 below must never be
+ * consulted again for any future compilation. */
+bool jit_arith_tainted(void);
 }
 
 #include <llvm/IR/IRBuilder.h>
@@ -414,8 +421,24 @@ static Value *emit_call(CompileCtx &cc, val_t fn_expr, val_t args) {
      * this function) does NOT check cc.lookup either, but shadowing one
      * of those keywords is R7RS-nonconformant on the plain interpreter
      * tier too (no tier-specific divergence) -- a separate, pre-existing
-     * question, not a JIT-only bug like this one. */
-    if (vis_symbol(fn_expr) && !cc.lookup(as_sym(fn_expr)->data)) {
+     * question, not a JIT-only bug like this one.
+     *
+     * Also gated on !jit_arith_tainted() (issue #118): a hot function's
+     * fast-pathed arithmetic still silently ignored a GLOBAL redefinition
+     * of +, -, *, / etc (e.g. (define (+ a b) 99) at top level, after some
+     * OTHER function using + was already JIT-compiled) -- cc.lookup only
+     * ever consults this codegen's own local scope stack, never
+     * GLOBAL_ENV. jit_arith_tainted() is a global, permanent, one-way
+     * flag set the instant any watched arithmetic name is ever globally
+     * redefined (env.c hooks env_define/env_set); once true, this
+     * function -- for every future compilation, not just ones touching
+     * the specific redefined name -- must fall through to the generic
+     * call path below instead of consulting ARITH2/ARITH1 at all.
+     * apply_arr/vm.c's OP_CALL-family fast dispatch (runtime.c) checks
+     * the same flag before ever invoking an ALREADY-compiled closure's
+     * native code, which is what actually deoptimizes a closure whose
+     * baked-in fast path predates the taint. */
+    if (vis_symbol(fn_expr) && !cc.lookup(as_sym(fn_expr)->data) && !jit_arith_tainted()) {
         std::string op_nm = as_sym(fn_expr)->data;
 
         /* Variadic fold: (+), (*) → identity; (- x) → negate; (op a b c…) → fold */

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -378,6 +378,107 @@ void jit_depth_pop(void)  { g_jit_call_depth--; }
 int  jit_depth_save(void)        { return g_jit_call_depth; }
 void jit_depth_restore(int saved) { g_jit_call_depth = saved; }
 
+/* ---- Arithmetic-fast-path deopt (issue #118) ----
+ *
+ * codegen.cpp's ARITH2/ARITH1 tables open-code +, -, *, /, <, sqrt, etc.
+ * as direct C-helper calls, assuming those names are never redefined --
+ * cheaper than a real global-variable lookup + generic call on every
+ * arithmetic operation, but wrong if a program later does
+ * (define (+ a b) ...) or (set! + ...). Rather than pay a per-call
+ * runtime guard to check this on every arithmetic operation (which
+ * would erase most of the fast path's benefit) or track precisely which
+ * already-JIT-compiled closures assumed which specific operator names
+ * (a much larger undertaking), this uses one global, permanent, one-way
+ * flag: the instant ANY watched arithmetic name is redefined away from
+ * its original builtin value, ALL arithmetic fast-pathing -- for every
+ * closure, whether or not it uses the redefined name specifically --
+ * stops forever. This is coarse (an unrelated closure loses a
+ * performance optimization it never needed to lose) but simple and
+ * definitely correct, matching the expectation that redefining core
+ * arithmetic operators at runtime is vanishingly rare in practice.
+ *
+ * Two consumers:
+ *   - Every already-JIT-compiled closure's native-fast-call dispatch
+ *     (apply_arr below, and the OP_CALL/OP_TAIL_CALL-family inline fast
+ *     paths in vm.c) checks jit_arith_tainted() before ever invoking a
+ *     closure's compiled native code -- this is the actual "deopt": a
+ *     closure whose native code still contains a now-stale direct call
+ *     to num_add (baked in at compile time, impossible to patch in
+ *     place) simply stops being reachable through the fast dispatch and
+ *     falls through to the bytecode interpreter instead, which always
+ *     reads GLOBAL_ENV's CURRENT binding correctly. No need to reset
+ *     the closure's jit_val to force recompilation: since the taint is
+ *     permanent, there would be nothing to gain from ever recompiling
+ *     it, so it's simply never called through the native path again.
+ *   - codegen.cpp checks jit_arith_tainted() before consulting ARITH2/
+ *     ARITH1 at all, so any closure compiled (or recompiled) after the
+ *     taint occurred never takes the fast path in the first place. */
+#ifdef BUILD_LLVM
+/* Plain int, NOT _Atomic-qualified: __atomic_load_n/__atomic_store_n are
+ * GCC/Clang's low-level intrinsics, which operate directly on an
+ * ordinary variable's address -- they reject a C11 _Atomic-qualified
+ * type outright (that qualifier is for the separate stdatomic.h
+ * atomic_load/atomic_store function-style API instead). Matches every
+ * other atomic variable already in this file (cl->jit_val, cl->call_count
+ * in BcClosure, vm.h), all plain-typed. */
+static int g_jit_arith_snapshot_ready = 0;
+static int g_jit_arith_tainted        = 0;
+
+/* Every name ARITH2/ARITH1 (src/llvm/codegen.cpp) open-codes. Kept in
+ * sync by hand -- small, stable list, not worth a shared header just
+ * for this. */
+static const char *const JIT_ARITH_WATCHED_NAMES[] = {
+    "+", "-", "*", "/", "<", ">", "<=", ">=", "=",
+    "inexact", "exact->inexact", "log", "exp", "sqrt",
+    "sin", "cos", "abs", "floor", "ceiling", "truncate", "round",
+};
+#define JIT_ARITH_WATCHED_COUNT \
+    (sizeof(JIT_ARITH_WATCHED_NAMES) / sizeof(JIT_ARITH_WATCHED_NAMES[0]))
+
+static val_t g_jit_arith_watched_syms[JIT_ARITH_WATCHED_COUNT];
+static val_t g_jit_arith_originals[JIT_ARITH_WATCHED_COUNT];
+#endif
+
+/* Called once, at the very end of builtins_register() (builtins.c) --
+ * every watched name is guaranteed bound to its real builtin by then.
+ * Snapshotting here, rather than treating "unset" as "never redefined",
+ * means the registration writes builtins_register() itself performs
+ * are never mistaken for a user redefinition. */
+void jit_arith_snapshot_init(void) {
+#ifdef BUILD_LLVM
+    for (size_t i = 0; i < JIT_ARITH_WATCHED_COUNT; i++) {
+        val_t sym = sym_intern_cstr(JIT_ARITH_WATCHED_NAMES[i]);
+        g_jit_arith_watched_syms[i] = sym;
+        g_jit_arith_originals[i]    = env_lookup_or_false(GLOBAL_ENV, sym);
+    }
+    __atomic_store_n(&g_jit_arith_snapshot_ready, true, __ATOMIC_RELEASE);
+#endif
+}
+
+void jit_maybe_taint_global_arith(val_t sym, val_t new_val) {
+#ifdef BUILD_LLVM
+    if (__atomic_load_n(&g_jit_arith_tainted, __ATOMIC_RELAXED)) return;
+    if (!__atomic_load_n(&g_jit_arith_snapshot_ready, __ATOMIC_ACQUIRE)) return;
+    for (size_t i = 0; i < JIT_ARITH_WATCHED_COUNT; i++) {
+        if (g_jit_arith_watched_syms[i] == sym) {
+            if (new_val != g_jit_arith_originals[i])
+                __atomic_store_n(&g_jit_arith_tainted, true, __ATOMIC_RELEASE);
+            return;
+        }
+    }
+#else
+    (void)sym; (void)new_val;
+#endif
+}
+
+bool jit_arith_tainted(void) {
+#ifdef BUILD_LLVM
+    return __atomic_load_n(&g_jit_arith_tainted, __ATOMIC_ACQUIRE);
+#else
+    return false;
+#endif
+}
+
 #ifdef BUILD_LLVM
 /* Build (let ((name0 'val0) ...) src_lambda) to inject captured upvalue
  * values as constants so the JIT compiles them in without needing runtime
@@ -470,7 +571,7 @@ val_t apply_arr(val_t proc, int argc, val_t *argv) {
          * Depth guard prevents C-stack overflow for deeply-recursive functions:
          * beyond JIT_CALL_DEPTH_LIMIT we fall through to the bytecode
          * interpreter which reuses its frame via OP_TAIL_CALL (O(1) C-stack). */
-        if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+        if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT && !jit_arith_tainted()
             && curry_profiling_level == 0) {
             vm_check_arity(cl, argc);
             JitClosure *jc = as_jitclos(cl->jit_val);

--- a/src/vm.c
+++ b/src/vm.c
@@ -726,6 +726,17 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             GlobCacheEntry *cache = GCACHE;
             EnvFrame *root = as_env(TARGET_ENV);
             uint32_t root_ver = atomic_load_explicit((_Atomic uint32_t *)&root->version, memory_order_acquire);
+            /* Compiled top-level set! on a bytecode-VM-compiled chunk goes
+             * straight through this opcode -- gc_wb_slot below, never
+             * env_set (env.c) -- so it must also hook the arithmetic-
+             * redefinition taint check (issue #118) directly here.
+             * env_define's OP_DEF_GLOBAL counterpart already routes
+             * through env_define itself and needs no separate hook.
+             * TARGET_ENV == GLOBAL_ENV mirrors env_set's own check: a
+             * set! against some other root frame (a define-library body)
+             * isn't a real global-arithmetic redefinition. */
+            if (TARGET_ENV == GLOBAL_ENV)
+                jit_maybe_taint_global_arith(CONSTS[ci], val);
             if (__builtin_expect(cache != NULL && cache[ci].slot != NULL &&
                                  cache[ci].version == root_ver, 1)) {
                 gc_wb_slot(cache[ci].slot, val);
@@ -1068,7 +1079,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             if (vis_bcclosure(callee)) {
                 BcClosure *cl = as_bcclosure(callee);
                 /* Tiered JIT: hot-swap to native code once compiled. */
-                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT && !jit_arith_tainted()
                     && curry_profiling_level == 0 && !vm_debug_active) {
                     vm_check_arity(cl, argc2);
                     JitClosure *jc = as_jitclos(cl->jit_val);
@@ -1125,7 +1136,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             if (vis_bcclosure(callee)) {
                 BcClosure *cl = as_bcclosure(callee);
                 /* Tiered JIT: hot-swap to native code once compiled. */
-                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT && !jit_arith_tainted()
                     && curry_profiling_level == 0 && !vm_debug_active) {
                     vm_check_arity(cl, argc2);
                     JitClosure *jc = as_jitclos(cl->jit_val);
@@ -1194,7 +1205,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
              * unlike callee identity (statically proven), jit_val is NOT
              * statically known and must still be checked every
              * iteration. */
-            if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+            if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT && !jit_arith_tainted()
                 && curry_profiling_level == 0 && !vm_debug_active) {
                 vm_check_arity(cl, argc2);
                 JitClosure *jc = as_jitclos(cl->jit_val);
@@ -1259,7 +1270,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
 
             if (vis_bcclosure(callee)) {
                 BcClosure *cl = as_bcclosure(callee);
-                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT && !jit_arith_tainted()
                     && curry_profiling_level == 0 && !vm_debug_active) {
                     vm_check_arity(cl, argc2);
                     JitClosure *jc = as_jitclos(cl->jit_val);
@@ -1318,7 +1329,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
 
             if (vis_bcclosure(callee)) {
                 BcClosure *cl = as_bcclosure(callee);
-                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT
+                if (vis_jitclosure(cl->jit_val) && g_jit_call_depth < JIT_CALL_DEPTH_LIMIT && !jit_arith_tainted()
                     && curry_profiling_level == 0 && !vm_debug_active) {
                     vm_check_arity(cl, argc2);
                     JitClosure *jc = as_jitclos(cl->jit_val);

--- a/tests/jit_tests.scm
+++ b/tests/jit_tests.scm
@@ -409,6 +409,63 @@
            (jit-ls-nested-user i) (+ i 1))
     (loop (+ i 1))))
 
+;;; 18. Global redefinition of an arithmetic operator must deopt already-
+;;; JIT-compiled closures and stop future fast-pathing (issue #118) ──────────
+;;; codegen.cpp's ARITH2/ARITH1 fast paths only ever checked LOCAL
+;;; shadowing (#115) -- a top-level (define (- a b) ...) or (set! - ...)
+;;; after some OTHER function using - was already JIT-compiled was still
+;;; silently ignored: the already-compiled native code keeps calling the
+;;; builtin num_sub forever, since a JIT-compiled function's machine code
+;;; can't be patched in place. Fixed with a global, permanent, one-way
+;;; taint flag (env.c hooks env_define/env_set on GLOBAL_ENV): once any
+;;; watched arithmetic name is ever redefined away from its original
+;;; value, apply_arr/vm.c's fast dispatch (runtime.c) stops invoking ANY
+;;; already-compiled closure's native code (falling back to the bytecode
+;;; interpreter, which always reads the CURRENT global binding correctly)
+;;; and codegen.cpp stops consulting ARITH2/ARITH1 for any future
+;;; compilation. Deliberately placed LAST in this file and using `-`
+;;; rather than `+`: the taint this test triggers is global and permanent
+;;; for the rest of this process, and `check`'s own pass/fail counting
+;;; above uses `+` internally -- redefining `+` here would corrupt every
+;;; later `check` call's own bookkeeping, not just the code under test.
+;;; set! specifically, run FIRST and using a different operator (*) than
+;;; the define-based test below (-): OP_STORE_GLOBAL (vm.c) bypasses
+;;; env_set entirely for a compiled top-level set!, so it needed its own
+;;; separate hook -- verified missing initially (independent security
+;;; review): (set! + myplus) after warmup still called the builtin, no
+;;; taint at all. Must run before the define-based test so this exercises
+;;; set!'s OWN path actually causing the (permanent, global) taint,
+;;; rather than piggybacking on an already-tainted flag from define.
+(define (jit-118-set-user n) (* n 2))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT: * still correct before any global redefinition"
+           (jit-118-set-user i) (* i 2))
+    (loop (+ i 1))))
+;;; 999, not e.g. 2: an earlier version of this test used a redefinition
+;;; whose result happened to numerically coincide with what the STALE
+;;; builtin would also produce for the same arguments ((* 1 2) is 2, and
+;;; the broken redefinition also returned 2) -- a false pass that looked
+;;; like the fix worked whether or not the taint hook actually fired.
+;;; Confirmed live against a deliberately-reverted build: with the fix
+;;; removed this test as originally written still printed the "expected"
+;;; value by coincidence, while a redefinition returning a value distinct
+;;; from every plausible correct answer (999) correctly failed.
+(define (jit-118-myplus a b) 999)
+(set! * jit-118-myplus)
+(check "JIT: global set! of * takes effect for an already-compiled caller"
+       (jit-118-set-user 1) 999)
+
+(define (jit-118-user n) (- n 1))
+(let loop ((i 0))
+  (when (< i 60)
+    (check "JIT: - still correct before any global redefinition"
+           (jit-118-user i) (- i 1))
+    (loop (+ i 1))))
+(define (- a b) 99)
+(check "JIT: global redefinition of - takes effect for an already-compiled caller"
+       (jit-118-user 1) 99)
+
 ;;; Summary ─────────────────────────────────────────────────────────────────────
 (newline)
 (display pass) (display " passed, ") (display fail) (display " failed")


### PR DESCRIPTION
## Summary
Fixes #118. The #115 fix only guarded LOCAL shadowing of arithmetic operators in the JIT's open-coded fast path (`+`/`-`/`*`/`/`/etc, `src/llvm/codegen.cpp`'s `ARITH2`/`ARITH1` tables) — a GLOBAL redefinition after some other function using the operator was already JIT-compiled was still silently ignored, since the already-compiled native code can't be patched in place.

Implements a full "deopt" system (the most invasive of three options presented — document/runtime-guard/full-deopt — chosen for correctness over performance):
- `env_define`/`env_set` (`src/env.c`) and `OP_STORE_GLOBAL` (`src/vm.c`, added after review found the first version missed it) hook a new `jit_maybe_taint_global_arith` check whenever `GLOBAL_ENV` is actually mutated
- A global, permanent, one-way taint flag, snapshotted against real builtin values once at the end of `builtins_register()`
- `codegen.cpp` stops consulting the fast-path tables once tainted; `apply_arr`/`vm.c`'s inline fast dispatch stop invoking already-compiled native code once tainted (the actual deopt — falls back to the bytecode interpreter, which always reads the current binding correctly)

Went through two rounds of independent review (parallel code+security, no shared context):
1. Both independently caught that the first version's `set!` path was broken — `OP_STORE_GLOBAL` bypasses `env_set` entirely for a compiled top-level `set!`, so `(set! + f)` on an already-hot function kept using stale native code despite the commit message and test claiming it was covered. Fixed.
2. Code review additionally caught a subtler bug in my own fix for #1: the new `set!`-based test used values where the broken and fixed behavior happened to produce the same number (`(* 1 2)` and the test's own broken redefinition both equaled `2`) — a false-passing test. Confirmed by reverting the fix and re-running (still "passed"); fixed by using a value distinct from any plausible correct answer, then re-confirmed the test now genuinely fails on a reverted build.

Known, documented, accepted remaining gap: `apply_arr`'s other JIT dispatch site (a bare `JitClosure` value, reachable only via the `curry-jit-eval`/`curry-jit-call` debug builtins) has no bytecode fallback to deopt to. Narrow, expert-facing, not part of ordinary language semantics.

## Test plan
- [x] Full ctest suite passes under `BUILD_LLVM=ON` (118/118, `jit` suite 1108/1108 checks) and the default `BUILD_LLVM=OFF` build (117/117; one flaky `websocket` timeout confirmed unrelated via isolated rerun)
- [x] Both `define`- and `set!`-based repros from the issue and the reviews manually re-verified fixed
- [x] Regression tests confirmed to actually fail when the underlying fix is reverted (not vacuous — verified for both the `define` and `set!` paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
