### PR TITLE
fix(compiler): named let's own name is not visible during its own init expressions

### DIFF
--- a/src/compiler_classic.c
+++ b/src/compiler_classic.c
@@ -810,16 +810,37 @@ static void compile_let(Compiler *c, val_t args, bool tail, int line) {
     /* Named let: (let loop ((x v) ...) body)
        Semantics: letrec ((loop (lambda (x ...) body))) (loop v ...)
 
-       Compiled as a zero-arg outer wrapper to isolate the loop's frame:
+       Compiled as an outer wrapper (arity = argc, one param per loop
+       variable) to isolate the loop's frame:
+         parent (c): compile each init value; OP_CLOSURE outer-wrapper;
+                     OP_CALL/OP_TAIL_CALL argc
          outer-wrapper:
-           slot 0 = loop (void initially, then the closure)
+           params 0..argc-1 = the loop variables (ordinary arguments,
+             already-computed values received from the parent's call --
+             ISSUE #120: an earlier version of this instead had outer
+             itself both hold loop_name's slot AND compile the init
+             expressions, at zero arity, computing/receiving them
+             internally rather than as call arguments -- which meant
+             loop_name was already a valid local (add_local'd before
+             compiling the inits) *while compiling* each init
+             expression, and by the time the inits actually RAN (after
+             OP_STORE_LOCAL had already written the real closure into
+             that slot), any init referencing loop_name saw the fully-
+             constructed closure instead of R7RS's mandated "loop_name
+             is not yet bound while evaluating its own inits, which run
+             in the ENCLOSING scope". Moving init compilation to run
+             in `c` (this function's own parameter, the true enclosing
+             scope) instead of `outer` fixes this outright, mirroring
+             exactly how the plain (non-named) let branch a few lines
+             below already computes its own args in `c` before calling
+             into a freshly compiled lambda.
+           slot argc = loop_name (void initially, then the closure)
            push void placeholder
-           push OP_CLOSURE for loop (captures slot 0 as upvalue)
-           OP_STORE_LOCAL 0        ; slot 0 = closure
-           OP_LOAD_LOCAL 0         ; push closure as callee
-           compile each init value  ; push args
-           OP_TAIL_CALL N          ; jump into the loop
-         parent: OP_CLOSURE outer-wrapper; OP_CALL/OP_TAIL_CALL 0 */
+           push OP_CLOSURE for loop (captures slot argc as upvalue)
+           OP_STORE_LOCAL argc      ; slot argc = closure
+           OP_LOAD_LOCAL argc       ; push closure as callee
+           OP_LOAD_LOCAL 0..argc-1  ; forward outer's own params as args
+           OP_TAIL_CALL argc        ; jump into the loop */
     if (vis_symbol(bindings)) {
         val_t loop_name = bindings;
         require_min_args(body, 1, "let");  /* named-let's own bindings list */
@@ -837,36 +858,39 @@ static void compile_let(Compiler *c, val_t args, bool tail, int line) {
         val_t fwd = V_NIL;
         while (vis_pair(params)) { fwd = scm_cons(vcar(params), fwd); params = vcdr(params); }
 
-        /* Zero-arg outer wrapper */
+        /* Outer wrapper, now with arity = argc instead of 0 */
         Compiler outer;
         init_compiler(&outer, c, as_sym(loop_name)->data);
-        outer.chunk->arity = 0;
+        /* Slots 0..argc-1 = the loop variables, matching an ordinary
+         * function's own param-binding convention exactly (same helper
+         * compile_lambda itself uses). */
+        outer.chunk->arity = compile_params(&outer, fwd);
 
-        /* Slot 0 = loop name (void placeholder) */
+        /* One more slot (argc) = loop_name's own self-reference
+         * placeholder, captured as an upvalue by the inner recursive
+         * lambda below -- unchanged from before, just moved from slot 0
+         * to slot argc now that the params occupy 0..argc-1. */
         add_local(&outer, loop_name);
         mark_initialised(&outer);
         emit(&outer, OP_VOID, line);
 
-        /* Inner loop lambda; loop_name resolves as upvalue from outer's slot 0.
-         * Arm the self-tail-call thread-local so a tail-position call to
-         * loop_name within this exact body compiles to OP_SELF_TAIL_CALL
-         * instead of the ordinary upvalue-load-then-call sequence -- see
-         * Compiler::self_tail_name's comment and compile_call. The
-         * set!-scan runs over the RAW (uncompiled) body once, up front,
-         * so every self-tail-call site compiled anywhere in this body
-         * consistently sees the same answer regardless of where in the
-         * body a set! to loop_name might textually appear relative to
-         * a given tail call. */
+        /* Inner loop lambda; loop_name resolves as upvalue from outer's
+         * slot argc. Arm the self-tail-call thread-local so a tail-
+         * position call to loop_name within this exact body compiles to
+         * OP_SELF_TAIL_CALL instead of the ordinary upvalue-load-then-
+         * call sequence -- see Compiler::self_tail_name's comment and
+         * compile_call. The set!-scan runs over the RAW (uncompiled)
+         * body once, up front, so every self-tail-call site compiled
+         * anywhere in this body consistently sees the same answer
+         * regardless of where in the body a set! to loop_name might
+         * textually appear relative to a given tail call. */
         g_compile_self_tail_name    = loop_name;
         g_compile_self_tail_mutated = body_mentions_set_target(c, body, loop_name);
         compile_lambda(&outer, fwd, body, as_sym(loop_name)->data, line);
-        emit_ab(&outer, OP_STORE_LOCAL, 0, line);  /* store closure → slot 0 */
-        emit_ab(&outer, OP_LOAD_LOCAL,  0, line);  /* callee */
-        b = bindings;
-        while (vis_pair(b)) {
-            compile(&outer, vcar(vcdr(vcar(b))), false, line);
-            b = vcdr(b);
-        }
+        emit_ab(&outer, OP_STORE_LOCAL, (uint8_t)argc, line);  /* store closure → slot argc */
+        emit_ab(&outer, OP_LOAD_LOCAL,  (uint8_t)argc, line);  /* callee */
+        for (int i = 0; i < argc; i++)
+            emit_ab(&outer, OP_LOAD_LOCAL, (uint8_t)i, line);  /* forward outer's own params as args */
         emit_ab(&outer, OP_TAIL_CALL, (uint8_t)argc, line);
         Chunk *och = end_compiler(&outer);
 
@@ -876,7 +900,16 @@ static void compile_let(Compiler *c, val_t args, bool tail, int line) {
             chunk_emit(c->chunk, outer.upvals[i].is_local ? 1 : 0, line);
             chunk_emit(c->chunk, (uint8_t)outer.upvals[i].index,   line);
         }
-        emit_ab(c, tail ? OP_TAIL_CALL : OP_CALL, 0, line);
+        /* Compile each init value in c's OWN scope -- the true
+         * enclosing environment R7RS mandates -- rather than outer's,
+         * pushed after the callee exactly like the plain-let branch
+         * below does for its own lambda's call args. See issue #120. */
+        b = bindings;
+        while (vis_pair(b)) {
+            compile(c, vcar(vcdr(vcar(b))), false, line);
+            b = vcdr(b);
+        }
+        emit_ab(c, tail ? OP_TAIL_CALL : OP_CALL, (uint8_t)argc, line);
         return;
     }
 

--- a/src/ir_emit.c
+++ b/src/ir_emit.c
@@ -810,17 +810,31 @@ void ir_emit(Compiler *c, IRNode *n) {
          * loop_name would alias whatever real local already lives in
          * slot 0, and the OP_STORE_LOCAL below would then overwrite that
          * unrelated local's actual runtime value. Splicing needs room for
-         * loop_name (1), the reloaded callee copy (1), and each binding
-         * (argc) simultaneously live at once; below that, fall back to
-         * building a real, separate closure for the wrapper exactly the
-         * way this case always did before this landing -- correctness
-         * over the optimization when the frame is already nearly full,
-         * matching the let-branch's own fallback philosophy exactly. */
+         * loop_name (1), the reloaded callee copy (1), each binding's
+         * ALREADY-computed init value (argc, held in a pending slot until
+         * the reload below re-pushes it -- see issue #120's own fix,
+         * which introduced this second `argc`-sized reservation to
+         * correctly compile each init in the caller's own enclosing
+         * scope), and each binding's RELOADED copy (argc again)
+         * simultaneously live at once: 2*argc + 2, not argc + 2. Below
+         * that, fall back to building a real, separate closure for the
+         * wrapper exactly the way this case always did before this
+         * landing -- correctness over the optimization when the frame is
+         * already nearly full, matching the let-branch's own fallback
+         * philosophy exactly. (Independent security review, #120's own
+         * follow-up: reserve_pending_slot's own bounds check keeps this
+         * currently inert -- nothing is compiled between the two
+         * reservation loops and release_pending_slots for anything to
+         * observe a wrong local_count through -- but the guard's
+         * arithmetic should still describe the peak it actually gates,
+         * not the pre-#120 shape's smaller one, since any future change
+         * compiling something in between would turn a latent
+         * miscounting into a live one.) */
         val_t loop_name0 = n->as.named_let.loop_name;
         val_t bindings0  = n->as.named_let.bindings;
         int   argc0 = 0;
         for (val_t b = bindings0; vis_pair(b); b = vcdr(b)) argc0++;
-        if (c->local_count + 2 + argc0 >= MAX_LOCALS) {
+        if (c->local_count + 2 * argc0 + 2 >= MAX_LOCALS) {
             val_t body0 = n->as.named_let.body;
             val_t params0 = V_NIL;
             for (val_t b = bindings0; vis_pair(b); b = vcdr(b))
@@ -828,9 +842,16 @@ void ir_emit(Compiler *c, IRNode *n) {
             val_t fwd0 = V_NIL;
             while (vis_pair(params0)) { fwd0 = scm_cons(vcar(params0), fwd0); params0 = vcdr(params0); }
 
+            /* Outer wrapper, arity = argc0 instead of 0: issue #120,
+             * same fix and same reasoning as compile_let's own outer-
+             * wrapper (compiler_classic.c) -- inits must be compiled by
+             * `c` (the true enclosing scope), not by `outer` itself,
+             * so a reference to loop_name0 within an init expression
+             * can never resolve to this named-let's own about-to-be-
+             * created self-reference. */
             Compiler outer;
             init_compiler(&outer, c, as_sym(loop_name0)->data);
-            outer.chunk->arity = 0;
+            outer.chunk->arity = compile_params(&outer, fwd0);
             add_local(&outer, loop_name0);
             mark_initialised(&outer);
             emit(&outer, OP_VOID, n->line);
@@ -839,18 +860,10 @@ void ir_emit(Compiler *c, IRNode *n) {
             IRNode *loop_lambda0 = ir_lower_lambda(&outer, fwd0, body0,
                                                     as_sym(loop_name0)->data, n->line);
             ir_emit(&outer, loop_lambda0);
-            emit_ab(&outer, OP_STORE_LOCAL, 0, n->line);
-            emit_ab(&outer, OP_LOAD_LOCAL,  0, n->line);
-            {
-                int osaved = outer.local_count;
-                reserve_pending_slot(&outer);
-                for (val_t b = bindings0; vis_pair(b); b = vcdr(b)) {
-                    IRNode *arg = ir_lower(&outer, vcar(vcdr(vcar(b))), false, n->line);
-                    ir_emit(&outer, arg);
-                    reserve_pending_slot(&outer);
-                }
-                release_pending_slots(&outer, osaved);
-            }
+            emit_ab(&outer, OP_STORE_LOCAL, (uint8_t)argc0, n->line);
+            emit_ab(&outer, OP_LOAD_LOCAL,  (uint8_t)argc0, n->line);
+            for (int i = 0; i < argc0; i++)
+                emit_ab(&outer, OP_LOAD_LOCAL, (uint8_t)i, n->line);
             emit_ab(&outer, OP_TAIL_CALL, (uint8_t)argc0, n->line);
             Chunk *och = end_compiler(&outer);
 
@@ -860,7 +873,20 @@ void ir_emit(Compiler *c, IRNode *n) {
                 chunk_emit(c->chunk, outer.upvals[i].is_local ? 1 : 0, n->line);
                 chunk_emit(c->chunk, (uint8_t)outer.upvals[i].index,   n->line);
             }
-            emit_ab(c, n->tail ? OP_TAIL_CALL : OP_CALL, 0, n->line);
+            /* Compile each init value in c's OWN scope, pushed after
+             * the callee -- the true enclosing environment R7RS
+             * mandates. See issue #120. */
+            {
+                int osaved = c->local_count;
+                reserve_pending_slot(c);  /* the callee just pushed via OP_CLOSURE above */
+                for (val_t b = bindings0; vis_pair(b); b = vcdr(b)) {
+                    IRNode *arg = ir_lower(c, vcar(vcdr(vcar(b))), false, n->line);
+                    ir_emit(c, arg);
+                    reserve_pending_slot(c);
+                }
+                release_pending_slots(c, osaved);
+            }
+            emit_ab(c, n->tail ? OP_TAIL_CALL : OP_CALL, (uint8_t)argc0, n->line);
             return;
         }
 
@@ -902,7 +928,29 @@ void ir_emit(Compiler *c, IRNode *n) {
         val_t fwd = V_NIL;
         while (vis_pair(params)) { fwd = scm_cons(vcar(params), fwd); params = vcdr(params); }
 
-        int saved     = c->local_count;
+        int saved = c->local_count;
+
+        /* Compile each init value FIRST, into temporary pending slots,
+         * BEFORE loop_name exists anywhere in c's own locals table --
+         * issue #120: the previous shape add_local'd loop_name (below)
+         * BEFORE compiling the inits, so a reference to loop_name within
+         * an init expression incorrectly resolved to this named-let's
+         * own about-to-be-created self-reference (and, worse, by the
+         * time the inits actually RAN at runtime -- after OP_STORE_LOCAL
+         * had already written the real closure into that slot -- such a
+         * reference saw the fully-constructed closure) instead of R7RS's
+         * mandated "loop_name is not yet bound while evaluating its own
+         * inits, which run in the ENCLOSING scope". Each value lands at
+         * a known physical position (arg_base + i) that nothing above
+         * this point could yet alias, exactly like any other pending
+         * call argument. */
+        int arg_base = c->local_count;
+        for (val_t b = bindings; vis_pair(b); b = vcdr(b)) {
+            IRNode *arg = ir_lower(c, vcar(vcdr(vcar(b))), false, n->line);
+            ir_emit(c, arg);
+            reserve_pending_slot(c);
+        }
+
         int loop_slot = add_local(c, loop_name);
         mark_initialised(c);
         emit(c, OP_VOID, n->line);
@@ -919,37 +967,56 @@ void ir_emit(Compiler *c, IRNode *n) {
         emit_ab(c, OP_STORE_LOCAL, (uint8_t)loop_slot, n->line);  /* store closure */
         emit_ab(c, OP_LOAD_LOCAL,  (uint8_t)loop_slot, n->line);  /* callee */
         reserve_pending_slot(c);  /* the callee just loaded, a pending value too */
-        for (val_t b = bindings; vis_pair(b); b = vcdr(b)) {
-            IRNode *arg = ir_lower(c, vcar(vcdr(vcar(b))), false, n->line);
-            ir_emit(c, arg);
+        /* Re-push a fresh copy of each already-computed init value from
+         * its arg_base+i position -- these have no discoverable NAME
+         * (reserve_pending_slot's placeholders never match a real
+         * lookup), but OP_LOAD_LOCAL addresses a physical slot by plain
+         * numeric index, same trick compile_let's own outer-wrapper fix
+         * uses to forward its own params. This assembles the calling
+         * convention's required contiguous [callee, arg1, ..., argN]
+         * layout even though the args were computed earlier, at lower
+         * physical positions, than the callee. */
+        for (int i = 0; i < argc; i++) {
+            emit_ab(c, OP_LOAD_LOCAL, (uint8_t)(arg_base + i), n->line);
             reserve_pending_slot(c);
         }
         release_pending_slots(c, saved);
-        /* The call above consumes exactly its own callee+args (the
-         * reloaded copy at OP_LOAD_LOCAL and the argc binding values) --
-         * NOT loop_slot's own underlying stack position, which is a
-         * SEPARATE physical slot the reload merely copied from (found by
-         * independent testing: a named-let nested as a non-first,
-         * non-tail argument of an enclosing call -- e.g.
-         * `(+ 1 (let loop ((i 0)) i))` -- corrupted the outer call's own
-         * slot numbering, since the enclosing call's own reserve_pending_
-         * slot bookkeeping assumed this expression's fresh, uncommitted
-         * result would land at physical index `saved` the way every other
-         * expression's result does, but the call above actually leaves it
-         * one slot higher, at `saved + 1`, with the stale, now-redundant
-         * closure copy still sitting at index `saved` since nothing ever
-         * consumes THAT slot). In the OP_TAIL_CALL case this doesn't
-         * matter -- by definition nothing else compiles into `c` after a
-         * true tail position, so the stale slot is never observed -- but
-         * the OP_CALL case needs an explicit OP_SLIDE(1) to reclaim it,
-         * exactly the same operation (and reason) end_scope already uses
-         * to remove a scope's own dead locals out from under its result:
-         * move the fresh result down over the one stale slot below it. */
+        /* Exactly like the previous shape, the call above consumes only
+         * its own reloaded callee+args copies -- NOT the argc original
+         * arg-value slots or loop_slot's own underlying stack position,
+         * all of which are SEPARATE physical slots the reloads merely
+         * copied from. Where the previous shape left exactly ONE stale
+         * slot below the call's own footprint (the original closure
+         * copy), this leaves argc+1 (the original arg values AND the
+         * original closure) -- so the OP_CALL case's cleanup needs
+         * OP_SLIDE(argc+1) here, not the fixed OP_SLIDE(1) that was
+         * correct only when there was nothing computed ahead of the
+         * closure itself. In the OP_TAIL_CALL case this doesn't matter,
+         * as before: nothing else compiles into `c` after a true tail
+         * position, so stale slots below are never observed. */
         if (n->tail) {
             emit_ab(c, OP_TAIL_CALL, (uint8_t)argc, n->line);
         } else {
             emit_ab(c, OP_CALL, (uint8_t)argc, n->line);
-            emit_ab(c, OP_SLIDE, 1, n->line);
+            /* loop_slot (an open upvalue captured by the inner recursive
+             * lambda above) is one of the stale slots OP_SLIDE is about
+             * to discard from the runtime stack -- but discarding a
+             * stack slot is not the same as closing the upvalue that
+             * still points at it. Without this, an escaped closure
+             * holding the loop's own name as an upvalue keeps pointing
+             * at that now-stale, soon-to-be-reused stack address: a
+             * LATER local in this same enclosing frame ends up sharing
+             * storage with it, so reading/writing through the escaped
+             * closure's upvalue silently aliases an unrelated variable
+             * instead. Pre-existing gap (this fast path never closed
+             * loop_slot on this exit path), but widening OP_SLIDE's
+             * operand from a fixed 1 to argc+1 (above) turned it from
+             * "clobber the named-let's own about-to-be-discarded result"
+             * into "clobber whichever enclosing local happens to sit
+             * argc+1 slots up, chosen by how many loop variables the
+             * source declares" -- independent security review. */
+            emit_ab(c, OP_CLOSE_UP, (uint8_t)arg_base, n->line);
+            emit_ab(c, OP_SLIDE, (uint8_t)(argc + 1), n->line);
         }
         return;
     }

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -449,6 +449,75 @@
 (check "named let" (let loop ((n 5) (acc 1))
                      (if (= n 0) acc (loop (- n 1) (* acc n)))) 120)
 
+;;; Regression coverage for issue #120: a named let's own init expressions
+;;; were compiled/evaluated in a scope where the loop's own name was
+;;; ALREADY a valid local (bound to a void placeholder, later the real
+;;; closure) instead of R7RS's mandated "inits run in the ENCLOSING
+;;; scope, before the loop's own binding exists at all". Two independent
+;;; bytecode-compilation paths had this bug (compiler_classic.c's
+;;; compile_let and the Tier 2.1 IR pipeline's own separate ir_emit.c
+;;; IR_NAMED_LET case, including ITS OWN separate MAX_LOCALS-overflow
+;;; fallback that builds a real, standalone closure the way compile_let
+;;; always did) -- all three fixed identically: compile each init value
+;;; via the true enclosing compiler, never the loop's own.
+(check "named let: own name is not visible during its own init exprs"
+       (guard (e (#t 'unbound)) (let loop ((i (procedure? loop))) i))
+       'unbound)
+(check "named let: init expr correctly sees an outer binding of the same name"
+       (let ((count (lambda (x) (* x 10))))
+         (let count ((i (count 5))) i))
+       50)
+;;; Same check again, but with enough loop variables (MAX_LOCALS is 256)
+;;; to force ir_emit.c's separate MAX_LOCALS-overflow "build a real,
+;;; standalone closure" fallback path, which has its own from-scratch
+;;; copy of the same logic (and, before the fix, the same bug) as the
+;;; common "splice the loop directly into the caller's frame" fast path
+;;; exercised by the checks above. Deliberately NOT built via `eval`/
+;;; `load` at runtime -- both route through eval.c's tree-walking
+;;; evaluator (prim_eval calls eval() directly; scm_load's own read-loop
+;;; does too), a third, wholly separate named-let implementation from
+;;; the two bytecode-compilation paths (compiler_classic.c, ir_emit.c)
+;;; this test exists to cover, so a form constructed and handed to
+;;; either at runtime would silently test nothing relevant. Must appear
+;;; as literal top-level source text in this script file, compiled the
+;;; same way every other top-level form in it is (main.c's own
+;;; compiler_compile + vm_run), machine-generated once rather than
+;;; hand-typed.
+(check "named let, enough loop vars to force the overflow fallback path: own name not visible"
+       (guard (e (#t 'unbound))
+         (let loop ((v0 0) (v1 0) (v2 0) (v3 0) (v4 0) (v5 0) (v6 0) (v7 0) (v8 0) (v9 0) (v10 0) (v11 0) (v12 0) (v13 0) (v14 0) (v15 0) (v16 0) (v17 0) (v18 0) (v19 0) (v20 0) (v21 0) (v22 0) (v23 0) (v24 0) (v25 0) (v26 0) (v27 0) (v28 0) (v29 0) (v30 0) (v31 0) (v32 0) (v33 0) (v34 0) (v35 0) (v36 0) (v37 0) (v38 0) (v39 0) (v40 0) (v41 0) (v42 0) (v43 0) (v44 0) (v45 0) (v46 0) (v47 0) (v48 0) (v49 0) (v50 0) (v51 0) (v52 0) (v53 0) (v54 0) (v55 0) (v56 0) (v57 0) (v58 0) (v59 0) (v60 0) (v61 0) (v62 0) (v63 0) (v64 0) (v65 0) (v66 0) (v67 0) (v68 0) (v69 0) (v70 0) (v71 0) (v72 0) (v73 0) (v74 0) (v75 0) (v76 0) (v77 0) (v78 0) (v79 0) (v80 0) (v81 0) (v82 0) (v83 0) (v84 0) (v85 0) (v86 0) (v87 0) (v88 0) (v89 0) (v90 0) (v91 0) (v92 0) (v93 0) (v94 0) (v95 0) (v96 0) (v97 0) (v98 0) (v99 0) (v100 0) (v101 0) (v102 0) (v103 0) (v104 0) (v105 0) (v106 0) (v107 0) (v108 0) (v109 0) (v110 0) (v111 0) (v112 0) (v113 0) (v114 0) (v115 0) (v116 0) (v117 0) (v118 0) (v119 0) (v120 0) (v121 0) (v122 0) (v123 0) (v124 0) (v125 0) (v126 0) (v127 0) (v128 0) (v129 0) (v130 0) (v131 0) (v132 0) (v133 0) (v134 0) (v135 0) (v136 0) (v137 0) (v138 0) (v139 0) (v140 0) (v141 0) (v142 0) (v143 0) (v144 0) (v145 0) (v146 0) (v147 0) (v148 0) (v149 0) (v150 0) (v151 0) (v152 0) (v153 0) (v154 0) (v155 0) (v156 0) (v157 0) (v158 0) (v159 0) (v160 0) (v161 0) (v162 0) (v163 0) (v164 0) (v165 0) (v166 0) (v167 0) (v168 0) (v169 0) (v170 0) (v171 0) (v172 0) (v173 0) (v174 0) (v175 0) (v176 0) (v177 0) (v178 0) (v179 0) (v180 0) (v181 0) (v182 0) (v183 0) (v184 0) (v185 0) (v186 0) (v187 0) (v188 0) (v189 0) (v190 0) (v191 0) (v192 0) (v193 0) (v194 0) (v195 0) (v196 0) (v197 0) (v198 0) (v199 0) (v200 0) (v201 0) (v202 0) (v203 0) (v204 0) (v205 0) (v206 0) (v207 0) (v208 0) (v209 0) (v210 0) (v211 0) (v212 0) (v213 0) (v214 0) (v215 0) (v216 0) (v217 0) (v218 0) (v219 0) (v220 0) (v221 0) (v222 0) (v223 0) (v224 0) (v225 0) (v226 0) (v227 0) (v228 0) (v229 0) (v230 0) (v231 0) (v232 0) (v233 0) (v234 0) (v235 0) (v236 0) (v237 0) (v238 0) (v239 0) (v240 0) (v241 0) (v242 0) (v243 0) (v244 0) (v245 0) (v246 0) (v247 0) (v248 0) (v249 0) (v250 0) (v251 0) (v252 0) (v253 (procedure? loop))) v253))
+       'unbound)
+
+;;; Regression coverage for issue #123, found during independent security
+;;; review of the #120 fix above: the IR pipeline's "splice the named let
+;;; directly into the caller's own frame" fast path captures the loop's
+;;; own name as an OPEN upvalue (for the inner recursive lambda's self-
+;;; calls), but its non-tail-call exit discarded that stack slot via
+;;; OP_SLIDE without ever closing the upvalue first. An escaped closure
+;;; holding that upvalue kept pointing at the now-stale, soon-to-be-
+;;; reused stack address, silently aliasing whatever LATER local ended up
+;;; there instead -- readable and (via set!) WRITABLE, from inside a
+;;; closure that already escaped the named let entirely. The #120 fix
+;;; widened OP_SLIDE's own operand from a fixed 1 to argc+1, which is
+;;; what turned this from "clobber the named let's own about-to-be-
+;;; discarded result" into "clobber whichever enclosing local happens to
+;;; sit argc+1 slots up, chosen by how many loop variables the source
+;;; declares" -- i.e. made the aliasing target attacker-influenceable
+;;; rather than a fixed, always-safe-to-discard value. Fixed by emitting
+;;; OP_CLOSE_UP before the OP_SLIDE.
+(check "named let: an escaped closure over the loop's own name does not alias a later local"
+       (let ()
+         (define esc #f)
+         (define (f)
+           (let* ((x (let loop ((i 0) (j 1))
+                       (set! esc (lambda (v) (set! loop v)))
+                       'done))
+                  (a 111) (b 222) (c 333) (d 444))
+             (esc 'clobbered)
+             (list x a b c d)))
+         (f))
+       (list 'done 111 222 333 444))
+
 ;;; Tail calls
 (define (count-down n)
   (if (= n 0) 'done (count-down (- n 1))))


### PR DESCRIPTION
## Summary
Fixes #120. R7RS requires a named let's init expressions to be evaluated in the enclosing scope, before the loop's own binding exists. Both of curry's independent bytecode-compilation paths (`compiler_classic.c`'s `compile_let`, and the Tier 2.1 IR pipeline's `ir_emit.c`) instead registered the loop's own name as a local BEFORE compiling its init expressions in that same scope:

```scheme
(display (let loop ((i (procedure? loop))) i))
;; before: #t   (loop already resolved to a valid, callable local)
;; after:  raises unbound variable (R7RS-correct)
```

Fixed in all three shapes this bug took (compile_let's outer wrapper, the IR pipeline's own MAX_LOCALS-overflow fallback, and the IR pipeline's more heavily optimized "splice into caller's frame" fast path) by computing init values in the true enclosing scope before the loop's own name exists anywhere.

Went through independent code + security review (parallel, no shared context) given the wide blast radius (every named-let, both compilation pipelines). Code review found no defects after extensive live testing (differential fuzzing against the tree-walker, boundary sweeps around the MAX_LOCALS guard, upvalue-capture verification). Security review found one real issue, fixed in this same commit: the fast path's widened `OP_SLIDE` discarded a captured self-reference slot without closing its upvalue first — pre-existing, but this fix's change to the slide's operand made the resulting aliasing target source-controlled rather than a fixed, safe-to-discard value. Fixed with one added `OP_CLOSE_UP`. Also tightened the MAX_LOCALS guard's arithmetic to match the fix's actual (larger) peak slot usage.

Three unrelated pre-existing bugs found while testing this region were filed separately, not fixed here: #124 (malformed `let` binding SIGSEGVs the compiler) and #125 (a `let*` with ~200+ bindings SIGSEGVs via unbounded C-stack recursion).

## Test plan
- [x] Full ctest suite passes under `BUILD_LLVM=ON` (118/118) and the default `BUILD_LLVM=OFF` build (117/117; one known-flaky `websocket` timeout confirmed unrelated by isolated rerun)
- [x] All regression tests (the core repro, outer-binding resolution, the 254-variable overflow-fallback case, and the escaped-closure-aliasing case) confirmed to actually fail when their respective fixes are reverted
- [x] Self-tail-call optimization (no C-stack growth at 5M+ iterations), upvalue capture from new slot positions, and the OP_SLIDE-sensitive nested-non-tail case all manually re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
