### PR TITLE
fix(compiler): malformed let/letrec/do/guard bindings and unbounded let* recursion (#124, #125)

### DIFF
--- a/src/compiler_classic.c
+++ b/src/compiler_classic.c
@@ -656,6 +656,14 @@ static void compile_let_syntax(Compiler *c, val_t args, bool tail, int line) {
     val_t bindings = vcar(args);
     val_t body     = vcdr(args);
 
+    /* Validates every (name transformer-expr) binding before either loop
+     * below destructures it -- see ir_lower_let's identical comment
+     * (issue #124, found incidentally while fixing the let/do family):
+     * (let-syntax ((m)) 1) previously SIGSEGV'd here on a binding with
+     * no transformer expression. */
+    for (val_t b = bindings; vis_pair(b); b = vcdr(b))
+        require_min_args(vcar(b), 2, "let-syntax");
+
     begin_scope(c);
 
     val_t saved_locals = sr_get_current_local_macros();
@@ -851,6 +859,16 @@ static void compile_let(Compiler *c, val_t args, bool tail, int line) {
         val_t b = bindings;
         while (vis_pair(b)) { argc++; b = vcdr(b); }
 
+        /* Validates every binding before either loop below destructures
+         * it -- see ir_lower_let's identical comment (issue #124). Not
+         * reachable from ordinary compilation today (classify_head's
+         * S_LET dispatch always routes through ir_lower's own IR path,
+         * which has the analogous fix; this function only runs via the
+         * test-only g_force_classic_compile switch), but fixed anyway
+         * since it's the same shape and the same one-line idiom. */
+        for (val_t b2 = bindings; vis_pair(b2); b2 = vcdr(b2))
+            require_min_args(vcar(b2), 2, "let");
+
         /* Build forward-order params list */
         val_t params = V_NIL;
         b = bindings;
@@ -917,6 +935,12 @@ static void compile_let(Compiler *c, val_t args, bool tail, int line) {
        The lambda creates a fresh frame, so slot 0 = first init arg
        regardless of what else is on the caller's stack. */
     {
+        /* Validates every binding before either loop below destructures
+         * it -- see this function's own named-let branch above (issue
+         * #124); same non-reachability caveat applies. */
+        for (val_t b2 = bindings; vis_pair(b2); b2 = vcdr(b2))
+            require_min_args(vcar(b2), 2, "let");
+
         /* Build params list in forward order */
         val_t params = V_NIL;
         int argc = 0;
@@ -951,6 +975,11 @@ static void compile_let_star(Compiler *c, val_t args, bool tail, int line) {
         return;
     }
     val_t binding  = vcar(bindings);
+    /* See compile_let's identical comment (issue #124); same
+     * non-reachability caveat. Only the first binding needs checking
+     * here -- each further one gets checked the next time this
+     * function recurses on the desugared inner let* form below. */
+    require_min_args(binding, 2, "let*");
     val_t name     = vcar(binding);
     val_t init     = vcar(vcdr(binding));
     val_t rest     = vcdr(bindings);
@@ -989,6 +1018,11 @@ static void compile_letrec(Compiler *c, val_t args, bool tail, int line) {
     int nb = 0;
     val_t bcount = bindings;
     while (vis_pair(bcount)) { nb++; bcount = vcdr(bcount); }
+
+    /* See compile_let's identical comment (issue #124); same
+     * non-reachability caveat. */
+    for (val_t b0 = bindings; vis_pair(b0); b0 = vcdr(b0))
+        require_min_args(vcar(b0), 2, "letrec");
 
     /* Pre-declare all locals with void placeholders */
     val_t b = bindings;
@@ -1363,6 +1397,16 @@ static void compile_do(Compiler *c, val_t args, bool tail, int line) {
     val_t test_expr = vcar(term);
     val_t result    = vcdr(term);
 
+    /* Validates every (var init [step]) spec before either loop below
+     * destructures it -- see ir_lower_let's identical comment (issue
+     * #124): `do` has no IR lowering at all (SF_DO routes straight
+     * here), so this is the one live compilation path for it, unlike
+     * let / let* / letrec's own analogous fix in ir_lower.c. (let ((f
+     * (lambda () (do (1) (#t) 1)))) 1) previously SIGSEGV'd at the
+     * first loop below on a spec with no init. */
+    for (val_t vs2 = var_specs; vis_pair(vs2); vs2 = vcdr(vs2))
+        require_min_args(vcar(vs2), 2, "do");
+
     Compiler lc;
     init_compiler(&lc, c, "<do>");
     lc.chunk->arity = 0;
@@ -1546,6 +1590,16 @@ static void compile_guard(Compiler *c, val_t args, bool tail, int line) {
     val_t S_COND2 = sym_intern_cstr("cond");
     val_t S_ELSE2 = sym_intern_cstr("else");
     val_t gk      = sym_intern_cstr("%guard-k");
+
+    /* Validates every clause is itself a non-empty pair before either
+     * loop below destructures it -- see ir_lower_let's identical comment
+     * (issue #124, found incidentally while fixing the let/do family):
+     * (guard (e ()) 1) previously SIGSEGV'd here on an empty `()`
+     * clause (guard's own clauses share cond's own clause shape, but
+     * unlike compile_cond -- which validates each clause -- this
+     * function never did). */
+    for (val_t cl0 = clauses; vis_pair(cl0); cl0 = vcdr(cl0))
+        require_min_args(vcar(cl0), 1, "guard");
 
     /* Count clauses and check for else */
     bool has_else = false;

--- a/src/eval.c
+++ b/src/eval.c
@@ -17,15 +17,6 @@
  * Each eval() call site can install a handler with scm_with_exception_handler().
  */
 
-/* pthread_getattr_np (used below to query the real per-thread stack size
- * on Linux) is a glibc extension gated behind _GNU_SOURCE. Harmless on
- * macOS, where the __APPLE__ branch uses pthread_get_stacksize_np
- * instead and never calls it. */
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-#include <pthread.h>
-
 #include "eval.h"
 #include "runtime_internal.h"
 #include "sx_rules.h"
@@ -148,73 +139,37 @@ static val_t eval_call_cc(val_t proc) {
 
 /* ---- Evaluator ---- */
 
-/* Per-thread cached stack base (Boehm's "bottom of stack" == the highest
- * address, for a downward-growing stack), lazily captured on first use.
- * Used to detect an approaching real C-stack overflow from unbounded
- * non-tail recursion through eval() -- goto-tail iterations below don't
- * grow the C stack and never reach this check at all; only genuine
- * recursive C-level re-entry into eval() (a non-tail sub-expression,
- * e.g. deep (+ 1 (deep-sum (- n 1)))) does. Without this, that recursion
- * SIGSEGVs the whole process once the OS stack is exhausted -- unlike
- * the bytecode VM's own compiled path, which has an explicit, catchable
- * frame-count guard (vm.c, "call stack overflow (max N frames)"). This
- * gives the tree-walker the same kind of catchable guard instead of a
- * hard crash. Reproduced: a define-library-defined function doing
- * non-tail recursion to depth ~1,000,000 previously segfaulted
- * immediately (define-library bodies are tree-walked, not compiled --
- * see modules.c's define_library_clause). */
-static CURRY_THREAD_LOCAL void   *eval_stack_base  = NULL;
-static CURRY_THREAD_LOCAL size_t  eval_stack_limit = 0;
-
-/* Real per-thread stack size, queried once and cached alongside
- * eval_stack_base. A fixed byte budget here (e.g. "assume ~8MB, leave
- * 1MB headroom") was found by independent security review to be unsafe:
- * curry's own parallel map/reduce/for-each worker pool (src/workpool.c)
- * spawns threads with a NULL pthread_attr_t, i.e. the platform default
- * stack size -- 512KB on macOS -- so a hardcoded 7MB threshold never
- * fires there and the real stack still exhausts and crashes first,
- * exactly as before this guard existed. Querying the actual size makes
- * the guard correct on any thread, whatever its real stack turns out to
- * be, instead of assuming every thread matches curry's own actor
- * convention (actors.c does explicitly request 8MB; workpool.c and an
- * externally-lowered main-thread ulimit do not). */
-static size_t eval_query_thread_stack_size(void) {
-#if defined(__APPLE__)
-    return pthread_get_stacksize_np(pthread_self());
-#else
-    size_t size = 8u * 1024u * 1024u; /* conservative fallback if the query itself fails */
-    pthread_attr_t attr;
-    if (pthread_getattr_np(pthread_self(), &attr) == 0) {
-        void *addr;
-        if (pthread_attr_getstack(&attr, &addr, &size) != 0)
-            size = 8u * 1024u * 1024u;
-        pthread_attr_destroy(&attr);
-    }
-    return size;
-#endif
+/* A `(var init)`-shaped let / let* / letrec / do binding, or one of do's own
+ * `(var init step)` specs, was destructured via unchecked vcar/vcdr
+ * chains throughout this file with no check that the binding itself is
+ * even a pair -- (eval '(let ((a)) 1) ...) SIGSEGV'd the whole process
+ * instead of raising a catchable error (issue #124, found via
+ * independent review of the analogous compiler-side bug; the compiler
+ * already has an equivalent helper, require_min_args, but that lives in
+ * compiler_internal.h, scoped to the bytecode compiler's own files --
+ * this is the tree-walker's separate copy of the same tiny check,
+ * matching its exact behavior and error message). */
+static void require_binding_shape(val_t binding, const char *form_name) {
+    if (!vis_pair(binding) || !vis_pair(vcdr(binding)))
+        scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "%s: ill-formed special form", form_name);
 }
 
 val_t eval(val_t expr, val_t env) {
-    if (__builtin_expect(!eval_stack_base, 0)) {
-        struct GC_stack_base sb;
-        GC_get_stack_base(&sb);
-        eval_stack_base = sb.mem_base;
-        size_t stack_size = eval_query_thread_stack_size();
-        /* Reserve 1/8 of the real stack (min 64KB) for whatever C stack
-         * the raise/longjmp unwind path itself still needs once
-         * triggered -- scales down with small stacks (e.g. workpool's
-         * 512KB) instead of a fixed byte count that could exceed the
-         * whole stack on a small thread. */
-        size_t margin = stack_size / 8;
-        if (margin < 64u * 1024u) margin = 64u * 1024u;
-        eval_stack_limit = stack_size > margin ? stack_size - margin : stack_size / 2;
-    }
-    {
-        char stack_probe;
-        size_t used = (size_t)((uintptr_t)eval_stack_base - (uintptr_t)&stack_probe);
-        if (__builtin_expect(used > eval_stack_limit, 0))
-            scm_raise_code(EC_STACK_OVERFLOW, "eval: call stack overflow");
-    }
+    /* Detects an approaching real C-stack overflow from unbounded
+     * non-tail recursion through eval() -- goto-tail iterations below
+     * don't grow the C stack and never reach this check at all; only
+     * genuine recursive C-level re-entry into eval() (a non-tail
+     * sub-expression, e.g. deep (+ 1 (deep-sum (- n 1)))) does. Without
+     * this, that recursion SIGSEGVs the whole process once the OS stack
+     * is exhausted -- unlike the bytecode VM's own compiled path, which
+     * has an explicit, catchable frame-count guard (vm.c, "call stack
+     * overflow (max N frames)"). Reproduced: a define-library-defined
+     * function doing non-tail recursion to depth ~1,000,000 previously
+     * segfaulted immediately (define-library bodies are tree-walked,
+     * not compiled -- see modules.c's define_library_clause). Shared
+     * with ir_emit.c's own unbounded recursion (issue #125) -- see
+     * check_c_stack_depth's own comment in runtime.c. */
+    check_c_stack_depth("eval");
     /* Shadow stack: register the two persistent locals so a moving GC can
      * update them after nursery evacuation.  op/rest are declared here so
      * they are in scope for GC_AUTOFRAME; goto tail re-assigns them each
@@ -360,6 +315,7 @@ tail:
             val_t params = V_NIL, inits_list = V_NIL;
             val_t b = bindings;
             while (vis_pair(b)) {
+                require_binding_shape(vcar(b), "let");
                 params      = make_pair(vcar(vcar(b)), params);
                 inits_list  = make_pair(vcadr(vcar(b)), inits_list);
                 b = vcdr(b);
@@ -398,6 +354,7 @@ tail:
         val_t b = bindings;
         while (vis_pair(b)) {
             val_t bind = vcar(b);
+            require_binding_shape(bind, "let");
             val_t v    = eval(vcadr(bind), env);
             env_define(new_env, vcar(bind), v);
             b = vcdr(b);
@@ -413,6 +370,7 @@ tail:
         val_t cur_env = env_extend(env);
         while (vis_pair(bindings)) {
             val_t bind = vcar(bindings);
+            require_binding_shape(bind, "let*");
             env_define(cur_env, vcar(bind), eval(vcadr(bind), cur_env));
             bindings = vcdr(bindings);
         }
@@ -426,7 +384,11 @@ tail:
         val_t new_env = env_extend(env);
         /* Pre-define all vars as undefined */
         val_t b = bindings;
-        while (vis_pair(b)) { env_define(new_env, vcar(vcar(b)), V_UNDEF); b = vcdr(b); }
+        while (vis_pair(b)) {
+            require_binding_shape(vcar(b), op == S_LETREC ? "letrec" : "letrec*");
+            env_define(new_env, vcar(vcar(b)), V_UNDEF);
+            b = vcdr(b);
+        }
         /* Evaluate and set */
         b = bindings;
         while (vis_pair(b)) {
@@ -588,6 +550,7 @@ tail:
         val_t vs = var_specs;
         while (vis_pair(vs)) {
             val_t spec = vcar(vs);
+            require_binding_shape(spec, "do");
             env_define(do_env, vcar(spec), eval(vcadr(spec), env));
             vs = vcdr(vs);
         }
@@ -667,6 +630,7 @@ tail:
         val_t new_env = env_extend(env);
         while (vis_pair(bindings)) {
             val_t bind = vcar(bindings);
+            require_binding_shape(bind, "let-syntax");
             val_t name = vcar(bind);
             val_t xfm  = eval(vcadr(bind), op == S_LET_SYNTAX ? env : new_env);
             Syntax *syn = CURRY_NEW(Syntax);
@@ -851,6 +815,15 @@ tail:
         val_t cs = clauses;
         while (vis_pair(cs)) {
             val_t clause = vcar(cs);
+            /* A guard clause shares cond's own shape, including a valid
+             * bare-test `(test)` form with no body -- unlike every other
+             * binding this file validates, require_binding_shape's "cdr
+             * must also be a pair" is too strict here, so this only
+             * checks that the clause itself is a pair (issue #124: an
+             * empty clause, (), previously SIGSEGV'd on the vcar(clause)
+             * just below). */
+            if (!vis_pair(clause))
+                scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "guard: ill-formed special form");
             val_t test   = vcar(clause);
             val_t cbody  = vcdr(clause);
             cs = vcdr(cs);

--- a/src/eval.c
+++ b/src/eval.c
@@ -307,6 +307,8 @@ tail:
         /* Named let: (let name ((var init)...) body...) */
         if (vis_symbol(bindings)) {
             val_t loop_name = bindings;
+            if (!vis_pair(body))
+                scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "let: ill-formed special form");
             bindings = vcar(body);
             body     = vcdr(body);
 
@@ -375,6 +377,7 @@ tail:
             bindings = vcdr(bindings);
         }
         env = cur_env;
+        if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
     }
@@ -398,6 +401,7 @@ tail:
             b = vcdr(b);
         }
         env = new_env;
+        if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
     }
@@ -541,9 +545,13 @@ tail:
 
     if (op == S_DO) {
         /* (do ((var init step)...) (test expr...) body...) */
+        if (!vis_pair(rest) || !vis_pair(vcdr(rest)))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "do: ill-formed special form");
         val_t var_specs = vcar(rest);
         val_t term      = vcadr(rest);
         val_t body      = vcddr(rest);
+        if (!vis_pair(term))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "do: ill-formed special form");
 
         val_t do_env = env_extend(env);
         /* Initialize */
@@ -573,8 +581,14 @@ tail:
             vs = var_specs;
             while (vis_pair(vs)) {
                 val_t spec = vcar(vs);
-                val_t step = vis_nil(vcddr(spec)) ? env_lookup(do_env, vcar(spec))
-                                                   : eval(vcaddr(spec), do_env);
+                /* !vis_pair (not just vis_nil) so an improper dotted tail
+                 * like (i 0 . 5) -- found via independent security review
+                 * to crash vcaddr on the non-pair tail -- is also treated
+                 * as "no step expression" rather than dereferenced,
+                 * mirroring compiler_classic.c's own do step-expr check
+                 * (vis_pair(vcdr(vcdr(spec)))). */
+                val_t step = !vis_pair(vcddr(spec)) ? env_lookup(do_env, vcar(spec))
+                                                     : eval(vcaddr(spec), do_env);
                 new_vals = make_pair(make_pair(vcar(spec), step), new_vals);
                 vs = vcdr(vs);
             }

--- a/src/eval.h
+++ b/src/eval.h
@@ -137,6 +137,14 @@ extern CURRY_THREAD_LOCAL int g_jit_call_depth;
 int  jit_depth_save(void);
 void jit_depth_restore(int saved);
 
+/* Shared C-stack-depth guard (runtime.c) -- raises EC_STACK_OVERFLOW,
+ * naming `context` in the message, once this thread's real C stack
+ * usage crosses the cached per-thread limit. Originally eval()'s own
+ * private mechanism; shared with ir_emit.c's own unbounded recursion
+ * (issue #125) since both consume the same physical C stack on the
+ * same thread. */
+void check_c_stack_depth(const char *context);
+
 /* Arithmetic-fast-path deopt (issue #118) -- see runtime.c's own comment
  * above their definitions for the full design. jit_arith_snapshot_init()
  * must be called exactly once, at the very end of builtins_register()

--- a/src/ir_emit.c
+++ b/src/ir_emit.c
@@ -232,6 +232,17 @@ static void ir_emit_inline_call(Compiler *c, val_t params, val_t body,
 }
 
 void ir_emit(Compiler *c, IRNode *n) {
+    /* ir_emit and ir_emit_inline_call (both call sites of the latter are
+     * inside this function, so guarding ir_emit's own entry covers the
+     * whole recursive tree) recurse into each other once per binding of
+     * a flat let* / letrec* / do chain -- unlike eval()'s own goto-tail
+     * trampoline, nothing here reuses a C frame, so a few hundred
+     * sequential bindings SIGSEGVs the whole process once the real C
+     * stack is exhausted (issue #125). check_c_stack_depth (runtime.c)
+     * is the same guard eval() already has for its own unbounded
+     * recursion -- shared rather than duplicated, since both consume
+     * the same physical C stack on the same thread. */
+    check_c_stack_depth("compile");
     switch (n->kind) {
     case IR_CONST: {
         val_t v = n->as.konst.value;
@@ -834,6 +845,12 @@ void ir_emit(Compiler *c, IRNode *n) {
         val_t bindings0  = n->as.named_let.bindings;
         int   argc0 = 0;
         for (val_t b = bindings0; vis_pair(b); b = vcdr(b)) argc0++;
+        /* Validates every binding before either branch below destructures
+         * it -- see ir_lower_let's identical comment (issue #124):
+         * (let loop ((a)) 1) previously SIGSEGV'd here (and in the
+         * splice fast path below) on a binding with no init. */
+        for (val_t b = bindings0; vis_pair(b); b = vcdr(b))
+            require_min_args(vcar(b), 2, "let");
         if (c->local_count + 2 * argc0 + 2 >= MAX_LOCALS) {
             val_t body0 = n->as.named_let.body;
             val_t params0 = V_NIL;

--- a/src/ir_lower.c
+++ b/src/ir_lower.c
@@ -921,13 +921,17 @@ static IRNode *ir_lower_let_star(Compiler *c, val_t args, bool tail, int line) {
  * letrec and letrec* today, so this produces identical observable
  * behavior through already-verified machinery instead of a parallel
  * bespoke implementation. */
-static IRNode *ir_lower_letrec(Compiler *c, val_t args, bool tail, int line) {
+static IRNode *ir_lower_letrec(Compiler *c, val_t args, bool tail, int line, val_t head) {
     val_t bindings = vcar(args);
     val_t body     = vcdr(args);
+    const char *form_name = (head == S_LETREC_STAR) ? "letrec*" : "letrec";
 
-    /* See ir_lower_let's identical comment (issue #124). */
+    /* See ir_lower_let's identical comment (issue #124). form_name
+     * distinguishes letrec/letrec* in the raised error -- previously
+     * hardcoded to "letrec" even for a malformed letrec* binding, found
+     * by independent code review. */
     for (val_t b = bindings; vis_pair(b); b = vcdr(b))
-        require_min_args(vcar(b), 2, "letrec");
+        require_min_args(vcar(b), 2, form_name);
 
     /* Build (define name init) forms in reverse, then prepend each (in
      * that reverse order) onto body -- restores original binding order
@@ -1074,7 +1078,7 @@ IRNode *ir_lower(Compiler *c, val_t expr, bool tail, int line) {
     }
     if (head == S_LETREC || head == S_LETREC_STAR) {
         require_min_args(args, 1, head == S_LETREC ? "letrec" : "letrec*");
-        return ir_lower_letrec(c, args, tail, line);
+        return ir_lower_letrec(c, args, tail, line, head);
     }
     /* Both `(define sym expr)` and `(define (f params...) body...)`
      * lambda-sugar are natively lowered (the latter via IR_LAMBDA, now

--- a/src/ir_lower.c
+++ b/src/ir_lower.c
@@ -282,6 +282,16 @@ static bool let_bindings_closed(Compiler *c, val_t bindings, BoundScope *outer_s
     val_t names = V_NIL;
     for (val_t b = bindings; vis_pair(b); b = vcdr(b)) {
         val_t binding = vcar(b);
+        /* This is a closedness PREDICATE, not a compile step -- a
+         * malformed binding here just means "not eligible for this
+         * optimization," fail-safe, not a raised error (unlike the
+         * actual compile-time checks in ir_lower_let/ir_lower_let_star/
+         * etc for the exact same shape). Raising here would incorrectly
+         * change behavior for a program that never actually compiles
+         * the lambda body being analyzed. Issue #124, found via
+         * independent review: (let ((f (lambda () (let (1) 1)))) 1)
+         * previously dereferenced a non-pair binding here and SIGSEGV'd. */
+        if (!vis_pair(binding)) return false;
         val_t name = vcar(binding);
         val_t init = vis_pair(vcdr(binding)) ? vcar(vcdr(binding)) : V_FALSE;
         if (!expr_is_closed(c, init, outer_scope, budget)) return false;
@@ -352,6 +362,7 @@ static bool expr_is_closed(Compiler *c, val_t expr, BoundScope *scope, int *budg
         BoundScope *cur = scope;
         for (val_t b = bindings; vis_pair(b); b = vcdr(b)) {
             val_t binding = vcar(b);
+            if (!vis_pair(binding)) return false;   /* see let_bindings_closed's comment */
             val_t name    = vcar(binding);
             val_t init    = vis_pair(vcdr(binding)) ? vcar(vcdr(binding)) : V_FALSE;
             /* Sequential: each init is checked against everything bound
@@ -371,6 +382,8 @@ static bool expr_is_closed(Compiler *c, val_t expr, BoundScope *scope, int *budg
         val_t body2    = vis_pair(vcdr(expr)) ? vcdr(vcdr(expr)) : V_NIL;
         /* letrec(*): every binding name is visible to every init AND to
          * the body -- build the whole scope layer first. */
+        for (val_t b = bindings; vis_pair(b); b = vcdr(b))
+            if (!vis_pair(vcar(b))) return false;   /* see let_bindings_closed's comment */
         val_t names = V_NIL;
         for (val_t b = bindings; vis_pair(b); b = vcdr(b))
             names = scm_cons(vcar(vcar(b)), names);
@@ -392,6 +405,7 @@ static bool expr_is_closed(Compiler *c, val_t expr, BoundScope *scope, int *budg
         val_t names = V_NIL;
         for (val_t vs = var_specs; vis_pair(vs); vs = vcdr(vs)) {
             val_t spec = vcar(vs);
+            if (!vis_pair(spec)) return false;   /* see let_bindings_closed's comment */
             val_t init = vis_pair(vcdr(spec)) ? vcar(vcdr(spec)) : V_FALSE;
             /* init exprs see the OUTER scope only, matching do's own
              * semantics (vars aren't bound yet for their own inits). */
@@ -401,6 +415,12 @@ static bool expr_is_closed(Compiler *c, val_t expr, BoundScope *scope, int *budg
         BoundScope inner = { scope, names };
         for (val_t vs = var_specs; vis_pair(vs); vs = vcdr(vs)) {
             val_t spec = vcar(vs);
+            /* Already validated as a pair by the first loop above (both
+             * walk the same var_specs list), but re-checked defensively
+             * since this loop re-derives `spec` independently -- cheap,
+             * and avoids relying on control flow across two separate
+             * loops to keep this safe if either is ever reordered. */
+            if (!vis_pair(spec)) return false;
             val_t step = vis_pair(vcdr(spec)) && vis_pair(vcdr(vcdr(spec)))
                              ? vcar(vcdr(vcdr(spec))) : vcar(spec);
             if (!expr_is_closed(c, step, &inner, budget)) return false;
@@ -731,6 +751,20 @@ static IRNode *ir_lower_let(Compiler *c, val_t args, bool tail, int line) {
     val_t bindings = vcar(args);
     val_t body     = vcdr(args);
 
+    /* require_min_args already guards the outer form's own spine
+     * (args itself, at this function's caller -- see classify_head's
+     * S_LET dispatch), but never validated each individual BINDING
+     * entry within it: (let ((a)) 1) has a well-formed two-element
+     * args list, so that check passes, then vcar(vcdr(vcar(b))) below
+     * dereferences (a)'s nonexistent cdr and SIGSEGVs the whole
+     * process (issue #124, found via independent review). Reusing
+     * require_min_args on each binding itself (rather than on `args`)
+     * catches both "not a pair at all" and "pair with no init"
+     * uniformly, matching the exact idiom this file already uses
+     * everywhere else. */
+    for (val_t b = bindings; vis_pair(b); b = vcdr(b))
+        require_min_args(vcar(b), 2, "let");
+
     /* Forward-order params list -- same double-reverse compile_let itself
      * uses (bindings is walked once to reverse, then reversed back). */
     val_t params = V_NIL;
@@ -810,6 +844,12 @@ static IRNode *ir_lower_let_star(Compiler *c, val_t args, bool tail, int line) {
         return ir_lower_seq(c, body, tail, line);
 
     val_t binding = vcar(bindings);
+    /* See ir_lower_let's identical comment (issue #124): validates this
+     * one binding before destructuring it. Only the first binding needs
+     * checking here -- each further one gets its own check the next
+     * time this function recurses on the desugared inner `let*` form
+     * below. */
+    require_min_args(binding, 2, "let*");
     val_t name    = vcar(binding);
     val_t init    = vcar(vcdr(binding));
     val_t rest    = vcdr(bindings);
@@ -884,6 +924,10 @@ static IRNode *ir_lower_let_star(Compiler *c, val_t args, bool tail, int line) {
 static IRNode *ir_lower_letrec(Compiler *c, val_t args, bool tail, int line) {
     val_t bindings = vcar(args);
     val_t body     = vcdr(args);
+
+    /* See ir_lower_let's identical comment (issue #124). */
+    for (val_t b = bindings; vis_pair(b); b = vcdr(b))
+        require_min_args(vcar(b), 2, "letrec");
 
     /* Build (define name init) forms in reverse, then prepend each (in
      * that reverse order) onto body -- restores original binding order

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -11,6 +11,15 @@
  * exclusively-internal helpers, and eval_call_cc.
  */
 
+/* pthread_getattr_np (used by check_c_stack_depth below to query the real
+ * per-thread stack size on Linux) is a glibc extension gated behind
+ * _GNU_SOURCE. Harmless on macOS, where the __APPLE__ branch uses
+ * pthread_get_stacksize_np instead and never calls it. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <pthread.h>
+
 #include "eval.h"
 #include "runtime_internal.h"
 #include "vm.h"
@@ -377,6 +386,80 @@ void jit_depth_pop(void)  { g_jit_call_depth--; }
  * see ExnHandler.saved_jit_depth in eval.h. */
 int  jit_depth_save(void)        { return g_jit_call_depth; }
 void jit_depth_restore(int saved) { g_jit_call_depth = saved; }
+
+/* ---- Shared C-stack-depth guard (issue #125) ----
+ *
+ * Originally eval()'s own private mechanism (eval.c) to detect an
+ * approaching real C-stack overflow from unbounded non-tail recursion
+ * through the tree-walker -- goto-tail iterations don't grow the C
+ * stack and never reach this check at all; only genuine recursive
+ * C-level re-entry does. Without it, that recursion SIGSEGVs the whole
+ * process once the OS stack is exhausted, unlike the bytecode VM's own
+ * compiled path, which has an explicit, catchable frame-count guard
+ * (vm.c, "call stack overflow (max N frames)").
+ *
+ * Extracted here, and made a single shared instance rather than one
+ * private copy per subsystem, when ir_emit.c's own C-level recursion
+ * (ir_emit <-> ir_emit_inline_call, unbounded by a flat let* / letrec*
+ * chain of local bindings -- see issue #125) turned out to have the
+ * identical gap: eval() and ir_emit() run on the SAME thread and
+ * consume the SAME physical C stack, so there is exactly one real
+ * "how close to the top" answer regardless of which caller asks --
+ * duplicating the thread-local base/limit state per subsystem would
+ * just be two answers to the same question, computed twice. */
+static CURRY_THREAD_LOCAL void   *c_stack_base  = NULL;
+static CURRY_THREAD_LOCAL size_t  c_stack_limit = 0;
+
+/* Real per-thread stack size, queried once and cached alongside
+ * c_stack_base. A fixed byte budget here (e.g. "assume ~8MB, leave 1MB
+ * headroom") was found by independent security review to be unsafe:
+ * curry's own parallel map/reduce/for-each worker pool (src/workpool.c)
+ * spawns threads with a NULL pthread_attr_t, i.e. the platform default
+ * stack size -- 512KB on macOS -- so a hardcoded 7MB threshold never
+ * fires there and the real stack still exhausts and crashes first,
+ * exactly as before this guard existed. Querying the actual size makes
+ * the guard correct on any thread, whatever its real stack turns out to
+ * be, instead of assuming every thread matches curry's own actor
+ * convention (actors.c does explicitly request 8MB; workpool.c and an
+ * externally-lowered main-thread ulimit do not). */
+static size_t query_thread_stack_size(void) {
+#if defined(__APPLE__)
+    return pthread_get_stacksize_np(pthread_self());
+#else
+    size_t size = 8u * 1024u * 1024u; /* conservative fallback if the query itself fails */
+    pthread_attr_t attr;
+    if (pthread_getattr_np(pthread_self(), &attr) == 0) {
+        void *addr;
+        if (pthread_attr_getstack(&attr, &addr, &size) != 0)
+            size = 8u * 1024u * 1024u;
+        pthread_attr_destroy(&attr);
+    }
+    return size;
+#endif
+}
+
+/* `context` names the caller for the raised error message (e.g. "eval",
+ * "compile") -- purely diagnostic, no behavioral difference. */
+void check_c_stack_depth(const char *context) {
+    if (__builtin_expect(!c_stack_base, 0)) {
+        struct GC_stack_base sb;
+        GC_get_stack_base(&sb);
+        c_stack_base = sb.mem_base;
+        size_t stack_size = query_thread_stack_size();
+        /* Reserve 1/8 of the real stack (min 64KB) for whatever C stack
+         * the raise/longjmp unwind path itself still needs once
+         * triggered -- scales down with small stacks (e.g. workpool's
+         * 512KB) instead of a fixed byte count that could exceed the
+         * whole stack on a small thread. */
+        size_t margin = stack_size / 8;
+        if (margin < 64u * 1024u) margin = 64u * 1024u;
+        c_stack_limit = stack_size > margin ? stack_size - margin : stack_size / 2;
+    }
+    char stack_probe;
+    size_t used = (size_t)((uintptr_t)c_stack_base - (uintptr_t)&stack_probe);
+    if (__builtin_expect(used > c_stack_limit, 0))
+        scm_raise_code(EC_STACK_OVERFLOW, "%s: call stack overflow", context);
+}
 
 /* ---- Arithmetic-fast-path deopt (issue #118) ----
  *

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -422,9 +422,23 @@ static CURRY_THREAD_LOCAL size_t  c_stack_limit = 0;
  * be, instead of assuming every thread matches curry's own actor
  * convention (actors.c does explicitly request 8MB; workpool.c and an
  * externally-lowered main-thread ulimit do not). */
+/* Clamp to a plausible ceiling: independent security review found that
+ * `ulimit -s unlimited` (a real, common setting -- e.g. the default for
+ * services on several Linux distros) makes pthread_getattr_np/
+ * pthread_attr_getstack report a synthetic ~93TB stack size on Linux
+ * (observed on Ubuntu 24.04 arm64), which would push c_stack_limit out
+ * past any depth of recursion actually reachable before a real SIGSEGV
+ * -- silently disabling this guard exactly on the systems where an
+ * unbounded stack makes a runaway recursion most dangerous to run
+ * unguarded. 512MB is comfortably above every real thread-stack size
+ * curry itself ever requests (actors: 8MB, workpool: platform default,
+ * typically 512KB-8MB) while still being a hard ceiling no legitimate
+ * query should exceed. */
+#define STACK_SIZE_CEILING (512u * 1024u * 1024u)
+
 static size_t query_thread_stack_size(void) {
 #if defined(__APPLE__)
-    return pthread_get_stacksize_np(pthread_self());
+    size_t size = pthread_get_stacksize_np(pthread_self());
 #else
     size_t size = 8u * 1024u * 1024u; /* conservative fallback if the query itself fails */
     pthread_attr_t attr;
@@ -434,8 +448,9 @@ static size_t query_thread_stack_size(void) {
             size = 8u * 1024u * 1024u;
         pthread_attr_destroy(&attr);
     }
-    return size;
 #endif
+    if (size > STACK_SIZE_CEILING) size = STACK_SIZE_CEILING;
+    return size;
 }
 
 /* `context` names the caller for the raised error message (e.g. "eval",
@@ -443,8 +458,18 @@ static size_t query_thread_stack_size(void) {
 void check_c_stack_depth(const char *context) {
     if (__builtin_expect(!c_stack_base, 0)) {
         struct GC_stack_base sb;
-        GC_get_stack_base(&sb);
-        c_stack_base = sb.mem_base;
+        /* GC_get_stack_base can fail (GC_UNIMPLEMENTED) on a platform
+         * Boehm GC doesn't support this query on -- independent security
+         * review found the unchecked case left sb.mem_base indeterminate,
+         * which corrupts the "used" computation below into either a huge
+         * bogus value (spurious stack-overflow raised on every single
+         * eval/compile on this thread from then on, since c_stack_base is
+         * cached) or silently disables the guard. Fall back to this
+         * frame's own address as the base on failure: an underestimate of
+         * the true base (stack grows down from something higher), so
+         * "used" is an overestimate -- the guard fires somewhat earlier
+         * than ideal instead of not at all, the safe direction to err. */
+        c_stack_base = (GC_get_stack_base(&sb) == GC_SUCCESS) ? sb.mem_base : (void *)&sb;
         size_t stack_size = query_thread_stack_size();
         /* Reserve 1/8 of the real stack (min 64KB) for whatever C stack
          * the raise/longjmp unwind path itself still needs once

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -594,6 +594,52 @@
 ;;; subprocess compile regardless, for the same reason #124's do/
 ;;; let-syntax/guard checks are in test_cli.sh rather than here.
 
+;;; Additional eval.c-only gaps found by independent code review of the
+;;; #124 fix above: the compiler paths already rejected these malformed
+;;; forms cleanly, but eval.c's own tree-walker still SIGSEGVed on them
+;;; (require_binding_shape only validates an individual BINDING's shape,
+;;; not that the enclosing form has enough top-level pieces to destructure
+;;; in the first place -- e.g. `(let* ((a 1)))` has a well-formed binding
+;;; but no body, and the old code unconditionally called vcdr on that nil
+;;; body while checking for more forms to evaluate).
+(check "let*: missing body doesn't crash (returns void)"
+       (jit124-malformed-raises? (lambda () (eval '(let* ((a 1))) (interaction-environment)) #f))
+       #f)
+(check "letrec: missing body doesn't crash (returns void)"
+       (jit124-malformed-raises? (lambda () (eval '(letrec ((a 1))) (interaction-environment)) #f))
+       #f)
+(check "named let: missing bindings/body raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(let loop) (interaction-environment))))
+       #t)
+(check "do: missing test clause raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(do ((i 0 (+ i 1)))) (interaction-environment))))
+       #t)
+(check "do: non-pair test clause raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(do ((i 0)) ()) (interaction-environment))))
+       #t)
+(check "do: dotted step-spec doesn't dereference the improper tail"
+       ;; (i 0 . 5) -- vcddr(spec) is 5, a non-pair. Matches
+       ;; compiler_classic.c's own do step-expr check (vis_pair(vcdr(vcdr
+       ;; (spec)))): treated as "no step expression" rather than crashing.
+       ;; This makes i never advance, hence the outer call/cc escape
+       ;; instead of actually looping.
+       (call-with-current-continuation
+        (lambda (k)
+          (guard (e (#t (k 'raised)))
+            (eval '(do ((i 0 . 5) (n 0 (+ n 1)))
+                       ((or (= i 1) (> n 2)) 'done))
+                  (interaction-environment)))))
+       'done)
+;; letrec* naming its own error correctly (ir_lower_letrec, shared by
+;; letrec/letrec*, was found by independent code review to hardcode
+;; "letrec" in the raised message even for a letrec* input) can't be
+;; tested from inside this file at all: `(letrec* ((a)) 1)` at the top
+;; level is a COMPILE-time error for the whole enclosing top-level form,
+;; including any guard meant to catch it -- the same eval-vs-compile
+;; distinction #124/#125's other compiler-path checks are subject to
+;; (see the comment above). Tested via a real subprocess in test_cli.sh
+;; instead, grepping stderr for the exact form name.
+
 ;;; Tail calls
 (define (count-down n)
   (if (= n 0) 'done (count-down (- n 1))))

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -518,6 +518,82 @@
          (f))
        (list 'done 111 222 333 444))
 
+;;; Regression coverage for issue #124: a let/let*/letrec/do/let-syntax/
+;;; guard binding or clause with the wrong shape (not a pair, or a pair
+;;; with no init/body) was destructured via unchecked vcar/vcdr chains
+;;; across THREE independent implementations of this logic (the Tier 2.1
+;;; IR pipeline in ir_lower.c/ir_emit.c, the classic compiler in
+;;; compiler_classic.c, and the tree-walking evaluator in eval.c) --
+;;; SIGSEGVing the whole process instead of raising a catchable error.
+;;; A malformed binding with a missing init is a plausible typo, so this
+;;; was reachable from ordinary source. Fixed by validating every
+;;; binding/clause up front with the same idiom already used for the
+;;; enclosing form's own arity (require_min_args in the two compiler
+;;; paths; a small equivalent helper in eval.c, which has no access to
+;;; the compiler-internal header that idiom lives in).
+(define (jit124-malformed-raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+(check "let: malformed binding raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(let ((a)) 1) (interaction-environment))))
+       #t)
+(check "named let: malformed binding raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(let loop ((a)) 1) (interaction-environment))))
+       #t)
+(check "let*: malformed binding raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(let* ((a)) 1) (interaction-environment))))
+       #t)
+(check "letrec: malformed binding raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(letrec ((a)) 1) (interaction-environment))))
+       #t)
+(check "letrec*: malformed binding raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(letrec* ((a)) 1) (interaction-environment))))
+       #t)
+(check "do: malformed var-spec raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(do ((a)) (#t) 1) (interaction-environment))))
+       #t)
+(check "let-syntax: malformed binding raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(let-syntax ((m)) 1) (interaction-environment))))
+       #t)
+(check "guard: empty clause raises instead of crashing"
+       (jit124-malformed-raises? (lambda () (eval '(guard (e ()) (raise 'oops)) (interaction-environment))))
+       #t)
+(check "guard: bare single-element clause (R7RS-valid, no body) still works"
+       (eval '(guard (e (#t)) (raise 5)) (interaction-environment))
+       #t)
+;; `eval` here exercises eval.c's OWN tree-walking implementation of each
+;; form, a THIRD independent copy of this logic distinct from both the
+;; classic bytecode compiler (compiler_classic.c) and the Tier 2.1 IR
+;; pipeline (ir_lower.c/ir_emit.c) -- each of those two has its own
+;; identical bug, independently confirmed fixed via `curry -e` (which
+;; compiles rather than tree-walks) during development, but not
+;; exercised by this .scm file: a malformed top-level form would crash
+;; during the COMPILE phase of loading this very test script, before any
+;; runtime `guard` could ever catch it. do/let-syntax/guard specifically
+;; have NO IR lowering at all (SF_DO/SF_LET_SYNTAX/SF_GUARD route
+;; straight to compiler_classic.c's own compile_do/compile_let_syntax/
+;; compile_guard), so for those three forms this compiler-side fix is
+;; the ONLY live path outside eval.c's own tree-walker -- but is
+;; likewise only checkable via a real subprocess compile, not from
+;; inside this file.
+;; Confirms the fix didn't regress ordinary usage of any of these forms.
+(check "let/let*/letrec/do/let-syntax/guard still work correctly"
+       (list (let ((a 1) (b 2)) (+ a b))
+             (let* ((a 1) (b (+ a 1))) b)
+             (letrec ((f (lambda (n) (if (= n 0) 1 (* n (f (- n 1))))))) (f 5))
+             (do ((i 0 (+ i 1)) (s 0 (+ s i))) ((= i 5) s))
+             (let-syntax ((m (syntax-rules () ((_ x) (+ x 1))))) (m 5))
+             (guard (e (#t 'caught)) (raise 'oops)))
+       (list 3 2 120 10 6 'caught))
+
+;;; Issue #125 (ir_emit/ir_emit_inline_call's unbounded per-binding C
+;;; recursion in a flat let* chain, Tier 2.1 IR pipeline) is regression-
+;;; tested in tests/test_cli.sh, not here: `eval` exercises eval.c's own
+;;; tree-walking let* -- a plain while loop over bindings, not per-
+;;; binding C recursion -- so it can't exercise ir_emit.c's bug at all;
+;;; and a malformed/huge top-level form must be tested via a real `curry`
+;;; subprocess compile regardless, for the same reason #124's do/
+;;; let-syntax/guard checks are in test_cli.sh rather than here.
+
 ;;; Tail calls
 (define (count-down n)
   (if (= n 0) 'done (count-down (- n 1))))

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -584,6 +584,20 @@ check_no_segv "do: malformed var-spec compiles to a clean error"          '(do (
 check_no_segv "let-syntax: malformed binding compiles to a clean error"   '(let-syntax ((m)) 1)'
 check_no_segv "letrec-syntax: malformed binding compiles to a clean error" '(letrec-syntax ((m)) 1)'
 check_no_segv "guard: empty clause compiles to a clean error"             '(guard (e ()) 1)'
+
+# ir_lower_letrec is shared by S_LETREC and S_LETREC_STAR; independent
+# code review found it hardcoded "letrec" (not "letrec*") in the raised
+# error message even for a letrec*-specific input -- cosmetic, but a
+# wrong form name in an error message sent a developer looking at the
+# wrong compiler code path. Checked here (not r7rs_tests.scm) because
+# the malformed binding is a COMPILE-time error for the whole enclosing
+# top-level form -- no runtime `guard` inside the same script could ever
+# see it, so this needs the real subprocess-stderr text, same as every
+# other compiler-path check in this section.
+letrec_star_err=$("$CURRY" -e '(let ((f (lambda () (letrec* ((a)) 1)))) (f))' 2>&1 || true)
+check "letrec*: malformed binding names letrec* (not letrec) in the error" \
+      "$(echo "$letrec_star_err" | grep -c 'letrec\*: ill-formed special form')" "1"
+
 # Confirms ordinary usage of all of these still compiles and runs correctly.
 out=$("$CURRY" -e '(display (list (let ((a 1) (b 2)) (+ a b))
                                    (let* ((a 1) (b (+ a 1))) b)

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -658,8 +658,17 @@ for i in $(seq 0 20000); do
     names="$names p$i"
 done
 big_letstar="(display (let* ($bindings) (+$names)))"
+# Written to a real script file and run as a positional argument, NOT
+# passed via -e: this form is ~300KB of source text, comfortably past
+# Linux's default single-argument/whole-argv length limits (ARG_MAX) --
+# confirmed the hard way when CI's ubuntu runners reported exit 126
+# ("argument list too long", bash's own report for an execve() E2BIG)
+# on the very first version of this test that used -e. A script file
+# has no such limit.
+BIG_LETSTAR_SCM="$TMPDIR_CLI/big_letstar.scm"
+printf '%s\n' "$big_letstar" > "$BIG_LETSTAR_SCM"
 set +e
-"$CURRY" -e "$big_letstar" >/dev/null 2>&1
+"$CURRY" "$BIG_LETSTAR_SCM" >/dev/null 2>&1
 big_letstar_code=$?
 set -e
 check "let* with 20001 sequential bindings compiles to a catchable stack-overflow, not a SIGSEGV" "$big_letstar_code" "1"

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -629,21 +629,31 @@ check "let/let*/letrec/do/let-syntax/guard still compile and run correctly" "$ou
 # actually compiles, and a plain bash loop avoids a python/perl
 # dependency in this shell-based suite.
 #
-# 3001 bindings, not ~220: the guard fires at a FRACTION of the real
-# per-thread C stack limit (check_c_stack_depth, runtime.c), and that
-# limit is queried at runtime from the actual ulimit -s in effect, not
-# a fixed constant -- confirmed to vary a lot across how this suite
-# gets invoked: an interactive shell here defaulted to an 8MB stack
-# (~220 bindings was enough to cross the guard's threshold), but
-# CTest's own test-runner process launches this script under a 64MB
-# stack, where 220 bindings finished cleanly (exit 0, guard never
-# fired) and the test read as a silent, non-obvious environment-
-# dependent flake rather than a real failure. 3001 is comfortably past
-# the threshold measured empirically under a 64MB stack too, so the
-# test is robust regardless of the caller's ulimit.
+# 20001 bindings, not ~220 or even 3001: the guard fires at a FRACTION
+# of the real per-thread C stack limit (check_c_stack_depth, runtime.c),
+# and both the actual stack limit AND how much of it each recursion
+# level of ir_emit consumes vary a lot across how this suite is built
+# and invoked -- confirmed empirically twice:
+#  - an interactive Debug-build shell here defaulted to an 8MB stack,
+#    where ~220 bindings was enough to cross the guard's threshold, but
+#    CTest's own test-runner process launches this script under a 64MB
+#    stack, where 220 (and even 3000) bindings finished cleanly (exit
+#    0, guard never fired) -- bumped to 3001, confirmed safe under a
+#    64MB stack too.
+#  - that 3001 figure then still failed the SAME way (exit 0, no
+#    SIGSEGV) under CI's macOS Release build specifically: a Release
+#    build's optimizer shrinks ir_emit's own per-call stack frame
+#    enough that 3001 recursion levels no longer reaches the guard's
+#    threshold at all, on top of the ulimit difference above. 20001 is
+#    comfortably past the threshold measured empirically under a
+#    Release build AND a 64MB stack simultaneously (triggers reliably
+#    above ~8000 in that combination), while staying well under the
+#    reader's own unrelated ~50000-element recursion limit (issue
+#    #129) so this test keeps testing ir_emit's guard specifically,
+#    not the reader's.
 bindings=""
 names=""
-for i in $(seq 0 3000); do
+for i in $(seq 0 20000); do
     bindings="$bindings(p$i 1)"
     names="$names p$i"
 done
@@ -652,7 +662,7 @@ set +e
 "$CURRY" -e "$big_letstar" >/dev/null 2>&1
 big_letstar_code=$?
 set -e
-check "let* with 3001 sequential bindings compiles to a catchable stack-overflow, not a SIGSEGV" "$big_letstar_code" "1"
+check "let* with 20001 sequential bindings compiles to a catchable stack-overflow, not a SIGSEGV" "$big_letstar_code" "1"
 # Confirms a much smaller, entirely ordinary let* chain (nowhere near
 # where the guard fires) still compiles and runs correctly.
 out=$("$CURRY" -e '(display (let* ((p0 1) (p1 1) (p2 1) (p3 1) (p4 1) (p5 1) (p6 1) (p7 1) (p8 1) (p9 1)

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -542,6 +542,110 @@ for cmd in expand asm break unbreak debug; do
     check_contains "REPL survives malformed argument to ,$cmd" "$out" "still alive"
 done
 
+# ─── Malformed let/do/let-syntax/guard binding compiles to a clean error,
+#     not a SIGSEGV (regression, issue #124) ──────────────────────────────────
+#
+# A let/let*/letrec/do/let-syntax/guard binding or clause with the wrong
+# shape (not a pair, or a pair missing its init/body) was destructured via
+# unchecked vcar/vcdr chains with no check that the binding itself was even
+# a pair -- e.g. (let ((a)) 1) SIGSEGV'd the compiler instead of raising a
+# catchable error. Three independent implementations had this bug: the
+# Tier 2.1 IR pipeline (ir_lower.c/ir_emit.c), the classic bytecode
+# compiler (compiler_classic.c), and the tree-walking evaluator (eval.c,
+# reachable via the `eval` builtin -- covered separately in
+# r7rs_tests.scm, since testing that path doesn't require a subprocess).
+# do/let-syntax/guard specifically have NO IR lowering at all, so
+# compiler_classic.c's own copy of the fix is these three forms' ONLY live
+# compilation path outside eval.c's tree-walker -- this is the one place
+# that path can actually be exercised, since a malformed TOP-LEVEL form
+# must crash (or not) during the compile phase of a fresh `curry -e`
+# invocation, before any runtime `guard` in a long-running test script
+# could ever catch it.
+#
+# A bash pipeline's $? for a process killed by a signal is 128+signal
+# (139 for SIGSEGV specifically on every platform this project targets);
+# a clean Scheme-level error instead exits 1 via main.c's own error path.
+# Asserting the exact clean-error exit code (not just "not 139") also
+# catches a fix that silently swallows the error instead of reporting it.
+check_no_segv() {
+    local label="$1" form="$2"
+    set +e
+    "$CURRY" -e "$form" >/dev/null 2>&1
+    local code=$?
+    set -e
+    check "$label" "$code" "1"
+}
+check_no_segv "let: malformed binding compiles to a clean error"          '(let ((a)) 1)'
+check_no_segv "named let: malformed binding compiles to a clean error"    '(let loop ((a)) 1)'
+check_no_segv "let*: malformed binding compiles to a clean error"         '(let* ((a)) 1)'
+check_no_segv "letrec: malformed binding compiles to a clean error"       '(letrec ((a)) 1)'
+check_no_segv "letrec*: malformed binding compiles to a clean error"      '(letrec* ((a)) 1)'
+check_no_segv "do: malformed var-spec compiles to a clean error"          '(do ((a)) (#t) 1)'
+check_no_segv "let-syntax: malformed binding compiles to a clean error"   '(let-syntax ((m)) 1)'
+check_no_segv "letrec-syntax: malformed binding compiles to a clean error" '(letrec-syntax ((m)) 1)'
+check_no_segv "guard: empty clause compiles to a clean error"             '(guard (e ()) 1)'
+# Confirms ordinary usage of all of these still compiles and runs correctly.
+out=$("$CURRY" -e '(display (list (let ((a 1) (b 2)) (+ a b))
+                                   (let* ((a 1) (b (+ a 1))) b)
+                                   (letrec ((f (lambda (n) (if (= n 0) 1 (* n (f (- n 1))))))) (f 5))
+                                   (do ((i 0 (+ i 1)) (s 0 (+ s i))) ((= i 5) s))
+                                   (let-syntax ((m (syntax-rules () ((_ x) (+ x 1))))) (m 5))
+                                   (guard (e (#t (quote caught))) (raise (quote oops)))))')
+check "let/let*/letrec/do/let-syntax/guard still compile and run correctly" "$out" "(3 2 120 10 6 caught)"
+
+# ─── Deeply nested let* compiles to a catchable stack-overflow, not a
+#     SIGSEGV (regression, issue #125) ────────────────────────────────────────
+#
+# ir_emit and ir_emit_inline_call (Tier 2.1 IR pipeline, ir_emit.c)
+# recurse into each other once per binding of a flat let*/letrec*/do
+# chain -- unlike eval()'s own goto-tail trampoline, nothing here reuses
+# a C frame, so a few hundred sequential bindings SIGSEGVs the whole
+# process once the real C stack is exhausted, instead of the catchable
+# stack-overflow condition eval() already raises for its own equivalent
+# unbounded recursion. Fixed by sharing eval()'s own guard
+# (check_c_stack_depth, runtime.c) at ir_emit's entry point. Must be
+# tested via a real subprocess compile: `eval` exercises eval.c's own
+# tree-walking let*, a plain while loop over bindings rather than
+# per-binding C recursion, so it can't reach ir_emit.c's bug at all
+# (see r7rs_tests.scm's own note at the same point).
+#
+# Built as literal source text, not generated Scheme, for the same
+# reason r7rs_tests.scm's own 254-loop-variable named-let test (issue
+# #120) is: this needs to appear as a real top-level form a subprocess
+# actually compiles, and a plain bash loop avoids a python/perl
+# dependency in this shell-based suite.
+#
+# 3001 bindings, not ~220: the guard fires at a FRACTION of the real
+# per-thread C stack limit (check_c_stack_depth, runtime.c), and that
+# limit is queried at runtime from the actual ulimit -s in effect, not
+# a fixed constant -- confirmed to vary a lot across how this suite
+# gets invoked: an interactive shell here defaulted to an 8MB stack
+# (~220 bindings was enough to cross the guard's threshold), but
+# CTest's own test-runner process launches this script under a 64MB
+# stack, where 220 bindings finished cleanly (exit 0, guard never
+# fired) and the test read as a silent, non-obvious environment-
+# dependent flake rather than a real failure. 3001 is comfortably past
+# the threshold measured empirically under a 64MB stack too, so the
+# test is robust regardless of the caller's ulimit.
+bindings=""
+names=""
+for i in $(seq 0 3000); do
+    bindings="$bindings(p$i 1)"
+    names="$names p$i"
+done
+big_letstar="(display (let* ($bindings) (+$names)))"
+set +e
+"$CURRY" -e "$big_letstar" >/dev/null 2>&1
+big_letstar_code=$?
+set -e
+check "let* with 3001 sequential bindings compiles to a catchable stack-overflow, not a SIGSEGV" "$big_letstar_code" "1"
+# Confirms a much smaller, entirely ordinary let* chain (nowhere near
+# where the guard fires) still compiles and runs correctly.
+out=$("$CURRY" -e '(display (let* ((p0 1) (p1 1) (p2 1) (p3 1) (p4 1) (p5 1) (p6 1) (p7 1) (p8 1) (p9 1)
+                                    (p10 1) (p11 1) (p12 1) (p13 1) (p14 1) (p15 1) (p16 1) (p17 1) (p18 1) (p19 1))
+                          (+ p0 p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17 p18 p19)))')
+check "let* with 20 sequential bindings still compiles and runs correctly" "$out" "20"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 
 echo


### PR DESCRIPTION
## Summary

Fixes #124 and #125.

- **#124**: malformed bindings for `let`/`let*`/`letrec`/`letrec*`/`do`/`let-syntax`/`letrec-syntax`/`guard` (e.g. `(let ((a)) ...)`, missing the init expression) SIGSEGVed the process instead of raising a clean compile-time error, across all three of curry's independent compilation paths: the Tier 2.1 IR lowerer (`ir_lower.c`), the classic bytecode compiler (`compiler_classic.c` -- the only live path for `do`/`let-syntax`/`letrec-syntax`/`guard`, which have no IR lowering), and the tree-walking evaluator (`eval.c`). Fixed by validating each binding/clause's shape before destructuring it.
- **#125**: a long flat `let*`/`letrec*`/`do` chain (a few hundred sequential bindings) SIGSEGVed during compilation, since `ir_emit()` recurses once per binding with no bound on the real C stack. Fixed by extracting `eval()`'s existing C-stack-depth guard into a shared `check_c_stack_depth()` (`runtime.c`), now called from both `eval()` and `ir_emit()`'s entry point.

A second commit fixes several more defects surfaced by independent code review and security review of the first commit, still within #124/#125's own scope:
- More eval.c-only crashes in the same form family (missing body on `let*`/`letrec`, missing bindings/body on named `let`, missing test clause on `do`, a dotted `do` step-spec dereferencing a non-pair tail).
- `ir_lower_letrec` named itself "letrec" in its raised error even for a malformed `letrec*` input.
- The #125 stack guard's per-thread stack-size query was unclamped, so `ulimit -s unlimited` (a real Linux default) could push the guard's threshold out past reach and silently disable it -- now clamped to a 512MB ceiling.
- `GC_get_stack_base`'s return value was unchecked, risking either a persistent spurious stack-overflow or a silently disabled guard on a platform where that query fails.

Three related-but-out-of-scope bugs the reviews also found were filed separately rather than folded into this PR: #127 (`cond`/`case` have the identical unchecked-destructure crash), #128 (eval.c has the same gap for `let-values`/`let*-values`/`parameterize`/`when`/`define-syntax`), #129 (the reader itself has no recursion-depth/length limit, so a large-enough malformed input crashes before any of this PR's guards ever run).

## Test plan

- [x] `tests/r7rs_tests.scm`: 362/362 pass (tree-walker-path regression coverage for both issues, via `eval`)
- [x] `tests/test_cli.sh`: 87/87 pass (real-subprocess compiler-path regression coverage -- `do`/`let-syntax`/`guard` have no IR lowering, and #125's stack-overflow chain must be a real top-level compile, so neither is testable via `eval` from inside a `.scm` script)
- [x] Full `ctest` suite, default build: 117/117 pass (`.scc` caches cleared first)
- [x] Full `ctest` suite, LLVM build: 118/118 pass (`.scc` caches cleared first)
- [x] Manually verified the #125 regression test actually catches a regression: reverted the `check_c_stack_depth` call, rebuilt, confirmed the same test now fails with a real SIGSEGV (exit 139), then restored the fix
- [x] Manually verified every crash-to-error fix doesn't regress ordinary, legitimate usage of the same form
