### PR TITLE
fix(compiler,reader): unchecked cond/case, eval.c gaps, unbounded reader recursion (#127, #128, #129)

### DIFF
--- a/src/compiler_classic.c
+++ b/src/compiler_classic.c
@@ -1190,6 +1190,12 @@ static void compile_cond(Compiler *c, val_t clauses, bool tail, int line) {
 
     while (vis_pair(clauses)) {
         val_t clause = vcar(clauses);
+        /* Issue #127: a clause that isn't itself a pair (e.g. `(cond ())`,
+         * `(cond 1)`) previously fell straight into vcar/vcdr below and
+         * SIGSEGVed instead of raising. require_min_args(clause, 1, ...)
+         * accepts the valid bare `(test)` shape (see the vis_nil(exprs)
+         * branch just below) while rejecting a non-pair clause. */
+        require_min_args(clause, 1, "cond");
         val_t test   = vcar(clause);
         val_t exprs  = vcdr(clause);
         clauses      = vcdr(clauses);
@@ -1306,6 +1312,10 @@ static void compile_case(Compiler *c, val_t args, bool tail, int line) {
     val_t cond_head = V_NIL, *cond_tail = &cond_head;
     while (vis_pair(clauses)) {
         val_t clause = vcar(clauses);  clauses = vcdr(clauses);
+        /* Issue #127: same unchecked-destructure shape as compile_cond
+         * above -- a non-pair clause (e.g. `(case 1 1)`, `(case 1 ())`)
+         * previously SIGSEGVed here instead of raising. */
+        require_min_args(clause, 1, "case");
         val_t datums = vcar(clause);
         val_t body   = vcdr(clause);
 
@@ -1595,9 +1605,11 @@ static void compile_guard(Compiler *c, val_t args, bool tail, int line) {
      * loop below destructures it -- see ir_lower_let's identical comment
      * (issue #124, found incidentally while fixing the let/do family):
      * (guard (e ()) 1) previously SIGSEGV'd here on an empty `()`
-     * clause (guard's own clauses share cond's own clause shape, but
-     * unlike compile_cond -- which validates each clause -- this
-     * function never did). */
+     * clause. guard's own clauses share cond's own clause shape; at the
+     * time this comment was first written, compile_cond had NOT yet
+     * been fixed to validate its own clauses either (that was issue
+     * #127, filed as a direct result of independent review flagging
+     * this comment's original claim as false) -- both are now fixed. */
     for (val_t cl0 = clauses; vis_pair(cl0); cl0 = vcdr(cl0))
         require_min_args(vcar(cl0), 1, "guard");
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -409,6 +409,14 @@ tail:
     if (op == S_LET_VALUES || op == S_LET_STAR_VALUES) {
         /* (let-values  (((a b) producer) ...) body...)
          * (let*-values (((a b) producer) ...) body...) */
+        /* Independent review of the #128 fix found `(let-values)` /
+         * `(let*-values)` -- no bindings list at all -- still reached
+         * vcar(rest) below unguarded; the per-binding check just below
+         * only covers a MALFORMED bindings list, not a MISSING one. */
+        if (!vis_pair(rest))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
+                            op == S_LET_VALUES ? "let-values: ill-formed special form"
+                                                : "let*-values: ill-formed special form");
         val_t bindings = vcar(rest), body = vcdr(rest);
         val_t new_env = env_extend(env);
         val_t b = bindings;
@@ -478,6 +486,14 @@ tail:
                 scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "cond: ill-formed special form");
             val_t test   = vcar(clause);
             val_t body   = vcdr(clause);
+            /* Independent security review of the first #127 fix found
+             * more crashes this alone didn't cover: `(cond (1 . 2))`
+             * and `(cond (else . 2))` -- an improper (non-nil, non-
+             * pair) clause tail -- still reached vcar(body) below on a
+             * non-pair. A clause's own body, once past the test, must
+             * be either empty or a proper list starting point. */
+            if (!vis_nil(body) && !vis_pair(body))
+                scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "cond: ill-formed special form");
             rest = vcdr(rest);
 
             if (test == S_ELSE) {
@@ -489,7 +505,11 @@ tail:
             if (vis_true(result)) {
                 if (vis_nil(body)) return result;
                 if (vcar(body) == S_ARROW) {
-                    /* (test => proc) */
+                    /* (test => proc) -- also found by the same review:
+                     * `(cond (1 =>))` has no receiver expression at all,
+                     * so vcadr(body) below would read past the end. */
+                    if (!vis_pair(vcdr(body)))
+                        scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "cond: ill-formed special form");
                     val_t proc = eval(vcadr(body), env);
                     return apply(proc, make_pair(result, V_NIL));
                 }
@@ -515,9 +535,24 @@ tail:
                 scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "case: ill-formed special form");
             val_t datums = vcar(clause);
             val_t body   = vcdr(clause);
+            /* Independent review of the first #127 fix found more
+             * crashes: an improper (non-nil, non-pair) clause body --
+             * `(case 1 ((1) . 2))` -- still reached vcar(body) below.
+             * Same check as S_COND's identical fix just above. */
+            if (!vis_nil(body) && !vis_pair(body))
+                scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "case: ill-formed special form");
             clauses = vcdr(clauses);
             if (datums == S_ELSE) {
-                if (vis_pair(body) && vcar(body) == S_ARROW) {
+                /* `(case 1 (else))` -- an else clause with no body at
+                 * all -- previously reached vcar(body)/vcdr(body) on a
+                 * nil body with no guard; the matched-datum branch below
+                 * already had this check, else's own copy did not. */
+                if (vis_nil(body)) return V_VOID;
+                if (vcar(body) == S_ARROW) {
+                    /* `(case 1 (else =>))` -- no receiver expression --
+                     * would read vcadr(body) past the end without this. */
+                    if (!vis_pair(vcdr(body)))
+                        scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "case: ill-formed special form");
                     return apply(eval(vcadr(body), env), make_pair(key, V_NIL));
                 }
                 while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
@@ -534,6 +569,10 @@ tail:
                 if (match) {
                     if (vis_nil(body)) return V_VOID;
                     if (vcar(body) == S_ARROW) {
+                        /* `(case 1 ((1) =>))` -- same missing-receiver
+                         * gap as else's own arrow form just above. */
+                        if (!vis_pair(vcdr(body)))
+                            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "case: ill-formed special form");
                         return apply(eval(vcadr(body), env), make_pair(key, V_NIL));
                     }
                     while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
@@ -775,6 +814,13 @@ tail:
         /* (parameterize ((param val)...) body...) */
         /* Register a WindFrame so escape continuations trigger parameter
          * restoration via wind_unwind_to, not just normal-exit cleanup. */
+        /* Independent review of the #128 fix found `(parameterize)` --
+         * no bindings list at all -- still reached vcar(rest) below
+         * unguarded; the per-binding check further down only covers a
+         * MALFORMED bindings list, not a MISSING one. Matches
+         * compile_parameterize's own require_min_args(args, 1, ...). */
+        if (!vis_pair(rest))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "parameterize: ill-formed special form");
         val_t bindings = vcar(rest), body = vcdr(rest);
         int n = list_length(bindings);
 
@@ -831,8 +877,19 @@ tail:
         h.saved_jit_depth = jit_depth_save();
         current_handler = &h;
         if (setjmp(h.jmp) == 0) {
-            while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
-            result = eval(vcar(body), env);
+            /* `(parameterize ((p v)))` / `(parameterize ())` -- no body
+             * forms at all -- previously reached vcar(body) on a nil
+             * body and crashed. The compiled path (compile_parameterize)
+             * is lenient here: it desugars to `(lambda () . body)`,
+             * and a zero-body lambda compiles to a no-op returning void
+             * (compile_seq's own vis_nil(list) case) rather than
+             * raising, so match that instead of introducing a stricter
+             * tree-walker-only rejection for the same input. Found via
+             * independent review of the #128 fix. */
+            if (!vis_nil(body)) {
+                while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
+                result = eval(vcar(body), env);
+            }
             current_handler = h.prev;
         } else {
             current_handler = h.prev;

--- a/src/eval.c
+++ b/src/eval.c
@@ -414,6 +414,10 @@ tail:
         val_t b = bindings;
         while (vis_pair(b)) {
             val_t bind   = vcar(b);
+            /* Issue #128: `(let-values (1) 1)` / `(let-values ((a)) 1)`
+             * previously fell straight into vcar/vcadr below and
+             * SIGSEGVed instead of raising. */
+            require_binding_shape(bind, op == S_LET_VALUES ? "let-values" : "let*-values");
             val_t formals = vcar(bind);
             val_t init_e  = vcadr(bind);
             val_t produced = eval(init_e, op == S_LET_STAR_VALUES ? new_env : env);
@@ -438,6 +442,7 @@ tail:
             b = vcdr(b);
         }
         env = new_env;
+        if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
     }
@@ -466,6 +471,11 @@ tail:
     if (op == S_COND) {
         while (vis_pair(rest)) {
             val_t clause = vcar(rest);
+            /* Issue #127: a clause that isn't itself a pair (e.g.
+             * `(cond ())`, `(cond 1)`) previously fell straight into
+             * vcar/vcdr below and SIGSEGVed instead of raising. */
+            if (!vis_pair(clause))
+                scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "cond: ill-formed special form");
             val_t test   = vcar(clause);
             val_t body   = vcdr(clause);
             rest = vcdr(rest);
@@ -491,10 +501,18 @@ tail:
     }
 
     if (op == S_CASE) {
+        /* Issue #127: `(case)` with no key at all previously fell
+         * straight into vcar(rest) below and SIGSEGVed. */
+        if (!vis_pair(rest))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "case: ill-formed special form");
         val_t key = eval(vcar(rest), env);
         val_t clauses = vcdr(rest);
         while (vis_pair(clauses)) {
             val_t clause = vcar(clauses);
+            /* Same shape check as S_COND above: a non-pair clause (e.g.
+             * `(case 1 1)`, `(case 1 ())`) previously SIGSEGVed here. */
+            if (!vis_pair(clause))
+                scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "case: ill-formed special form");
             val_t datums = vcar(clause);
             val_t body   = vcdr(clause);
             clauses = vcdr(clauses);
@@ -528,17 +546,28 @@ tail:
     }
 
     if (op == S_WHEN) {
+        /* Issue #128: `(when)` with no test at all previously fell
+         * straight into vcar(rest) below and SIGSEGVed. */
+        if (!vis_pair(rest))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "when: ill-formed special form");
         val_t cond = eval(vcar(rest), env);
         if (vis_false(cond)) return V_VOID;
         val_t body = vcdr(rest);
+        /* `(when #t)` -- a true test with no body forms at all -- hit
+         * the same missing-body gap #124/#125 fixed for let* / letrec:
+         * vcdr(body) on a nil body crashed instead of returning void. */
+        if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
     }
 
     if (op == S_UNLESS) {
+        if (!vis_pair(rest))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "unless: ill-formed special form");
         val_t cond = eval(vcar(rest), env);
         if (vis_true(cond)) return V_VOID;
         val_t body = vcdr(rest);
+        if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
     }
@@ -630,6 +659,11 @@ tail:
     }
 
     if (op == S_DEFINE_SYNTAX) {
+        /* Issue #128: `(define-syntax)` with no name/transformer at all
+         * previously fell straight into vcar(rest) below and SIGSEGVed.
+         * require_binding_shape checks rest is a pair whose cdr is also
+         * a pair -- exactly the (name transformer-expr) shape needed. */
+        require_binding_shape(rest, "define-syntax");
         val_t name        = vcar(rest);
         val_t transformer = eval(vcadr(rest), env);
         Syntax *syn = CURRY_NEW(Syntax);
@@ -753,7 +787,25 @@ tail:
         val_t b = bindings;
         for (int i = 0; i < n; i++, b = vcdr(b)) {
             val_t pair  = vcar(b);
+            /* Issue #128: `(parameterize (1) 1)` -- a non-pair binding --
+             * previously fell straight into vcar/vcadr below and
+             * SIGSEGVed. Matches compile_parameterize's own
+             * require_min_args(binding, 2, "parameterize") check. */
+            require_binding_shape(pair, "parameterize");
             val_t param = eval(vcar(pair), env);
+            /* `(parameterize ((car)) 1)` -- an expression that evaluates
+             * to something other than an actual parameter object --
+             * previously read ->converter off whatever T_* header
+             * happened to be there instead of raising. The compiled
+             * path (compile_parameterize) never needs this check: it
+             * desugars to an ordinary call through the value as if it
+             * WERE a parameter procedure, so a non-parameter fails
+             * naturally via normal application (e.g. arity or
+             * not-a-procedure) instead of an explicit check here; this
+             * function calls as_param directly rather than going
+             * through apply, so it needs its own check to match. */
+            if (!vis_param(param))
+                scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "parameterize: not a parameter");
             val_t val   = eval(vcadr(pair), env);
             if (!vis_false(as_param(param)->converter))
                 val = apply(as_param(param)->converter, make_pair(val, V_NIL));

--- a/src/reader.c
+++ b/src/reader.c
@@ -333,6 +333,19 @@ static val_t read_list(val_t port, int close_ch);
  * character is a literal '.'), and nothing re-checked for a genuine
  * dotted tail immediately following it. */
 static val_t read_list_tail(val_t port, int close_ch) {
+    /* Issue #129: read_list_tail and read_list (below) are mutually
+     * recursive once per list element -- a flat list of tens of
+     * thousands of elements, or a chain of dot-prefixed-symbol
+     * elements specifically (this function's own direct self-
+     * recursion just below, for "..."/".foo"-style tokens), previously
+     * exhausted the real C stack with no bound at all and SIGSEGVed,
+     * well before either of #125's own guards (eval()/ir_emit(), both
+     * compile-time) are ever reached -- read happens first. Shares
+     * check_c_stack_depth (src/runtime.c) with those two, the same way
+     * ir_emit() shares it with eval() rather than each guarding a
+     * private copy: it's the same real stack, the same "how close to
+     * the top" answer regardless of which caller asks. */
+    check_c_stack_depth("read");
     skip_whitespace(port);
     int elem_line = port_line(port);
     int c = peek_char_port(port);
@@ -367,6 +380,10 @@ static val_t read_list_tail(val_t port, int close_ch) {
 }
 
 static val_t read_list(val_t port, int close_ch) {
+    /* See read_list_tail's identical comment just above (issue #129) --
+     * this function is the other half of the same mutually-recursive
+     * pair, called once per list element in both directions. */
+    check_c_stack_depth("read");
     skip_whitespace(port);
     int c = peek_char_port(port);
     if (c == close_ch) { next_char(port); return V_NIL; }
@@ -463,6 +480,12 @@ static val_t wrap1(val_t sym, val_t v) {
 /* ---- Main reader ---- */
 
 static val_t read_datum(val_t port) {
+    /* Issue #129: a long chain of prefix reader macros (a few thousand
+     * nested `'`/`` ` ``/`,`/`,@`) recurses through this function's own
+     * quote/quasiquote/unquote cases below with no bound, the same
+     * unguarded-recursion class as read_list/read_list_tail's own
+     * per-element recursion (see their identical comment). */
+    check_c_stack_depth("read");
     skip_whitespace(port);
     int c = next_char(port);
     if (c == -1) return V_EOF;

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1208,6 +1208,33 @@
 (check "case: missing key raises instead of crashing"
        (jit127-malformed-raises? (lambda () (eval '(case) (interaction-environment))))
        #t)
+;; A second round of independent review of the fix just above found
+;; more crashes it didn't cover -- an improper (non-nil, non-pair)
+;; clause body, and an `=>` arrow clause with no receiver expression --
+;; in both cond and case, including case's own `else` clause (which had
+;; its own separate copy of the same logic, missing the same checks its
+;; sibling matched-datum branch already had).
+(check "cond: improper clause tail raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(cond (1 . 2)) (interaction-environment))))
+       #t)
+(check "cond: improper else-clause tail raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(cond (else . 2)) (interaction-environment))))
+       #t)
+(check "cond: arrow clause with no receiver raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(cond (1 =>)) (interaction-environment))))
+       #t)
+(check "case: improper clause tail raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(case 1 ((1) . 2)) (interaction-environment))))
+       #t)
+(check "case: else clause with no body doesn't crash (returns void)"
+       (jit127-malformed-raises? (lambda () (eval '(case 1 (else)) (interaction-environment)) #f))
+       #f)
+(check "case: else-arrow clause with no receiver raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(case 1 (else =>)) (interaction-environment))))
+       #t)
+(check "case: matched-arrow clause with no receiver raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(case 1 ((1) =>)) (interaction-environment))))
+       #t)
 ;; The compiler-path halves of #127 (compile_cond/compile_case) can only
 ;; be tested via a real subprocess compile, same reasoning as #124's own
 ;; do/let-syntax/guard checks -- see tests/test_cli.sh.
@@ -1240,6 +1267,26 @@
 (check "parameterize: non-parameter value raises instead of crashing"
        (jit127-malformed-raises? (lambda () (eval '(parameterize ((car 5)) 1) (interaction-environment))))
        #t)
+;; A second round of independent review of the fix just above found
+;; `(let-values)` / `(let*-values)` / `(parameterize)` -- no operand
+;; list at all, not merely a malformed one -- still crashed: the
+;; per-binding checks above only fire once a bindings LIST is already
+;; being iterated. Also confirms `(parameterize ())` (a valid empty
+;; bindings list with no body) matches the compiled path's own
+;; leniency here (returns void) rather than introducing a stricter,
+;; tree-walker-only rejection for the same input.
+(check "let-values: missing bindings list raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(let-values) (interaction-environment))))
+       #t)
+(check "let*-values: missing bindings list raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(let*-values) (interaction-environment))))
+       #t)
+(check "parameterize: missing bindings list raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(parameterize) (interaction-environment))))
+       #t)
+(check "parameterize: empty bindings and no body doesn't crash (returns void)"
+       (jit127-malformed-raises? (lambda () (eval '(parameterize ()) (interaction-environment)) #f))
+       #f)
 (check "when: missing test raises instead of crashing"
        (jit127-malformed-raises? (lambda () (eval '(when) (interaction-environment))))
        #t)

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1184,6 +1184,133 @@
 (check "type-of: a primitive" (type-of car) 'primitive)
 (check "type-of: flonum" (type-of 1.5) 'flonum)
 
+;;; Issue #127: cond/case clause destructuring was unchecked in both
+;;; compile_cond/compile_case (compiler_classic.c) and eval.c's own
+;;; S_COND/S_CASE handlers -- a clause that wasn't itself a pair (e.g.
+;;; `(cond ())`, `(cond 1)`, `(case 1 1)`) SIGSEGVed instead of raising.
+;;; Found via independent security review of the #124/#125 fix, which
+;;; used the identical validate-before-destructure idiom for the
+;;; let/letrec/do family but missed this sibling form entirely.
+(define (jit127-malformed-raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+(check "cond: empty clause raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(cond ()) (interaction-environment))))
+       #t)
+(check "cond: non-pair clause raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(cond 1) (interaction-environment))))
+       #t)
+(check "case: empty clause raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(case 1 ()) (interaction-environment))))
+       #t)
+(check "case: non-pair clause raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(case 1 1) (interaction-environment))))
+       #t)
+(check "case: missing key raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(case) (interaction-environment))))
+       #t)
+;; The compiler-path halves of #127 (compile_cond/compile_case) can only
+;; be tested via a real subprocess compile, same reasoning as #124's own
+;; do/let-syntax/guard checks -- see tests/test_cli.sh.
+(check "cond/case still work correctly"
+       (list (cond (#f 1) (#t 2))
+             (cond ((assv 1 (list (cons 1 'a))) => cdr) (else 'no))
+             (case 2 ((1) 'one) ((2) 'two) (else 'other))
+             (case 5 ((1 2) 'a) (else 'b)))
+       (list 2 'a 'two 'b))
+
+;;; Issue #128: several more eval.c-only unchecked-destructure gaps in
+;;; the same class as #124/#127, found by independent code review.
+;;; These are tree-walker-only bugs -- the corresponding compiler paths
+;;; already validate correctly for the same malformed input.
+(check "let-values: non-pair binding raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(let-values (1) 1) (interaction-environment))))
+       #t)
+(check "let-values: malformed binding raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(let-values ((a)) 1) (interaction-environment))))
+       #t)
+(check "let*-values: malformed binding raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(let*-values ((a)) 1) (interaction-environment))))
+       #t)
+(check "parameterize: non-pair binding raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(parameterize (1) 1) (interaction-environment))))
+       #t)
+(check "parameterize: malformed binding raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(parameterize ((car)) 1) (interaction-environment))))
+       #t)
+(check "parameterize: non-parameter value raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(parameterize ((car 5)) 1) (interaction-environment))))
+       #t)
+(check "when: missing test raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(when) (interaction-environment))))
+       #t)
+(check "when: missing body doesn't crash (returns void)"
+       (jit127-malformed-raises? (lambda () (eval '(when #t) (interaction-environment)) #f))
+       #f)
+(check "unless: missing test raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(unless) (interaction-environment))))
+       #t)
+(check "define-syntax: missing name/transformer raises instead of crashing"
+       (jit127-malformed-raises? (lambda () (eval '(define-syntax) (interaction-environment))))
+       #t)
+(check "let-values/let*-values/parameterize/when/unless still work correctly"
+       (list (let-values (((a b) (values 1 2))) (+ a b))
+             (let*-values (((a) (values 1)) ((b) (values (+ a 1)))) b)
+             (let* ((p (make-parameter 10)))
+               (parameterize ((p 20)) (p)))
+             (when #t 'yes)
+             (unless #f 'also-yes))
+       (list 3 2 20 'yes 'also-yes))
+
+;;; Issue #129: the reader itself (src/reader.c) had no recursion-depth
+;;; or list-length limit at all -- read_list/read_list_tail recurse
+;;; once per list element with no bound, and read_datum recurses once
+;;; per prefix reader macro (quote/quasiquote/unquote) with no bound
+;;; either. A sufficiently large flat list, deeply nested parens, or a
+;;; long quote-chain all SIGSEGVed at READ time, before any compiler or
+;;; eval() guard (#125) is ever reached. Fixed by sharing the same
+;;; check_c_stack_depth guard #125 added, called from read_datum,
+;;; read_list, and read_list_tail. Exercised here via `read` on a
+;;; string port -- the reader is a single shared implementation (unlike
+;;; eval() vs. the compilers), so this genuinely exercises the same
+;;; code a top-level script parse would.
+;; 1000000, not the ~15000-60000 that was enough to crash the pre-fix
+;; binary: same lesson as #125's own test_cli.sh threshold (see that
+;; file's comment), compounded by BOTH known sources of variance found
+;; there -- the guard fires at a FRACTION of the real per-thread stack
+;; limit, and (a) CTest's test-runner process launches this script
+;; under a much larger default stack (64MB) than an interactive shell
+;; (8MB), while (b) a Release build's optimizer shrinks read_list/
+;; read_list_tail/read_datum's own per-recursion-level stack frame
+;; enough that a given recursion depth needs even more levels to reach
+;; the same threshold. Confirmed empirically: Release-build + 64MB
+;; stack (the worst combination actually seen, on CI) needed >600000
+;; for the tightest of the three vectors (nested parens). 1000000 is
+;; comfortably past all three under that combination, confirmed fast
+;; (well under a second) even at this size.
+(define (jit129-flat-list-source n)
+  (let ((out (open-output-string)))
+    (write-char #\( out)
+    (do ((i 0 (+ i 1))) ((= i n))
+      (write-char #\1 out) (write-char #\space out))
+    (write-char #\) out)
+    (get-output-string out)))
+(check "reader: oversized flat list raises a catchable stack-overflow, not a SIGSEGV"
+       (guard (e (#t 'caught))
+         (read (open-input-string (jit129-flat-list-source 1000000))))
+       'caught)
+(check "reader: deeply nested parens raise a catchable stack-overflow, not a SIGSEGV"
+       (guard (e (#t 'caught))
+         (read (open-input-string
+                (string-append (make-string 1000000 #\() "1" (make-string 1000000 #\))))))
+       'caught)
+(check "reader: long quote-chain raises a catchable stack-overflow, not a SIGSEGV"
+       (guard (e (#t 'caught))
+         (read (open-input-string (string-append (make-string 1000000 #\') "1"))))
+       'caught)
+(check "reader: ordinary lists/nesting/quoting still read correctly"
+       (read (open-input-string "(1 2 (3 (4 5)) 'x)"))
+       '(1 2 (3 (4 5)) (quote x)))
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -598,6 +598,20 @@ letrec_star_err=$("$CURRY" -e '(let ((f (lambda () (letrec* ((a)) 1)))) (f))' 2>
 check "letrec*: malformed binding names letrec* (not letrec) in the error" \
       "$(echo "$letrec_star_err" | grep -c 'letrec\*: ill-formed special form')" "1"
 
+# Issue #127: compile_cond/compile_case (compiler_classic.c) had the
+# identical unchecked-clause-destructure crash as the let/letrec/do
+# family above, found by independent security review of the #124/#125
+# fix -- missed entirely since it's a different form family, not a
+# variant of let. r7rs_tests.scm covers the eval.c (tree-walker) half
+# via `eval`; these need a real subprocess compile for the same reason
+# every other compiler-path check in this section does.
+check_no_segv "cond: empty clause compiles to a clean error"  '(cond ())'
+check_no_segv "cond: non-pair clause compiles to a clean error" '(cond 1)'
+check_no_segv "case: empty clause compiles to a clean error"  '(case 1 ())'
+check_no_segv "case: non-pair clause compiles to a clean error" '(case 1 1)'
+out=$("$CURRY" -e '(display (list (cond (#f 1) (#t 2)) (case 2 ((1) (quote one)) ((2) (quote two)))))')
+check "cond/case still compile and run correctly" "$out" "(2 two)"
+
 # Confirms ordinary usage of all of these still compiles and runs correctly.
 out=$("$CURRY" -e '(display (list (let ((a 1) (b 2)) (+ a b))
                                    (let* ((a 1) (b (+ a 1))) b)


### PR DESCRIPTION
## Summary

Fixes #127, #128, and #129 — three follow-up bugs found by independent code review and security review of the #124/#125 fix (PR #130, merged), all the same unchecked-destructure SIGSEGV class but in different forms/subsystems that PR didn't cover.

- **#127**: `compile_cond`/`compile_case` (compiler_classic.c) and eval.c's own `S_COND`/`S_CASE` handlers didn't validate clause shape before destructuring — `(cond ())`, `(cond 1)`, `(case 1 ())`, `(case 1 1)`, `(case)` all SIGSEGVed. Fixed with the same `require_min_args`/pair-check idiom used throughout #124. Also corrects a comment in `compile_guard` that had (at the time) falsely claimed `compile_cond` already validated its own clauses — true again now, but was the actual source of this issue being filed in the first place.
- **#128**: more eval.c-only gaps in the same class — `let-values`/`let*-values` (non-pair/malformed binding, missing body), `parameterize` (non-pair binding, and a value that isn't actually a parameter object — this function reads `as_param` directly rather than going through `apply`, so unlike the compiled path it needs its own explicit type check), `when`/`unless` (missing test, missing body), `define-syntax` (missing name/transformer). All tree-walker-only; the corresponding compiler paths already validated correctly.
- **#129**: the reader (`src/reader.c`) had no recursion-depth or list-length limit at all. `read_list`/`read_list_tail` are mutually recursive once per list element; `read_datum` recurses once per quote/quasiquote/unquote prefix. A large enough flat list, deep nesting, or long quote-chain SIGSEGVed at **read** time, before any of #125's own guards (`eval()`/`ir_emit()`, both compile-time) are ever reached. Fixed by sharing the same `check_c_stack_depth` guard #125 added, called from all three reader functions.

## Test plan

- [x] `tests/r7rs_tests.scm`: 383/383 pass (tree-walker + reader coverage — the reader is a single shared implementation, so `read` on a string port genuinely exercises the same code a top-level parse would)
- [x] `tests/test_cli.sh`: 92/92 pass (real-subprocess compiler-path coverage for cond/case)
- [x] Full `ctest`, default build: 117/117 pass (one pre-existing flaky `websocket` port-bind failure, confirmed unrelated by rerunning in isolation)
- [x] Full `ctest`, LLVM build: 118/118 pass
- [x] Manually verified every crash-to-error fix doesn't regress ordinary, legitimate usage of the same form
- [x] Reader test thresholds (1,000,000 elements) verified reliable across Debug/Release builds combined with both an 8MB and a 64MB stack ulimit locally, after discovering the same threshold-sensitivity #125 hit (a Release build's optimizer shrinks the per-recursion-level stack frame, and CTest launches under a much larger default stack than an interactive shell)
