### PR TITLE
fix(eval,port): systemic eval.c argument-shape gaps and printer recursion (#132, #133)

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -171,6 +171,21 @@ static void require_binding_shape(val_t binding, const char *form_name) {
     require_min_args(binding, 2, form_name);
 }
 
+/* A second round of independent review of the #132 fix found more
+ * crashes in the exact same class, one level down: several of the
+ * "if (vis_nil(body)) return V_VOID; while (vis_pair(vcdr(body))) ..."
+ * body-loops the earlier fixes added only guarded the NIL case (no
+ * body forms at all) -- an IMPROPER (non-nil, non-pair) body, e.g.
+ * `(let* () . 5)` or `((lambda () . 5))`, still reaches vcdr(body) on
+ * a non-pair and crashes. This checks both invalid shapes in one call;
+ * callers still need their own `if (vis_nil(body)) return V_VOID;`
+ * (or equivalent) for the legitimate empty-body case -- this only
+ * rejects what's actually malformed. */
+static void require_body_shape(val_t body, const char *form_name) {
+    if (!vis_nil(body) && !vis_pair(body))
+        scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "%s: ill-formed special form", form_name);
+}
+
 val_t eval(val_t expr, val_t env) {
     /* Detects an approaching real C-stack overflow from unbounded
      * non-tail recursion through eval() -- goto-tail iterations below
@@ -252,6 +267,12 @@ tail:
          * compiled path already accepts and compiles `(lambda ())` as
          * a no-op returning void when called. */
         require_min_args(rest, 1, "lambda");
+        /* `((lambda () . 5))` -- an improper (non-nil, non-pair) body --
+         * previously stored straight into c->body and crashed the FIRST
+         * time this closure was ever called (the shared closure-
+         * application trampoline, below, does vcdr(body) unconditionally).
+         * Checked once here at creation time rather than on every call. */
+        require_body_shape(vcdr(rest), "lambda");
         Closure *c = CURRY_NEW_PINNED(Closure);
         c->hdr.type  = T_CLOSURE;
         c->hdr.flags = 0;
@@ -263,6 +284,13 @@ tail:
     }
 
     if (op == S_BEGIN) {
+        /* `(begin . 5)` -- an improper (non-nil, non-pair) body --
+         * previously reached vcdr(rest) on a non-pair and crashed;
+         * found by a second round of independent review, and relevant
+         * beyond `begin` itself since named let's own tail call
+         * delegates to `(begin . body)` (see S_LET below), so this
+         * closes that path too. */
+        require_body_shape(rest, "begin");
         if (vis_nil(rest)) return V_VOID;
         while (vis_pair(vcdr(rest))) {
             eval(vcar(rest), env);
@@ -289,6 +317,8 @@ tail:
                 as_clos(val)->name = name_form;
         } else if (vis_pair(name_form)) {
             /* (define (name params...) body...) */
+            /* `(define (f) . 5)` -- see S_LAMBDA's identical comment. */
+            require_body_shape(vcdr(rest), "define");
             val_t name   = vcar(name_form);
             val_t params = vcdr(name_form);
             Closure *c   = CURRY_NEW_PINNED(Closure);
@@ -312,6 +342,17 @@ tail:
          * vcar(rest)/vcadr(rest) below and SIGSEGVed. */
         require_min_args(rest, 2, "set!");
         val_t sym = vcar(rest);
+        /* `(set! 1 2)` -- a non-symbol name -- found by independent
+         * security review to be a type-confusion bug, not just a
+         * missing-check crash: sym_cstr(sym) below unconditionally
+         * reads sym as if it were a Symbol object's own header/data
+         * layout, so a fixnum crashes outright and a String reads
+         * memory at the wrong struct-field offset and %s-formats
+         * whatever's there into the raised error message -- an
+         * out-of-bounds heap read reachable from untrusted source, not
+         * just a segfault. */
+        if (!vis_symbol(sym))
+            scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "set!: not a symbol");
         val_t val = eval(vcadr(rest), env);
         if (!env_set(env, sym, val))
             scm_raise_code(EC_UNBOUND_VARIABLE, "set!: unbound variable: %s", sym_cstr(sym));
@@ -346,6 +387,10 @@ tail:
 
     /* (let ((x v) ...) body...) */
     if (op == S_LET) {
+        /* Issue #132 (missed in the first pass, found by a second round
+         * of independent review): `(let)` -- no bindings/body at all --
+         * previously fell straight into vcar(rest) below and SIGSEGVed. */
+        require_min_args(rest, 1, "let");
         val_t bindings = vcar(rest);
         val_t body     = vcdr(rest);
 
@@ -356,6 +401,10 @@ tail:
                 scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "let: ill-formed special form");
             bindings = vcar(body);
             body     = vcdr(body);
+            /* `(let loop () . 5)` -- see S_LAMBDA's identical comment;
+             * this closure's body is invoked via the same shared
+             * closure-application trampoline every ordinary call is. */
+            require_body_shape(body, "let");
 
             val_t new_env = env_extend(env);
             /* Collect params and inits */
@@ -407,12 +456,15 @@ tail:
             b = vcdr(b);
         }
         env = new_env;
+        require_body_shape(body, "let");
         if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
     }
 
     if (op == S_LET_STAR) {
+        /* `(let*)` -- see S_LET's identical comment just above. */
+        require_min_args(rest, 1, "let*");
         val_t bindings = vcar(rest), body = vcdr(rest);
         val_t cur_env = env_extend(env);
         while (vis_pair(bindings)) {
@@ -422,12 +474,15 @@ tail:
             bindings = vcdr(bindings);
         }
         env = cur_env;
+        require_body_shape(body, "let*");
         if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
     }
 
     if (op == S_LETREC || op == S_LETREC_STAR) {
+        /* `(letrec)` / `(letrec*)` -- see S_LET's identical comment above. */
+        require_min_args(rest, 1, op == S_LETREC ? "letrec" : "letrec*");
         val_t bindings = vcar(rest), body = vcdr(rest);
         val_t new_env = env_extend(env);
         /* Pre-define all vars as undefined */
@@ -446,6 +501,7 @@ tail:
             b = vcdr(b);
         }
         env = new_env;
+        require_body_shape(body, op == S_LETREC ? "letrec" : "letrec*");
         if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
@@ -495,6 +551,7 @@ tail:
             b = vcdr(b);
         }
         env = new_env;
+        require_body_shape(body, op == S_LET_VALUES ? "let-values" : "let*-values");
         if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
@@ -639,7 +696,10 @@ tail:
         val_t body = vcdr(rest);
         /* `(when #t)` -- a true test with no body forms at all -- hit
          * the same missing-body gap #124/#125 fixed for let* / letrec:
-         * vcdr(body) on a nil body crashed instead of returning void. */
+         * vcdr(body) on a nil body crashed instead of returning void.
+         * `(when #t . 5)` -- an improper body -- hit the sibling gap a
+         * later review round found (see require_body_shape's comment). */
+        require_body_shape(body, "when");
         if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
@@ -651,6 +711,7 @@ tail:
         val_t cond = eval(vcar(rest), env);
         if (vis_true(cond)) return V_VOID;
         val_t body = vcdr(rest);
+        require_body_shape(body, "unless");
         if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
@@ -682,6 +743,9 @@ tail:
             if (vis_true(test_val)) {
                 /* Termination */
                 val_t result = vcdr(term);
+                /* `(do () (#t . 2))` -- an improper result-clause tail --
+                 * found by a later review round. */
+                require_body_shape(result, "do");
                 if (vis_nil(result)) return V_VOID;
                 while (vis_pair(vcdr(result))) { eval(vcar(result), do_env); result = vcdr(result); }
                 expr = vcar(result); env = do_env; goto tail;
@@ -714,6 +778,10 @@ tail:
     }
 
     if (op == S_DELAY) {
+        /* `(delay . 5)` -- see S_LAMBDA's identical comment; this
+         * closure's body is forced via the same shared closure-
+         * application trampoline every ordinary call is. */
+        require_body_shape(rest, "delay");
         Promise *p = CURRY_NEW(Promise);
         p->hdr.type=T_PROMISE; p->hdr.flags=0;
         p->state = PROMISE_LAZY;
@@ -726,6 +794,7 @@ tail:
     }
 
     if (op == S_DELAY_FORCE) {
+        require_body_shape(rest, "delay-force");
         Promise *p = CURRY_NEW(Promise);
         p->hdr.type=T_PROMISE; p->hdr.flags=0;
         p->state = PROMISE_LAZY;
@@ -761,6 +830,12 @@ tail:
     }
 
     if (op == S_LET_SYNTAX || op == S_LETREC_SYNTAX) {
+        /* `(let-syntax)` -- see S_LET's identical comment above -- and
+         * `(let-syntax ())` -- valid empty bindings but no body at all,
+         * confirmed the compiled path already accepts this leniently
+         * (returns void) -- previously crashed on vcar(rest) and on
+         * vcdr(body) respectively; neither was guarded before. */
+        require_min_args(rest, 1, op == S_LET_SYNTAX ? "let-syntax" : "letrec-syntax");
         val_t bindings = vcar(rest), body = vcdr(rest);
         val_t new_env = env_extend(env);
         while (vis_pair(bindings)) {
@@ -774,6 +849,8 @@ tail:
             bindings = vcdr(bindings);
         }
         env = new_env;
+        require_body_shape(body, op == S_LET_SYNTAX ? "let-syntax" : "letrec-syntax");
+        if (vis_nil(body)) return V_VOID;
         while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
         expr = vcar(body); goto tail;
     }
@@ -877,6 +954,10 @@ tail:
         if (!vis_pair(rest))
             scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "parameterize: ill-formed special form");
         val_t bindings = vcar(rest), body = vcdr(rest);
+        /* `(parameterize ((p 1)) . 5)` -- an improper body -- found by a
+         * later review round; checked up front rather than after the
+         * wind-frame machinery below is already set up. */
+        require_body_shape(body, "parameterize");
         int n = list_length(bindings);
 
         ParamBindings *pb = gc_alloc_raw_pinned(sizeof(ParamBindings));
@@ -975,6 +1056,11 @@ tail:
         val_t var         = vcar(var_clauses);
         val_t clauses     = vcdr(var_clauses);
         val_t body        = vcdr(rest);
+        /* `(guard (e) . 5)` -- an improper body -- found by a later
+         * review round; the nil case remains intentionally lenient
+         * (see comment above), only the genuinely malformed shape
+         * raises. */
+        require_body_shape(body, "guard");
 
         val_t result = V_VOID;
         ExnHandler h;
@@ -1018,12 +1104,26 @@ tail:
             val_t cbody  = vcdr(clause);
             cs = vcdr(cs);
             if (test == S_ELSE) {
+                /* `(guard (e (else)) ...)` / `(guard (e (else . 2)) ...)`
+                 * -- a missing or improper else-body -- found by a later
+                 * review round; unlike cond's else (which shares this
+                 * exact validate-then-nil-means-void shape, from #127),
+                 * this branch had never been guarded at all. */
+                if (!vis_nil(cbody) && !vis_pair(cbody))
+                    scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "guard: ill-formed special form");
+                if (vis_nil(cbody)) return V_VOID;
                 while (vis_pair(vcdr(cbody))) { eval(vcar(cbody), guard_env); cbody = vcdr(cbody); }
                 return eval(vcar(cbody), guard_env);
             }
             val_t tv = eval(test, guard_env);
             if (vis_true(tv)) {
-                if (vis_nil(cbody)) return tv;
+                /* `!vis_pair(cbody)` (not just vis_nil) so an improper
+                 * body like `(guard (e (#t . 2)) ...)` -- found by the
+                 * same review round -- also falls back to returning the
+                 * test's own value rather than crashing on vcdr(cbody)
+                 * below; matches the compiled path's own confirmed
+                 * (if slightly odd) leniency for this exact shape. */
+                if (!vis_pair(cbody)) return tv;
                 while (vis_pair(vcdr(cbody))) { eval(vcar(cbody), guard_env); cbody = vcdr(cbody); }
                 return eval(vcar(cbody), guard_env);
             }

--- a/src/eval.c
+++ b/src/eval.c
@@ -312,6 +312,13 @@ tail:
         val_t val;
         if (vis_symbol(name_form)) {
             /* (define name expr) */
+            /* `(define x . 5)` -- an improper tail -- found by a third
+             * review round: the comment above claims a missing value
+             * expression is "already handled safely" by the ternary
+             * just below, which is true only for a NIL tail; vcdr(rest)
+             * being improper (non-nil, non-pair) still reached
+             * vcadr(rest) -> vcar(5) and crashed. */
+            require_body_shape(vcdr(rest), "define");
             val = vis_nil(vcdr(rest)) ? V_VOID : eval(vcadr(rest), env);
             if (vis_closure(val) && vis_false(as_clos(val)->name))
                 as_clos(val)->name = name_form;

--- a/src/eval.c
+++ b/src/eval.c
@@ -149,9 +149,26 @@ static val_t eval_call_cc(val_t proc) {
  * compiler_internal.h, scoped to the bytecode compiler's own files --
  * this is the tree-walker's separate copy of the same tiny check,
  * matching its exact behavior and error message). */
+/* Issue #132: independent security review of the #127/#128 fix found
+ * the identical unchecked-`rest`-destructure crash across a much wider
+ * set of special forms than any single prior issue tracked (if/lambda/
+ * define/set!/define-values/quasiquote/call-with-values/call/cc/guard
+ * all SIGSEGVed on a too-short argument list). This is the tree-
+ * walker's own copy of compiler.c's require_min_args (same exact
+ * shape-checking loop, same error), used at every one of those sites
+ * below rather than hand-rolling an equivalent `!vis_pair(...)` check
+ * per site as the earlier one-off fixes did. */
+static void require_min_args(val_t args, int min, const char *form_name) {
+    val_t p = args;
+    for (int i = 0; i < min; i++) {
+        if (!vis_pair(p))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "%s: ill-formed special form", form_name);
+        p = vcdr(p);
+    }
+}
+
 static void require_binding_shape(val_t binding, const char *form_name) {
-    if (!vis_pair(binding) || !vis_pair(vcdr(binding)))
-        scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS, "%s: ill-formed special form", form_name);
+    require_min_args(binding, 2, form_name);
 }
 
 val_t eval(val_t expr, val_t env) {
@@ -211,6 +228,12 @@ tail:
     }
 
     if (op == S_IF) {
+        /* Issue #132: `(if)` and `(if test)` (missing the consequent)
+         * previously fell straight into vcar(rest)/vcar(vcdr(rest))
+         * below and SIGSEGVed. The alternate branch is genuinely
+         * optional (checked separately below via vis_nil(alt)), but
+         * test and consequent are not. */
+        require_min_args(rest, 2, "if");
         val_t cond = eval(vcar(rest), env);
         rest = vcdr(rest);
         if (vis_true(cond)) {
@@ -223,6 +246,12 @@ tail:
     }
 
     if (op == S_LAMBDA) {
+        /* Issue #132: `(lambda)` -- no params list at all -- previously
+         * fell straight into vcar(rest) below and SIGSEGVed. A zero-
+         * body lambda (rest = (params) only) is fine -- confirmed the
+         * compiled path already accepts and compiles `(lambda ())` as
+         * a no-op returning void when called. */
+        require_min_args(rest, 1, "lambda");
         Closure *c = CURRY_NEW_PINNED(Closure);
         c->hdr.type  = T_CLOSURE;
         c->hdr.flags = 0;
@@ -243,6 +272,14 @@ tail:
     }
 
     if (op == S_DEFINE) {
+        /* Issue #132: `(define)` -- no name/expr at all -- previously
+         * fell straight into vcar(rest) below and SIGSEGVed. A missing
+         * value expression (`(define x)`) is already handled safely
+         * just below (vis_nil(vcdr(rest)) ? V_VOID : ...), and a
+         * non-symbol/non-pair name_form already raises via the final
+         * else branch -- only the totally-missing-rest case was
+         * unguarded. */
+        require_min_args(rest, 1, "define");
         val_t name_form = vcar(rest);
         val_t val;
         if (vis_symbol(name_form)) {
@@ -270,6 +307,10 @@ tail:
     }
 
     if (op == S_SET) {
+        /* Issue #132: `(set!)` / `(set! x)` -- missing the symbol
+         * and/or value expression -- previously fell straight into
+         * vcar(rest)/vcadr(rest) below and SIGSEGVed. */
+        require_min_args(rest, 2, "set!");
         val_t sym = vcar(rest);
         val_t val = eval(vcadr(rest), env);
         if (!env_set(env, sym, val))
@@ -283,6 +324,10 @@ tail:
 
     if (op == S_DEFINE_VALUES) {
         /* (define-values (var...) expr) */
+        /* Issue #132: `(define-values)` / `(define-values (a))` --
+         * missing the vars list and/or expr -- previously fell
+         * straight into vcar(rest)/vcadr(rest) below and SIGSEGVed. */
+        require_min_args(rest, 2, "define-values");
         val_t vars = vcar(rest);
         val_t val  = eval(vcadr(rest), env);
         if (!vis_values(val)) {
@@ -693,6 +738,9 @@ tail:
     }
 
     if (op == S_QUASIQUOTE) {
+        /* Issue #132: `(quasiquote)` -- no operand at all -- previously
+         * fell straight into vcar(rest) below and SIGSEGVed. */
+        require_min_args(rest, 1, "quasiquote");
         val_t expanded = expand_qq(vcar(rest), env, 0);
         expr = expanded; goto tail;
     }
@@ -792,6 +840,10 @@ tail:
     }
 
     if (op == S_CALL_WITH_VALUES) {
+        /* Issue #132: `(call-with-values)` / `(call-with-values p)` --
+         * missing the producer and/or consumer -- previously fell
+         * straight into vcar(rest)/vcadr(rest) below and SIGSEGVed. */
+        require_min_args(rest, 2, "call-with-values");
         val_t producer = eval(vcar(rest), env);
         val_t consumer = eval(vcadr(rest), env);
         val_t produced = apply(producer, V_NIL);
@@ -806,6 +858,9 @@ tail:
     }
 
     if (op == S_CALL_CC || op == S_CALL_WITH_CC) {
+        /* Issue #132: `(call/cc)` -- no operand at all -- previously
+         * fell straight into vcar(rest) below and SIGSEGVed. */
+        require_min_args(rest, 1, op == S_CALL_CC ? "call/cc" : "call-with-current-continuation");
         val_t proc = eval(vcar(rest), env);
         return eval_call_cc(proc);
     }
@@ -906,7 +961,17 @@ tail:
 
     if (op == S_GUARD) {
         /* (guard (var clause...) body...) */
+        /* Issue #132: `(guard)` -- no var/clauses list at all -- and
+         * `(guard ())` -- an empty one, missing var -- previously fell
+         * straight into vcar(rest)/vcar(var_clauses) below and
+         * SIGSEGVed. Matches compile_guard's own two require_min_args
+         * calls (one for each level). A missing BODY, by contrast, is
+         * intentionally left lenient below (matches the compiled
+         * path's own leniency: `(guard (e))` compiles to a no-op
+         * returning void, not an error). */
+        require_min_args(rest, 1, "guard");
         val_t var_clauses = vcar(rest);
+        require_min_args(var_clauses, 1, "guard");
         val_t var         = vcar(var_clauses);
         val_t clauses     = vcdr(var_clauses);
         val_t body        = vcdr(rest);
@@ -920,8 +985,10 @@ tail:
         vm_exn_state_save(&h.saved_vm_frame_count, &h.saved_vm_sp, &h.saved_vm_open_upvalues);
         current_handler = &h;
         if (setjmp(h.jmp) == 0) {
-            while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
-            result = eval(vcar(body), env);
+            if (!vis_nil(body)) {
+                while (vis_pair(vcdr(body))) { eval(vcar(body), env); body = vcdr(body); }
+                result = eval(vcar(body), env);
+            }
             current_handler = h.prev;
             return result;
         }
@@ -994,6 +1061,13 @@ tail:
                 const char *kw = sym_cstr(vcar(rest));
                 if (kw[0] == '#' && kw[1] == ':') {
                     val_t kw_sym = vcar(rest); rest = vcdr(rest);
+                    /* Issue #132: a #:keyword modifier with no argument
+                     * after it at all (e.g. `(import (curry redis)
+                     * #:prefix)`) previously fell straight into
+                     * vcar(rest) below on a nil rest and SIGSEGVed. */
+                    if (!vis_pair(rest))
+                        scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
+                                        "import: missing argument after %s", sym_cstr(kw_sym));
                     val_t kw_arg = vcar(rest); rest = vcdr(rest);
                     const char *name = sym_cstr(kw_sym) + 2; /* skip "#:" */
 

--- a/src/port.c
+++ b/src/port.c
@@ -3,6 +3,7 @@
 #include "gc.h"
 #include "numeric.h"
 #include "symbol.h"
+#include "eval.h"
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -408,6 +409,15 @@ static void write_number_notation(val_t v, val_t port) {
 }
 
 void scm_write(val_t v, val_t port) {
+    /* Issue #133: this plain (non-cycle-safe) writer -- reached
+     * directly by write-simple and by the debugger's own value
+     * printing (debug.c), bypassing scm_write_shared/ws_write's own
+     * guard entirely -- has the identical unbounded car-recursion in
+     * its own pair-writing branch below. Guarded at this function's
+     * single entry point since scm_write recurses into itself (both
+     * directly for a nested pair's car, and indirectly for a nested
+     * pair's own tail via the cdr loop's per-element calls). */
+    check_c_stack_depth("write");
     char buf[64];
     if (vis_nil(v))      { port_write_string(port, "()", 2); return; }
     if (vis_void(v))     { return; /* unspecified - write nothing */ }
@@ -716,6 +726,15 @@ static bool ws_is_compound(val_t v) {
  * list (no cycle, no sharing) overflow the C stack on write()/display(),
  * since those now route through this pass unconditionally. */
 static void ws_count_refs(val_t v, WSharedMap *m) {
+    /* Issue #133: the cdr-chain loop above is already iterative (see
+     * this function's own header comment), but the car recursion just
+     * below is not -- a deeply CAR-nested structure built at runtime
+     * (e.g. repeated `(list x)`-wrapping in a loop, never going through
+     * the reader) recurses once per nesting level with no bound, the
+     * same unbounded-C-recursion class #125/#129 already fixed for
+     * ir_emit and the reader. Shares check_c_stack_depth (runtime.c)
+     * with those, for the same reason ir_emit shares it with eval(). */
+    check_c_stack_depth("write");
     while (ws_is_compound(v)) {
         WSharedEntry *e = ws_find(m, v);
         if (e) { e->count++; return; }
@@ -758,6 +777,13 @@ static void ws_write_list(val_t v, val_t port, WSharedMap *m, bool as_display) {
 }
 
 static void ws_write(val_t v, val_t port, WSharedMap *m, bool as_display) {
+    /* See ws_count_refs's identical comment (issue #133) -- ws_write and
+     * ws_write_list are mutually recursive once per level of CAR
+     * nesting (ws_write_list's own cdr loop is already iterative, but
+     * its per-element ws_write(vcar(...)) call is not); guarding this
+     * single entry point covers the whole recursive tree, the same way
+     * ir_emit's own single guarded entry covers ir_emit_inline_call. */
+    check_c_stack_depth("write");
     if (!ws_is_compound(v)) { if (as_display) scm_display(v, port); else scm_write(v, port); return; }
     WSharedEntry *e = ws_find(m, v);
     if (e && e->count > 1) {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -788,6 +788,17 @@ val_t apply_arr(val_t proc, int argc, val_t *argv) {
 
 val_t eval_body(val_t exprs, val_t env) {
     if (vis_nil(exprs)) return V_VOID;
+    /* `(with-assumptions () . 5)` -- an improper (non-nil, non-pair)
+     * body -- found by a third round of independent review: this is
+     * the shared body-sequencing trampoline several eval.c special
+     * forms delegate to (with-assumptions among them), and unlike
+     * eval.c's own inlined body loops (see require_body_shape's
+     * comment there, same fix), this copy had never been guarded
+     * against a non-pair exprs that isn't nil either. Checked here
+     * once, in the shared function, rather than requiring every future
+     * caller to remember its own copy of the check. */
+    if (!vis_pair(exprs))
+        scm_raise(V_FALSE, "ill-formed special form: improper body");
     bool in_body = false;
     while (vis_pair(vcdr(exprs))) {
         val_t form = vcar(exprs);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -139,7 +139,29 @@ void scm_raise_val(val_t exn) {
         current_handler->exn = exn;
         longjmp(current_handler->jmp, 1);
     }
-    /* Unhandled: print and abort */
+    /* Unhandled: print and abort. */
+    /* Independent security review of #133 (the printer's own stack-
+     * depth guard) found this path could recurse without bound instead
+     * of aborting: raising an UNCAUGHT exception whose payload is
+     * itself deeply CAR-nested makes scm_write_shared below hit
+     * check_c_stack_depth's guard (we're already deep in the C stack --
+     * that's WHY it fired), which raises a stack-overflow condition by
+     * calling scm_raise_val again; with no current_handler that lands
+     * right back at this same "Unhandled: print" code, which tries to
+     * print AGAIN while still at (or past) the same stack depth,
+     * firing the guard again immediately -- an unbounded print-raise
+     * cycle observed to print thousands of "Unhandled exception:"
+     * lines before eventually SIGSEGVing anyway once even the
+     * guard's own emergency margin is exhausted. A thread-local re-
+     * entrancy flag breaks the cycle: the second (or later) entry
+     * skips the recursive-printer call entirely and goes straight to
+     * abort() with a plain, non-recursive fallback message. */
+    static CURRY_THREAD_LOCAL bool in_unhandled_exception = false;
+    if (in_unhandled_exception) {
+        fprintf(stderr, "\n(unhandled exception while printing a previous unhandled exception)\n");
+        abort();
+    }
+    in_unhandled_exception = true;
     fprintf(stderr, "Unhandled exception: ");
     scm_write_shared(exn, PORT_STDERR);
     fprintf(stderr, "\n");

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1518,6 +1518,19 @@
 (check "set!: non-symbol name raises instead of crashing"
        (jit132-malformed-raises? (lambda () (eval '(set! 1 2) (interaction-environment))))
        #t)
+;; A third round of independent review found two more sites in the
+;; same class: define's symbol-name branch had its own separate
+;; ternary for the missing-value case that require_body_shape's sweep
+;; hadn't reached (only the lambda-sugar branch got it), and
+;; with-assumptions delegates to eval_body (runtime.c) -- the shared
+;; closure-application trampoline -- which had never been guarded
+;; against an improper body at all.
+(check "define: improper tail (symbol-name branch) raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(define x . 5) (interaction-environment))))
+       #t)
+(check "with-assumptions: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(with-assumptions () . 5) (interaction-environment))))
+       #t)
 (check "let/let*/letrec/let-syntax/when/unless/guard/do/begin still work correctly with ordinary bodies"
        (list (let () 1 2 3) (let* () 4) (letrec () 5) (let-syntax () 6)
              (when #t 'yes) (unless #f 'also-yes)

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1428,6 +1428,106 @@
              (call/cc (lambda (k) (k 42))))
        (list 1 2 5 10 2 1 '(1 2) 3 'caught 42))
 
+;;; A second round of independent code/security review of the #132 fix
+;;; found more crashes it didn't cover: `(let)`/`(let*)`/`(letrec)`/
+;;; `(letrec*)`/`(let-syntax)`/`(letrec-syntax)` -- no bindings/body at
+;;; all, missed since the first pass only checked forms with a fixed
+;;; small number of required arguments, not this "at least the
+;;; bindings position must exist" family -- plus a whole separate class
+;;; the first pass didn't consider: an IMPROPER (non-nil, non-pair)
+;;; body, e.g. `(let () . 5)`, reaches vcdr(body) on a non-pair in the
+;;; body-sequencing loop nearly every form in this file shares. Also
+;;; found: `(set! 1 2)` was a type-confusion bug, not just a crash --
+;;; sym_cstr(sym) read a non-Symbol object's memory at the wrong
+;;; struct-field offset.
+(check "let: missing bindings/body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(let) (interaction-environment))))
+       #t)
+(check "let*: missing bindings/body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(let*) (interaction-environment))))
+       #t)
+(check "letrec: missing bindings/body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(letrec) (interaction-environment))))
+       #t)
+(check "letrec*: missing bindings/body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(letrec*) (interaction-environment))))
+       #t)
+(check "let-syntax: missing bindings/body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(let-syntax) (interaction-environment))))
+       #t)
+(check "letrec-syntax: missing bindings/body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(letrec-syntax) (interaction-environment))))
+       #t)
+(check "let-syntax: empty bindings and no body doesn't crash (returns void)"
+       (jit132-malformed-raises? (lambda () (eval '(let-syntax ()) (interaction-environment)) #f))
+       #f)
+(check "when: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(when #t . 5) (interaction-environment))))
+       #t)
+(check "unless: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(unless #f . 5) (interaction-environment))))
+       #t)
+(check "let: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(let () . 5) (interaction-environment))))
+       #t)
+(check "let*: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(let* () . 5) (interaction-environment))))
+       #t)
+(check "letrec: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(letrec () . 5) (interaction-environment))))
+       #t)
+(check "let-values: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(let-values () . 5) (interaction-environment))))
+       #t)
+(check "let-syntax: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(let-syntax () . 5) (interaction-environment))))
+       #t)
+(check "lambda: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '((lambda () . 5)) (interaction-environment))))
+       #t)
+(check "named let: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(let loop () . 5) (interaction-environment))))
+       #t)
+(check "delay: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(delay . 5) (interaction-environment))))
+       #t)
+(check "delay-force: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(delay-force . 5) (interaction-environment))))
+       #t)
+(check "guard: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(guard (e) . 5) (interaction-environment))))
+       #t)
+(check "guard: else clause with no body doesn't crash (returns void)"
+       (jit132-malformed-raises? (lambda () (eval '(guard (e (else)) (raise 1)) (interaction-environment)) #f))
+       #f)
+(check "guard: else clause with improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(guard (e (else . 2)) (raise 1)) (interaction-environment))))
+       #t)
+(check "guard: matched-test clause with improper body doesn't crash (falls back to test value)"
+       (eval '(guard (e (#t . 2)) (raise 1)) (interaction-environment))
+       #t)
+(check "parameterize: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(parameterize () . 5) (interaction-environment))))
+       #t)
+(check "do: improper result-clause tail raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(do () (#t . 2)) (interaction-environment))))
+       #t)
+(check "begin: improper body raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(begin . 5) (interaction-environment))))
+       #t)
+(check "set!: non-symbol name raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(set! 1 2) (interaction-environment))))
+       #t)
+(check "let/let*/letrec/let-syntax/when/unless/guard/do/begin still work correctly with ordinary bodies"
+       (list (let () 1 2 3) (let* () 4) (letrec () 5) (let-syntax () 6)
+             (when #t 'yes) (unless #f 'also-yes)
+             (do () (#t 'done))
+             (begin 1 2 3)
+             (let ((x 1)) (set! x 2) x)
+             (guard (e (else 'e)) (raise 1))
+             (guard (e (#t)) (raise 1)))
+       (list 3 4 5 6 'yes 'also-yes 'done 3 2 'e #t))
+
 ;;; Issue #133: the printer (write/display, src/port.c) has the same
 ;;; unbounded-recursion class #129 fixed for the reader, but for
 ;;; runtime-constructed data rather than source text: ws_count_refs/

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1358,6 +1358,116 @@
        (read (open-input-string "(1 2 (3 (4 5)) 'x)"))
        '(1 2 (3 (4 5)) (quote x)))
 
+;;; Issue #132: independent security review of the #127/#128 fix found
+;;; the identical unchecked-`rest`-destructure crash across a much
+;;; wider set of eval.c special forms than any single prior issue
+;;; tracked -- if/lambda/define/set!/define-values/quasiquote/
+;;; call-with-values/call-cc/guard/import(#:keyword) all SIGSEGVed on a
+;;; too-short argument list. Each of these already had a compiled-path
+;;; equivalent (compiler_classic.c/ir_lower.c) that validated correctly
+;;; for the same input -- only the tree-walker was missing the check.
+(define (jit132-malformed-raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+(check "if: missing arguments raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(if) (interaction-environment))))
+       #t)
+(check "if: missing consequent raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(if #t) (interaction-environment))))
+       #t)
+(check "lambda: missing params raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(lambda) (interaction-environment))))
+       #t)
+(check "define: missing name/expr raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(define) (interaction-environment))))
+       #t)
+(check "set!: missing arguments raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(set!) (interaction-environment))))
+       #t)
+(check "set!: missing value raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(set! x) (interaction-environment))))
+       #t)
+(check "define-values: missing arguments raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(define-values) (interaction-environment))))
+       #t)
+(check "define-values: missing expr raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(define-values (a)) (interaction-environment))))
+       #t)
+(check "quasiquote: missing operand raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(quasiquote) (interaction-environment))))
+       #t)
+(check "call-with-values: missing arguments raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(call-with-values) (interaction-environment))))
+       #t)
+(check "call-with-values: missing consumer raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(call-with-values (lambda () 1)) (interaction-environment))))
+       #t)
+(check "call/cc: missing operand raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(call/cc) (interaction-environment))))
+       #t)
+(check "guard: missing var-clauses list raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(guard) (interaction-environment))))
+       #t)
+(check "guard: empty var-clauses list raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(guard ()) (interaction-environment))))
+       #t)
+(check "guard: missing body doesn't crash (returns void)"
+       (jit132-malformed-raises? (lambda () (eval '(guard (e)) (interaction-environment)) #f))
+       #f)
+(check "import: #:keyword with no argument raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(import (curry crypto) #:prefix) (interaction-environment))))
+       #t)
+(check "if/lambda/define/set!/define-values/quasiquote/call-with-values/call-cc/guard still work correctly"
+       (list (if #t 1) (if #f 1 2) ((lambda () 5))
+             (let () (define x 10) x)
+             (let ((y 1)) (set! y 2) y)
+             (let-values (((a) (values 1))) a)
+             `(1 ,(+ 1 1))
+             (call-with-values (lambda () (values 1 2)) +)
+             (guard (e (#t 'caught)) (raise 'oops))
+             (call/cc (lambda (k) (k 42))))
+       (list 1 2 5 10 2 1 '(1 2) 3 'caught 42))
+
+;;; Issue #133: the printer (write/display, src/port.c) has the same
+;;; unbounded-recursion class #129 fixed for the reader, but for
+;;; runtime-constructed data rather than source text: ws_count_refs/
+;;; ws_write (the write/display-shared machinery) and plain scm_write
+;;; (write-simple, and the debugger's own value printing) all recurse
+;;; once per level of CAR nesting with no bound. A deeply car-nested
+;;; list built at runtime (never going through the reader, so #129's
+;;; own fix doesn't cover it) previously SIGSEGVed on write/display/
+;;; write-simple. Fixed by sharing check_c_stack_depth (the same guard
+;;; #125/#129 already share) at all three functions' own entries.
+;; 1000000, not a smaller depth: same lesson as #125/#129's own test
+;; thresholds -- the guard fires at a fraction of the real per-thread
+;; stack limit, and a Release build's optimizer shrinks ws_write's own
+;; per-recursion-level stack frame enough that 500000 (already
+;; confirmed reliable under Debug builds and under write-simple's
+;; simpler, unshared scm_write path at any build type) stopped
+;; reaching the guard's threshold under Release+64MB-stack specifically
+;; -- confirmed empirically that 800000 was the minimum reliable depth
+;; there; 1000000 gives comfortable margin, confirmed fast (well under
+;; a second) even at this size.
+(define (jit133-build-deep n x)
+  (if (= n 0) x (jit133-build-deep (- n 1) (list x))))
+(check "write: deeply car-nested runtime list raises a catchable stack-overflow, not a SIGSEGV"
+       (guard (e (#t 'caught))
+         (write (jit133-build-deep 1000000 1) (open-output-string)))
+       'caught)
+(check "write-simple: deeply car-nested runtime list raises a catchable stack-overflow, not a SIGSEGV"
+       (guard (e (#t 'caught))
+         (write-simple (jit133-build-deep 1000000 1) (open-output-string)))
+       'caught)
+(check "display: deeply car-nested runtime list raises a catchable stack-overflow, not a SIGSEGV"
+       (guard (e (#t 'caught))
+         (display (jit133-build-deep 1000000 1) (open-output-string)))
+       'caught)
+(check "write/write-simple/display: ordinary depth still works correctly"
+       (let ((out (open-output-string)))
+         (write (jit133-build-deep 50 1) out)
+         (string-length (get-output-string out)))
+       101)
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")


### PR DESCRIPTION
## Summary

Fixes #132 and #133, plus follow-up gaps found across two further rounds of independent review of this same fix.

- **#132**: eval.c's special-form handlers destructure a form's own argument list without checking it's a pair first, across a much wider set of forms than any prior issue tracked. Fixed `if`/`lambda`/`define`/`set!`/`define-values`/`quasiquote`/`call-with-values`/`call/cc`/`guard`/`let`/`let*`/`letrec`/`letrec*`/`let-syntax`/`letrec-syntax`/`with-assumptions`, plus a whole separate class of **improper (dotted) body** crashes across nearly all of the above (`(let () . 5)`, `((lambda () . 5))`, `(delay . 5)`, `(do () (#t . 2))`, `(begin . 5)`, etc.) via a new shared `require_body_shape` helper. Also fixed a real type-confusion bug: `(set! 1 2)` read a non-Symbol value as if it had a Symbol's own memory layout.
- **#133**: the printer (write/display, `src/port.c`) has the same unbounded-recursion class #129 fixed for the reader, but for runtime-constructed data (a deeply CAR-nested list built via repeated `cons`/`list`, never touching the reader). Fixed by sharing `check_c_stack_depth` at `ws_count_refs`/`ws_write`/`scm_write`'s own entries. Also fixed a related bug the guard itself exposed: raising an *uncaught* exception whose payload is deeply nested turned the new guard into an unbounded print-raise recursion cycle in `runtime.c`'s unhandled-exception path — fixed with a re-entrancy flag.

Two follow-up issues found during review are filed separately, out of scope here: #134 (the symbolic CAS module has a related but distinct unbounded-recursion problem, both during expression-tree construction and in its own dedicated printers) and #135 (`define-record-type` and `syntax-rules` crash on malformed input on **both** the compiled and tree-walked paths — a different class from everything else in this series, since those were tree-walker-only gaps).

## Test plan

- [x] `tests/r7rs_tests.scm`: 444/444 pass (confirmed across Debug/Release builds × 8MB/64MB stack ulimits, following the threshold-sensitivity lessons from #125/#129)
- [x] `tests/test_cli.sh`: 92/92 pass
- [x] Full `ctest`, default build: 117/117 pass
- [x] Full `ctest`, LLVM build: 118/118 pass
- [x] Three rounds of independent code-review/security-review subagents, each round's findings fixed and re-verified before the next
- [x] Manually verified every crash-to-error fix doesn't regress ordinary, legitimate usage of the same form
- [x] Manually verified the unhandled-exception re-entrancy fix actually breaks the print-raise cycle (a deeply nested uncaught `raise` now aborts cleanly instead of flooding stderr)
