### PR TITLE
fix(symbolic,numeric,set): unbounded recursion in CAS, tuple arithmetic, and equal?/hash (#134)

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -305,6 +305,14 @@ bool num_is_integer(val_t v) {
 
 /* Apply a binary numeric op element-wise to two same-type tuples. */
 static val_t tuple_binop(val_t a, val_t b, val_t (*op)(val_t, val_t), const char *ctx) {
+    /* Issue #134 (found via independent security review of the
+     * symbolic-CAS fix): a nested tuple (built in O(1) per level via
+     * `up`/`down`, with no simplification pass to cap depth the way
+     * sx_simplify does) recurses here once per level of nesting when
+     * `op` (num_neg/num_add/etc) dispatches back into a nested tuple
+     * element, with no bound. Same guard, same class as symbolic.c's
+     * own tree-walkers. */
+    check_c_stack_depth("numeric");
     Tuple *ta = as_tuple(a), *tb = as_tuple(b);
     if (ta->hdr.type != tb->hdr.type || ta->len != tb->len)
         scm_raise(V_FALSE, "tuple %s: type/dimension mismatch", ctx);
@@ -315,6 +323,8 @@ static val_t tuple_binop(val_t a, val_t b, val_t (*op)(val_t, val_t), const char
 
 /* Apply a unary numeric op element-wise to a tuple. */
 static val_t tuple_unop(val_t a, val_t (*op)(val_t)) {
+    /* Same unbounded-recursion class as tuple_binop above (issue #134). */
+    check_c_stack_depth("numeric");
     Tuple *t = as_tuple(a);
     val_t buf[256]; uint32_t n = t->len < 256 ? t->len : 256;
     for (uint32_t i = 0; i < n; i++) buf[i] = op(t->data[i]);
@@ -531,6 +541,14 @@ val_t num_mul(val_t a, val_t b) {
     /* Tuple distribution takes priority over symbolic so that sym-var × up-tuple
        distributes component-wise rather than wrapping in a CAS expression. */
     if (vis_tuple(a) || vis_tuple(b)) {
+        /* Issue #134: unlike num_add/num_sub/num_neg (which all route
+         * through the already-guarded tuple_binop/tuple_unop), this is
+         * num_mul's own separate inline tuple-distribution loop, which
+         * recurses into itself (num_mul(scalar, t->data[i])) once per
+         * level of a nested (up-wrapped) tuple with no bound. Found via
+         * independent security review after tuple_binop/tuple_unop's
+         * own guards turned out not to cover this path. */
+        check_c_stack_depth("numeric");
         if (vis_tuple(a) && vis_tuple(b)) {
             if (!vis_down(a) || !vis_up(b))
                 scm_raise(V_FALSE, "tuple *: only (down)*(up) contraction is defined");

--- a/src/set.c
+++ b/src/set.c
@@ -3,6 +3,7 @@
 #include "gc.h"
 #include "numeric.h"
 #include "symbolic.h"
+#include "eval.h"
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -33,6 +34,13 @@ bool scm_eqv(val_t a, val_t b) {
 }
 
 bool scm_equal(val_t a, val_t b) {
+    /* Same unbounded-recursion class as symbolic.c's own tree-walkers
+     * (issue #134, found via independent security review of that fix):
+     * self-recurses into pair/vector/etc structure with no bound, and
+     * is reachable from ordinary Scheme data with no symbolic module
+     * involved at all -- a deeply nested list built via `(list e)` in
+     * a loop and compared with `equal?` SIGSEGVed. */
+    check_c_stack_depth("equal?");
     if (scm_eqv(a, b)) return true;
     if (vis_pair(a) && vis_pair(b))
         return scm_equal(vcar(a), vcar(b)) && scm_equal(vcdr(a), vcdr(b));
@@ -109,6 +117,8 @@ static uint32_t hash_mpz(mpz_srcptr z) {
  * inequality at the first differing element — an accepted tradeoff, same
  * as every other Scheme's equal-hash implementation. */
 uint32_t val_hash(val_t v, int cmp_type) {
+    /* Same unbounded-recursion class as scm_equal above (issue #134). */
+    check_c_stack_depth("equal?");
     if (cmp_type == SET_CMP_EQ || vis_imm(v) || vis_fixnum(v) || vis_char(v))
         return hash_u64((uint64_t)v);
     if (vis_flonum(v)) {

--- a/src/symbolic.c
+++ b/src/symbolic.c
@@ -225,6 +225,16 @@ static bool decompose_trig_sq(val_t term,
 
 
 val_t sx_simplify(val_t expr) {
+    /* Issue #134: sx_simplify recurses into itself once per argument of
+     * every nested SymExpr node (just below, and again for the tuple
+     * case) with no bound at all -- a deeply nested expression tree
+     * built via repeated unary/binary applications (e.g. `(sin (sin
+     * (sin ... x)))` a few thousand levels deep, or any user script
+     * that recursively wraps a sym-var) SIGSEGVs during construction,
+     * before the value even exists for #133's printer guard to ever
+     * see. Shares check_c_stack_depth (runtime.c) with eval()/ir_emit()/
+     * the reader/the printer -- same real C stack, same guard. */
+    check_c_stack_depth("symbolic");
     if (!vis_symexpr(expr)) {
         /* Tuple: simplify each component */
         if (vis_tuple(expr)) {
@@ -1263,6 +1273,11 @@ static val_t sx_diff_symfn_idx(val_t fn, int idx) {
 /* ---- Symbolic differentiation ---- */
 
 val_t sx_diff(val_t expr, val_t var) {
+    /* Same unbounded-recursion class as sx_simplify/sx_substitute above
+     * (issue #134): its own separate self-recursive tree-walk (product/
+     * chain-rule cases below recurse into sx_diff on their own
+     * subexpressions), not merely a caller of either. */
+    check_c_stack_depth("symbolic");
     /* var must be a T_SYMVAR */
     if (!vis_symvar(var))
         scm_raise(V_FALSE, "∂: second argument must be a symbolic variable");
@@ -1485,6 +1500,8 @@ val_t sx_diff(val_t expr, val_t var) {
 /* ---- Wirtinger derivatives  ∂/∂z  and  ∂/∂z̄ ---- */
 
 val_t sx_wirtinger(val_t expr, val_t var, bool is_dbar) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symvar(var))
         scm_raise(V_FALSE, "wirtinger: second argument must be a symbolic variable");
 
@@ -1657,6 +1674,11 @@ val_t sx_wirtinger(val_t expr, val_t var, bool is_dbar) {
 /* ---- Substitution ---- */
 
 val_t sx_substitute(val_t expr, val_t var, val_t val) {
+    /* Same unbounded-recursion class as sx_simplify above (issue #134):
+     * this is its own separate self-recursive tree-walk, not merely a
+     * caller of sx_simplify (which only gets consulted at the very end
+     * of each level, on the way back up), so it needs its own guard. */
+    check_c_stack_depth("symbolic");
     if (vis_number(expr)) return expr;
     if (vis_symvar(expr)) {
         if (as_symvar(expr)->name == as_symvar(var)->name) return val;
@@ -1741,6 +1763,8 @@ static val_t expand_ncmul2(val_t a, val_t b) {
 }
 
 val_t sx_expand(val_t expr) {
+    /* Same unbounded-recursion class as sx_simplify above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symbolic(expr)) return expr;
     if (vis_symvar(expr)) return expr;
 
@@ -2011,6 +2035,8 @@ val_t sx_leading_coeff(val_t expr, val_t var) {
 /* ---- Symbolic integration ---- */
 
 val_t sx_integrate(val_t expr, val_t var) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symvar(var))
         scm_raise(V_FALSE, "∫: second argument must be a symbolic variable");
 
@@ -2497,6 +2523,8 @@ val_t sx_integrate(val_t expr, val_t var) {
  *   D^α (D^β f) = D^(α+β) f                  (composition)
  */
 val_t sx_fracdiff(val_t expr, val_t alpha, val_t var) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symvar(var))
         scm_raise(V_FALSE, "frac-diff: third argument must be a symbolic variable");
 
@@ -2622,6 +2650,8 @@ unevaluated:;
  *   I^α (c·f)  = c · I^α f                   (constant factor)
  */
 val_t sx_fracint(val_t expr, val_t alpha, val_t var) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symvar(var))
         scm_raise(V_FALSE, "frac-int: third argument must be a symbolic variable");
 
@@ -2855,6 +2885,12 @@ static val_t sx_limit_unevaluated(val_t expr, val_t var, val_t point) {
 }
 
 static val_t sx_limit_inner(val_t expr, val_t var, val_t point, int dir, int depth) {
+    /* LHOPITAL_MAX below only bounds the L'Hopital-iteration count
+     * (depth+1 calls); the separate tree-structural recursion into each
+     * subexpression (la[i] = sx_limit_inner(args[i], ...), same depth)
+     * is bounded only by expression NESTING, which is unbounded --
+     * issue #134's same class as sx_diff/sx_simplify above. */
+    check_c_stack_depth("symbolic");
     if (depth > LHOPITAL_MAX)
         return sx_limit_unevaluated(expr, var, point);
 
@@ -3121,6 +3157,8 @@ static val_t sx_linear_coeff(val_t expr, val_t var) {
 }
 
 val_t sx_laplace(val_t expr, val_t t_var, val_t s_var) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symvar(t_var))
         scm_raise(V_FALSE, "laplace: t argument must be a symbolic variable");
     if (!vis_symvar(s_var))
@@ -3252,6 +3290,8 @@ val_t sx_laplace(val_t expr, val_t t_var, val_t s_var) {
 /* ---- Inverse Laplace (table-based) ---- */
 
 val_t sx_ilaplace(val_t expr, val_t s_var, val_t t_var) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symvar(s_var))
         scm_raise(V_FALSE, "ilaplace: s argument must be a symbolic variable");
     if (!vis_symvar(t_var))
@@ -3421,6 +3461,8 @@ static val_t sx_fourier_fn(val_t fn, val_t t_var, val_t w_var) {
 }
 
 val_t sx_fourier(val_t expr, val_t t_var, val_t w_var) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symvar(t_var))
         scm_raise(V_FALSE, "fourier: t argument must be a symbolic variable");
     if (!vis_symvar(w_var))
@@ -3492,6 +3534,8 @@ val_t sx_fourier(val_t expr, val_t t_var, val_t w_var) {
 }
 
 val_t sx_ifourier(val_t expr, val_t w_var, val_t t_var) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     /* Minimal inverse: linearity only, fallback unevaluated */
     if (!vis_symvar(w_var))
         scm_raise(V_FALSE, "ifourier: omega argument must be a symbolic variable");

--- a/src/symbolic.c
+++ b/src/symbolic.c
@@ -148,6 +148,8 @@ val_t sx_expr_arg(val_t e, int i) { return as_symexpr(e)->args[i]; }
 /* ---- Structural equality ---- */
 
 bool sx_equal(val_t a, val_t b) {
+    /* Same unbounded-recursion class as sx_simplify (issue #134). */
+    check_c_stack_depth("symbolic");
     if (a == b) return true;
     if (vis_symvar(a) && vis_symvar(b))
         return as_symvar(a)->name == as_symvar(b)->name;
@@ -949,6 +951,8 @@ val_t sx_simplify(val_t expr) {
  *   cos²(f) − sin²(f)  →  cos(2·f)
  */
 val_t sx_trigsimp(val_t expr) {
+    /* Same unbounded-recursion class as sx_simplify above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symexpr(expr)) return expr;
 
     SymExpr *se = as_symexpr(expr);
@@ -1127,6 +1131,8 @@ val_t sx_trigsimp(val_t expr) {
    quaternion-typed sym-var — signalling that products involving v are
    non-commutative and must use SX_NCMUL. */
 static bool sx_is_nc(val_t v) {
+    /* Same unbounded-recursion class as sx_simplify above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (vis_quat(v) || vis_oct(v)) return true;
     if (vis_symvar(v)) return (sym_var_flags(v) & SYM_ASSUME_QUATERNION) != 0;
     if (!vis_symexpr(v)) return false;
@@ -1704,6 +1710,16 @@ val_t sx_substitute(val_t expr, val_t var, val_t val) {
 /* ---- Dependency test ---- */
 
 bool sx_depends_on(val_t expr, val_t var) {
+    /* Same unbounded-recursion class as sx_simplify above (issue #134).
+     * Found by independent security review to be reachable at
+     * unbounded depth despite sx_integrate/sx_limit/sx_series/
+     * sx_laplace/sx_ilaplace/sx_fourier/sx_ifourier's own guards
+     * already having run: this is called as their first structural
+     * check, on a `up`/`down` tuple expression, which builds nesting
+     * in O(1) per level with no simplification pass -- unlike ordinary
+     * symexpr construction (capped by sx_simplify's own guard), a
+     * tuple's depth is not bounded before it ever reaches here. */
+    check_c_stack_depth("symbolic");
     if (vis_number(expr)) return false;
     if (vis_symvar(expr))
         return as_symvar(expr)->name == as_symvar(var)->name;
@@ -1832,6 +1848,8 @@ val_t sx_expand(val_t expr) {
 
 /* Internal: degree as a C long (−1 for transcendentals of var, 0 for constants). */
 long sx_degree_long(val_t expr, val_t var) {
+    /* Same unbounded-recursion class as sx_diff above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (vis_number(expr)) return 0;
     if (vis_symvar(expr))
         return (as_symvar(expr)->name == as_symvar(var)->name) ? 1 : 0;
@@ -2790,6 +2808,10 @@ unevaluated_i:;
 static val_t sx_ratio_simplify(val_t num, val_t den);
 
 static val_t sx_mul_for_ratio(val_t a, val_t b) {
+    /* Same unbounded-recursion class as sx_simplify above (issue #134):
+     * mutually recursive with sx_ratio_simplify below, driven by nested
+     * DIV/NEG structure. */
+    check_c_stack_depth("symbolic");
     /* (p/q)*b → ratio_simplify(p*b, q) */
     if (vis_symexpr(a) && as_symexpr(a)->op == SX_DIV && as_symexpr(a)->nargs == 2)
         return sx_ratio_simplify(sx_mul_for_ratio(as_symexpr(a)->args[0], b),
@@ -2805,6 +2827,8 @@ static val_t sx_mul_for_ratio(val_t a, val_t b) {
 }
 
 static val_t sx_ratio_simplify(val_t num, val_t den) {
+    /* Same unbounded-recursion class as sx_mul_for_ratio above (issue #134). */
+    check_c_stack_depth("symbolic");
     /* Pull negation from denominator */
     if (vis_symexpr(den) && as_symexpr(den)->op == SX_NEG && as_symexpr(den)->nargs == 1)
         return sx_neg(sx_ratio_simplify(num, as_symexpr(den)->args[0]));

--- a/src/symbolic_print.c
+++ b/src/symbolic_print.c
@@ -4,6 +4,7 @@
 #include "numeric.h"
 #include "port.h"
 #include "lang_registry.h"
+#include "eval.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -107,6 +108,13 @@ static void sp_pos_mul_latex(val_t v, val_t port) {
  * expression is wrapped in parentheses so the caller's context is respected.
  */
 static void sp_infix(val_t expr, int ctx, val_t port) {
+    /* Issue #134: this expression-tree traversal self-recurses once per
+     * subexpression with no bound, distinct from #133's printer guard
+     * (which only covers scm_write's own plain-list/vector recursion,
+     * reached only for a numeric LEAF here, not this function's own
+     * tree-walk above that). Shares check_c_stack_depth with #133 and
+     * symbolic.c's own sx_simplify/sx_diff/etc (same fix, issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symbolic(expr) && !vis_symfn(expr)) { scm_display(expr, port); return; }
     if (vis_symvar(expr)) {
         Symbol *s = as_sym(as_symvar(expr)->name);
@@ -361,6 +369,8 @@ static void sl_num(val_t v, val_t port) {
  * is wrapped in \left(\right) for proper grouping.
  */
 static void sl_latex(val_t expr, int ctx, val_t port) {
+    /* Same unbounded-recursion class as sp_infix above (issue #134). */
+    check_c_stack_depth("symbolic");
     if (!vis_symbolic(expr) && !vis_symfn(expr)) { sl_num(expr, port); return; }
     if (vis_symvar(expr)) { sl_varname(expr, port); return; }
     if (vis_symfn(expr)) {
@@ -535,6 +545,9 @@ void sx_write_latex(val_t expr, val_t port) { sl_latex(expr, SP_LOW, port); }
 /* ---- Display (prefix notation) ---- */
 
 void sx_write(val_t expr, val_t port) {
+    /* Same unbounded-recursion class as sp_infix/sl_latex above (issue
+     * #134): this prefix-notation writer self-recurses too. */
+    check_c_stack_depth("symbolic");
     if (vis_symvar(expr)) {
         Symbol *s = as_sym(as_symvar(expr)->name);
         port_write_string(port, s->data, s->len);

--- a/src/symbolic_print.c
+++ b/src/symbolic_print.c
@@ -634,6 +634,15 @@ static Symbol *sxc_op_glyph(val_t op) {
 }
 
 static void sxc_write(val_t expr, val_t port) {
+    /* Same unbounded-recursion class as sx_write/sp_infix/sl_latex above
+     * (issue #134): a fourth self-recursive symbolic-expression writer,
+     * for the 'cuneiform notation. Not independently demonstrated to be
+     * exploitable (its own per-level stack frame is far smaller than
+     * the construction-side functions above, so in practice a tree
+     * survives construction only if it's already too shallow to reach
+     * this guard) -- added for defense-in-depth and consistency with
+     * the other three writers rather than a confirmed crash. */
+    check_c_stack_depth("symbolic");
     if (!vis_symbolic(expr) && !vis_symfn(expr)) {
         /* Numeric leaf: render in cuneiform when the value supports it
          * (sex_to_cuneiform already falls back to plain decimal itself). */

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1581,6 +1581,46 @@
          (string-length (get-output-string out)))
        101)
 
+;;; Issue #134 (found via independent security review of the fix itself):
+;;; scm_equal/val_hash (src/set.c) have the same unbounded-recursion
+;;; class, but reachable from ordinary Scheme data with no symbolic
+;;; module involved at all -- a deeply nested list compared with
+;;; `equal?` (or hashed) SIGSEGVed. Unlike the symbolic-CAS construction
+;;; functions, building a list this way costs O(depth), not O(depth^2)
+;;; (no re-simplification pass), so a large N here stays fast without
+;;; needing to constrain the process's own stack via ulimit the way
+;;; test_cli.sh's own #134 test does.
+(check "equal?: deeply nested list raises a catchable stack-overflow, not a SIGSEGV"
+       (guard (e (#t 'caught))
+         (equal? (jit133-build-deep 3000000 1) (jit133-build-deep 3000000 1)))
+       'caught)
+(check "equal?: ordinary depth still works correctly"
+       (equal? (jit133-build-deep 50 1) (jit133-build-deep 50 1))
+       #t)
+
+;;; Issue #134 (found via independent security review of the fix
+;;; itself): num_mul's own separate inline tuple-distribution loop
+;;; (src/numeric.c) -- unlike num_add/num_sub/num_neg, which all route
+;;; through the already-guarded tuple_binop/tuple_unop -- recursed into
+;;; a nested (up-wrapped) tuple with no bound of its own. `up`/`down`
+;;; build nesting in O(1) per level with no simplification pass, so
+;;; this (like the equal? case above) stays fast at a large depth
+;;; without needing test_cli.sh's ulimit constraint. Also confirms
+;;; sx_depends_on (used by ∫/limit/series/laplace/fourier/etc as their
+;;; first structural check) is now guarded too -- it was the first
+;;; thing independent review found still crashing after the initial
+;;; #134 fix landed.
+(define (jit134-build-up n x)
+  (if (= n 0) x (jit134-build-up (- n 1) (up x))))
+(check "integrate: deeply nested up-tuple raises a catchable stack-overflow, not a SIGSEGV"
+       (let ((x (sym-var 'x)))
+         (guard (e (#t 'caught)) (∫ (jit134-build-up 3000000 x) x)))
+       'caught)
+(check "tuple arithmetic (+ - * on up/down) still works correctly"
+       (let ((v (up 1 2 3)))
+         (list (- v) (* 2 v) (+ v v) (* (down 1 1 1) v)))
+       (list (up -1 -2 -3) (up 2 4 6) (up 2 4 6) 6))
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -693,6 +693,43 @@ out=$("$CURRY" -e '(display (let* ((p0 1) (p1 1) (p2 1) (p3 1) (p4 1) (p5 1) (p6
                           (+ p0 p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17 p18 p19)))')
 check "let* with 20 sequential bindings still compiles and runs correctly" "$out" "20"
 
+# ─── Symbolic CAS (sx_simplify/sx_diff/etc, symbolic.c) shares the same
+#     stack-depth guard -- deep expression construction raises a
+#     catchable stack-overflow instead of a SIGSEGV (issue #134) ────────────
+#
+# sx_simplify re-walks its ENTIRE argument tree from scratch on every
+# call (no memoization of already-simplified subexpressions), so
+# building a chain of N nested `(sin ...)` applications one at a time
+# (each call re-simplifying the whole existing tree so far) costs
+# O(depth-at-guard^2), not O(N) -- confirmed empirically to take 30+
+# seconds under a Release build with a real 64MB stack, since the
+# guard's threshold (and therefore how deep the chain gets before
+# firing) scales with the real available stack. Rather than chase an
+# ever-larger N to outrun a bigger stack (as #125/#129/#133's own
+# thresholds needed), this test explicitly constrains the CHILD
+# process's own stack via `ulimit -s` first, making the guard's
+# threshold small, deterministic, and fast regardless of the host
+# environment's default stack or build type -- confirmed reliable and
+# fast (well under a second) across both Debug and Release builds.
+SYMDEEP_SCM="$TMPDIR_CLI/symdeep.scm"
+cat > "$SYMDEEP_SCM" << 'SYMDEEP_EOF'
+(define x (sym-var 'x))
+(define (wrap n e) (if (= n 0) e (wrap (- n 1) (sin e))))
+(guard (e (#t (display "caught"))) (wrap 3000 x) (display "no-crash"))
+SYMDEEP_EOF
+set +e
+symdeep_out=$(bash -c "ulimit -s 2048; \"$CURRY\" \"$SYMDEEP_SCM\"" 2>&1)
+set -e
+check "symbolic: deep expression construction raises a catchable stack-overflow, not a SIGSEGV" "$symdeep_out" "caught"
+# Confirms ordinary symbolic construction/simplification/differentiation/
+# printing (nowhere near where the guard fires) still works correctly.
+sym_out=$("$CURRY" -e '(define x (sym-var (quote x)))
+(display (list (sym->string (sym-expr (quote +) (sym-expr (quote sin) x) (sym-expr (quote *) x x)))
+               (simplify (sym-expr (quote +) x 0))
+               (∂ (sym-expr (quote sin) x) x)))')
+check "symbolic: ordinary construction/simplify/diff/printing still work correctly" \
+      "$sym_out" "(sin(x) + x^2 x (cos x))"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 
 echo

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -715,12 +715,17 @@ SYMDEEP_SCM="$TMPDIR_CLI/symdeep.scm"
 cat > "$SYMDEEP_SCM" << 'SYMDEEP_EOF'
 (define x (sym-var 'x))
 (define (wrap n e) (if (= n 0) e (wrap (- n 1) (sin e))))
-(guard (e (#t (display "caught"))) (wrap 3000 x) (display "no-crash"))
+(guard (e (#t (display (error-message e)))) (wrap 3000 x) (display "no-crash"))
 SYMDEEP_EOF
 set +e
 symdeep_out=$(bash -c "ulimit -s 2048; \"$CURRY\" \"$SYMDEEP_SCM\"" 2>&1)
 set -e
-check "symbolic: deep expression construction raises a catchable stack-overflow, not a SIGSEGV" "$symdeep_out" "caught"
+# Matches on the specific stack-overflow condition's own message
+# (via error-message), not just "guard caught something" -- an
+# unrelated error (a typo, an unbound name) would otherwise also
+# satisfy a bare "did guard's #t clause fire" check.
+check_contains "symbolic: deep expression construction raises a catchable stack-overflow, not a SIGSEGV" \
+               "$symdeep_out" "call stack overflow"
 # Confirms ordinary symbolic construction/simplification/differentiation/
 # printing (nowhere near where the guard fires) still works correctly.
 sym_out=$("$CURRY" -e '(define x (sym-var (quote x)))


### PR DESCRIPTION
## Summary

Fixes #134: the symbolic CAS subsystem (`src/symbolic.c`, `src/symbolic_print.c`) had the same unbounded-C-stack-recursion class #125/#129/#133 already fixed for `eval()`/`ir_emit()`, the reader, and the printer — a deeply nested symbolic expression (e.g. repeated `(sin ...)` wrapping) SIGSEGVed during construction/simplification, before #133's printer guard could ever be reached.

Every self-recursive expression-tree walker in `symbolic.c` now shares `check_c_stack_depth` (`src/runtime.c`): `sx_simplify`, `sx_diff`, `sx_wirtinger`, `sx_substitute`, `sx_expand`, `sx_integrate`, `sx_limit_inner`, `sx_fracdiff`, `sx_fracint`, `sx_laplace`, `sx_ilaplace`, `sx_fourier`, `sx_ifourier`, `sx_equal`, `sx_trigsimp`, `sx_is_nc`, `sx_depends_on`, `sx_degree_long`, and the mutually-recursive `sx_mul_for_ratio`/`sx_ratio_simplify` pair. `symbolic_print.c`'s four dedicated writers (`sx_write`, `sp_infix`, `sl_latex`, `sxc_write`) are covered too.

Two review rounds also found real bugs beyond the initial scope, both fixed here:
- **`sx_depends_on`** was still crashing at unbounded depth even after the first round of guards, because it's called as the first structural check by `∫`/`limit`/`series`/`laplace`/`ilaplace`/`fourier`/`ifourier` on a `up`/`down` **tuple** expression — tuples build nesting in O(1) per level with no simplification pass, unlike ordinary symbolic construction (which `sx_simplify`'s own guard caps).
- **`num_mul`** (`src/numeric.c`) has its own separate inline tuple-distribution loop, unlike `num_add`/`num_sub`/`num_neg` which route through the already-guarded `tuple_binop`/`tuple_unop` — this was the actual remaining crash for a deeply up-wrapped tuple.
- **`scm_equal`/`val_hash`** (`src/set.c`) have the identical class but are reachable from *ordinary* Scheme data with no symbolic module involved — a deeply nested list compared with `equal?` (or hashed) SIGSEGVed. Fixed here since it's the same one-line guard and broader-impact than the rest of #134.

A third, final review round (read-only, no working-tree changes) found nothing further exploitable — it traced every remaining self-recursive helper and confirmed each is unreachable at dangerous depth by construction (bounded by `sx_simplify`'s own much larger stack frame).

Filed **#137** (out of scope here): `sx_simplify` has no memoization, so repeatedly wrapping an already-simplified expression one level at a time costs O(depth²) — a genuine CPU-exhaustion DoS distinct from the stack-depth fix here, confirmed to burn 20-30+ seconds of CPU under a generous stack ulimit before this fix's guard even fires. Needs real memoization, a bigger change than a stack guard.

## Test plan

- [x] `tests/r7rs_tests.scm`: 448/448 pass
- [x] `tests/test_cli.sh`: 94/94 pass (the symbolic-construction regression test explicitly constrains the child process's own stack via `ulimit -s`, since the naive test construction is O(depth²) and a large stack would make the test take 20-30+ seconds — see #137)
- [x] Full `ctest`, default build: 117/117 pass
- [x] Full `ctest`, LLVM build: 118/118 pass
- [x] Three rounds of independent review (two rounds with fixes applied and re-verified, a final read-only round confirming no further exploitable gaps)
- [x] Confirmed the two new O(depth) regression tests (`equal?`, up-tuple `∫`) are genuinely linear, not quadratic, by timing at multiple scales
- [x] Manually verified every crash-to-error fix doesn't regress ordinary, legitimate symbolic/tuple/equal? usage
