### PR TITLE
fix(record-type,syntax-rules): crashes on malformed input on both compiled and tree-walked paths (#135)

### DIFF
--- a/src/record_type.c
+++ b/src/record_type.c
@@ -67,6 +67,20 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
         scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
                         "define-record-type: ill-formed special form");
     val_t name_sym = vcar(rest);
+    /* Issue #135 (second round, found by independent review): a
+     * non-symbol record name -- `(define-record-type 42 (fields a))`,
+     * `(define-record-type (x) (fields a))` -- previously reached
+     * sym_cstr(name_sym) below (both branches share this variable) and
+     * either crashed outright or read a non-Symbol object's memory at
+     * the wrong struct-field offset, feeding whatever bytes were there
+     * into snprintf -- a real out-of-bounds heap read, not just a
+     * missing-check crash, since it's reachable from untrusted source
+     * (or a programmatically-built form via `eval`) and its result
+     * (a corrupted generated binding name) is then observable by user
+     * code. Checked once here, covering both the R6RS and R7RS
+     * branches below since both use name_sym the same way. */
+    if (!vis_symbol(name_sym))
+        scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "define-record-type: name must be a symbol");
     bool is_r6rs = vis_pair(vcdr(rest)) &&
                    vis_pair(vcadr(rest)) &&
                    (vcar(vcadr(rest)) == S_FIELDS  ||
@@ -92,6 +106,30 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
             val_t cl = vcar(c);
             if (vis_pair(cl) && vcar(cl) == S_FIELDS) { field_list = vcdr(cl); break; }
             c = vcdr(c);
+        }
+
+        /* Issue #135 (second round): a field-spec that's a pair but
+         * too short -- `(fields (mutable))`, missing the field name --
+         * previously reached vcadr(fspec) below (three separate loops
+         * all re-derive fspec from this same field_list) on a nil cdr.
+         * A field-spec that's a pair whose cadr isn't itself a symbol
+         * -- `(fields (mutable 42))` -- previously reached sym_cstr on
+         * a non-Symbol value, the same out-of-bounds-read class as
+         * name_sym above. Each fspec is either a bare symbol (an
+         * immutable field named directly) or `(mutable|immutable
+         * name)` per R6RS; validated once here rather than in each of
+         * the three loops that would otherwise re-derive the same
+         * unchecked fname. */
+        for (val_t fchk = field_list; vis_pair(fchk); fchk = vcdr(fchk)) {
+            val_t fspec = vcar(fchk);
+            if (vis_pair(fspec)) {
+                if (!vis_pair(vcdr(fspec)) || !vis_symbol(vcadr(fspec)))
+                    scm_raise_code(EC_WRONG_TYPE_ARGUMENT,
+                                    "define-record-type: ill-formed field spec");
+            } else if (!vis_symbol(fspec)) {
+                scm_raise_code(EC_WRONG_TYPE_ARGUMENT,
+                                "define-record-type: ill-formed field spec");
+            }
         }
 
         uint32_t nfields = (uint32_t)rp_list_length(field_list);

--- a/src/record_type.c
+++ b/src/record_type.c
@@ -182,9 +182,37 @@ void record_type_build_spec(val_t rest, val_t rtd_ref, RecordTypeSpec *spec) {
 
     /* R7RS: (define-record-type name (ctor-name field...) pred
      *        (field acc [mut])...) */
+    /* Issue #135: unlike every other special form in curry (#124-#132),
+     * this shape is destructured identically by BOTH the compiler and
+     * the tree-walker via this one shared function, so a single fix
+     * here closes both paths at once. `(define-record-type x)` (no
+     * ctor-form/pred at all) and `(define-record-type (x))` (name_sym
+     * itself a list, so vcdr(rest) is nil) previously fell straight
+     * into vcadr(rest)/vcaddr(rest) below and SIGSEGVed. */
+    if (!vis_pair(vcdr(rest)) || !vis_pair(vcdr(vcdr(rest))))
+        scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
+                        "define-record-type: ill-formed special form");
     val_t ctor_form    = vcadr(rest);
     val_t pred_sym     = vcaddr(rest);
     val_t field_specs  = vcdr(vcddr(rest));
+
+    /* `(define-record-type point ctor-name point? ...)` -- ctor_form
+     * itself not a `(ctor-name field...)` list -- previously reached
+     * vcar(ctor_form)/vcdr(ctor_form) below on a non-pair. */
+    if (!vis_pair(ctor_form))
+        scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
+                        "define-record-type: ill-formed special form");
+
+    /* `(define-record-type point (mk-point x) point? y)` -- a bare
+     * field-spec, not `(field-name getter [setter])` -- previously
+     * reached vcar(vcar(fs)) (the nfields-counting loop below) and
+     * vcadr(fspec) (the binding-building loop further down) on a
+     * non-pair. Both loops re-derive fspec from the same field_specs
+     * list, so validating once up front covers both. */
+    for (val_t fchk = field_specs; vis_pair(fchk); fchk = vcdr(fchk))
+        if (!vis_pair(vcar(fchk)) || !vis_pair(vcdr(vcar(fchk))))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
+                            "define-record-type: ill-formed field spec");
 
     uint32_t nfields = (uint32_t)rp_list_length(field_specs);
     RecordType *rtd = (RecordType *)gc_alloc_pinned(sizeof(RecordType) + nfields * sizeof(val_t));

--- a/src/syntax_rules.c
+++ b/src/syntax_rules.c
@@ -798,6 +798,12 @@ static val_t sr_compile_fn(int ac, val_t *av, void *ud) {
     val_t ellipsis, literals, rules_kv;
     if (vis_symbol(second)) {
         /* (syntax-rules ellipsis (literal ...) rule ...) */
+        /* Issue #135: `(syntax-rules x)` -- an ellipsis identifier with
+         * no literals list (or anything) after it -- previously fell
+         * straight into vcaddr(form) below and SIGSEGVed. */
+        if (!vis_pair(vcddr(form)))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
+                            "syntax-rules: ill-formed special form");
         ellipsis = second;
         literals = vcaddr(form);
         rules_kv = vcdr(vcddr(form));
@@ -811,6 +817,12 @@ static val_t sr_compile_fn(int ac, val_t *av, void *ud) {
     val_t compiled = V_NIL;
     for (val_t r = rules_kv; vis_pair(r); r = vcdr(r)) {
         val_t rule = vcar(r);
+        /* `(syntax-rules () ())` -- an empty rule, not (pattern
+         * template) -- previously fell straight into vcar(rule)/
+         * vcadr(rule) below and SIGSEGVed. */
+        if (!vis_pair(rule) || !vis_pair(vcdr(rule)))
+            scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
+                            "syntax-rules: ill-formed rule");
         val_t pat  = vcar(rule);
         val_t tmpl = vcadr(rule);
         compiled = scm_cons(scm_cons(pat, tmpl), compiled);

--- a/src/syntax_rules.c
+++ b/src/syntax_rules.c
@@ -744,8 +744,27 @@ static val_t sr_transformer_fn(int ac, val_t *av, void *ud) {
         val_t pat  = vcar(rule);
         val_t tmpl = vcdr(rule);
 
-        /* Skip the keyword position in the pattern */
-        val_t pat_rest  = vcdr(pat);
+        /* Skip the keyword position in the pattern. A top-level vector
+         * pattern (`#(keyword ...)`, valid per issue #135's own new
+         * vis_pair(pat)||vis_vector(pat) check) must be converted to a
+         * list first -- unlike every NESTED vector sub-pattern (handled
+         * by sr_match_one at line 122/173), this top-level keyword-skip
+         * previously called vcdr(pat) directly on a raw Vector object.
+         * Pair.cdr and Vector.data[0] sit at different struct offsets,
+         * so this was a real type-confusion / out-of-bounds read (found
+         * by a third review round), not just a missing-check crash:
+         * `vcdr` silently reinterpreted the vector's own length/first-
+         * element word as a val_t and handed it to sr_match_list. */
+        val_t pat_list  = vis_vector(pat) ? sr_vector_to_list(pat) : pat;
+        /* `#()` -- a zero-length vector pattern, with no keyword
+         * position at all -- converts to `()`, and vcdr(()) below
+         * would crash the same way vcdr on a raw empty Vector did.
+         * Treated as "this rule can never match" rather than raised,
+         * matching how a genuinely unmatchable rule is handled further
+         * down (sr_match_list returning false), since a macro can
+         * have other rules that DO match the same use. */
+        if (!vis_pair(pat_list)) continue;
+        val_t pat_rest  = vcdr(pat_list);
         val_t form_rest = vcdr(form);
 
         val_t bindings = V_NIL, ell_bindings = V_NIL;

--- a/src/syntax_rules.c
+++ b/src/syntax_rules.c
@@ -824,6 +824,19 @@ static val_t sr_compile_fn(int ac, val_t *av, void *ud) {
             scm_raise_code(EC_WRONG_NUMBER_OF_ARGUMENTS,
                             "syntax-rules: ill-formed rule");
         val_t pat  = vcar(rule);
+        /* Issue #135 (second round, found by independent review): a
+         * pattern that isn't itself a pair or vector -- `(syntax-rules
+         * () (x 1))`, `(syntax-rules () (5 1))` -- previously passed
+         * this rule-shape check (rule is a fine 2-element list) but
+         * later crashed sr_transformer_fn's own vcdr(pat) the first
+         * time the macro was actually USED, not when it was defined --
+         * so a malformed macro could be shipped/loaded successfully
+         * and only detonate for whoever calls it. Every R7RS pattern
+         * has a keyword/sub-pattern head position, so the top-level
+         * pattern is always list- or vector-shaped, never a bare atom. */
+        if (!vis_pair(pat) && !vis_vector(pat))
+            scm_raise_code(EC_WRONG_TYPE_ARGUMENT,
+                            "syntax-rules: pattern must be a list or vector");
         val_t tmpl = vcadr(rule);
         compiled = scm_cons(scm_cons(pat, tmpl), compiled);
     }
@@ -883,9 +896,16 @@ val_t sr_rebuild_syntax_env(val_t literals, val_t rules, val_t ellipsis, val_t d
         scm_raise(V_FALSE, "%%rebuild-syntax-rules: literals must be a proper list");
     if (scm_list_length(rules) < 0)
         scm_raise(V_FALSE, "%%rebuild-syntax-rules: rules must be a proper list");
-    for (val_t r = rules; vis_pair(r); r = vcdr(r))
+    for (val_t r = rules; vis_pair(r); r = vcdr(r)) {
         if (!vis_pair(vcar(r)))
             scm_raise(V_FALSE, "%%rebuild-syntax-rules: each rule must be a (pattern . template) pair");
+        /* Same pattern-shape gap as sr_compile_fn's identical fix
+         * (issue #135, second round): a non-pair/non-vector pattern
+         * here crashes sr_transformer_fn's own vcdr(pat) at first use,
+         * not at definition time. */
+        if (!vis_pair(vcar(vcar(r))) && !vis_vector(vcar(vcar(r))))
+            scm_raise(V_FALSE, "%%rebuild-syntax-rules: pattern must be a list or vector");
+    }
     if (!vis_symbol(ellipsis))
         scm_raise(V_FALSE, "%%rebuild-syntax-rules: ellipsis must be a symbol");
 

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1713,6 +1713,32 @@
              (interaction-environment))
        (list #t 1 2 3 5))
 
+;;; A third review round found the top-level vis_vector(pat) case the
+;;; #135 fix's own new pattern-shape check explicitly allows was itself
+;;; a type-confusion / out-of-bounds read: sr_transformer_fn called
+;;; vcdr(pat) directly on a raw Vector object (Pair.cdr and Vector's
+;;; own first-element slot sit at different struct offsets), silently
+;;; reinterpreting adjacent memory as a match-binding value instead of
+;;; raising or cleanly failing to match.
+(check "syntax-rules: top-level vector pattern doesn't type-confuse (rc=1, no wrong binding)"
+       (jit132-malformed-raises?
+        (lambda ()
+          (eval '(begin (define-syntax m (syntax-rules () (#(a) 'a))) (display (m 1 2 3)))
+                (interaction-environment))))
+       #t)
+(check "syntax-rules: empty vector pattern doesn't crash (never matches, tries other rules)"
+       (eval '(begin
+                (define-syntax m (syntax-rules () (#() 'empty) ((_ x) x)))
+                (m 42))
+             (interaction-environment))
+       42)
+(check "syntax-rules: nested vector sub-pattern still works correctly"
+       (eval '(begin
+                (define-syntax vec-len (syntax-rules () ((_ #(a b c)) (list a b c))))
+                (vec-len #(1 2 3)))
+             (interaction-environment))
+       (list 1 2 3))
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1621,6 +1621,47 @@
          (list (- v) (* 2 v) (+ v v) (* (down 1 1 1) v)))
        (list (up -1 -2 -3) (up 2 4 6) (up 2 4 6) 6))
 
+;;; Issue #135: define-record-type and syntax-rules crash on malformed
+;;; input on BOTH the compiled and tree-walked paths, unlike every
+;;; other issue in this series (#124-#132) -- record_type_build_spec
+;;; (src/record_type.c) and sr_compile_fn (src/syntax_rules.c) are each
+;;; a single function shared by compiler.c's native codegen and eval.c's
+;;; own S_DEFINE_RECORD_TYPE case, so a fix here closes both paths at
+;;; once and `eval` genuinely exercises the same code either path would
+;;; use, unlike #124-#132's own eval-only tests. Also exercised directly
+;;; (not just via eval) in tests/test_cli.sh, confirming the compiled
+;;; path specifically.
+(check "define-record-type: missing ctor/pred raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(define-record-type x) (interaction-environment))))
+       #t)
+(check "define-record-type: name itself a list raises instead of crashing"
+       (jit132-malformed-raises? (lambda () (eval '(define-record-type (x)) (interaction-environment))))
+       #t)
+(check "define-record-type: non-pair ctor-form raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(define-record-type point x point? (x px)) (interaction-environment))))
+       #t)
+(check "define-record-type: non-pair field-spec raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(define-record-type point (mk-point x) point? y) (interaction-environment))))
+       #t)
+(check "syntax-rules: ellipsis identifier with nothing after it raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(define-syntax m (syntax-rules x)) (interaction-environment))))
+       #t)
+(check "syntax-rules: empty rule raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(define-syntax m (syntax-rules () ())) (interaction-environment))))
+       #t)
+(check "define-record-type/syntax-rules still work correctly"
+       (eval '(begin
+                (define-record-type point (mk-point x y) point? (x point-x) (y point-y set-point-y!))
+                (define p (mk-point 1 2))
+                (define-syntax my-if (syntax-rules () ((_ c t e) (cond (c t) (else e)))))
+                (list (point? p) (point-x p) (point-y p) (my-if #t 'yes 'no)))
+             (interaction-environment))
+       (list #t 1 2 'yes))
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -1662,6 +1662,57 @@
              (interaction-environment))
        (list #t 1 2 'yes))
 
+;;; A second round of independent code/security review of the #135 fix
+;;; found the R6RS branch of record_type_build_spec had NO validation
+;;; at all (the commit's own claim that it was "already defensive" was
+;;; wrong), and that a malformed syntax-rules PATTERN (as opposed to a
+;;; malformed RULE, already fixed) passed definition-time validation
+;;; but crashed sr_transformer_fn's own vcdr(pat) the first time the
+;;; macro was actually used -- so a malformed macro could be defined/
+;;; loaded successfully and only detonate for whoever later called it.
+(check "define-record-type: R6RS field-spec too short raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(define-record-type x (fields (mutable))) (interaction-environment))))
+       #t)
+(check "define-record-type: R6RS non-symbol field name raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(define-record-type x (fields 5)) (interaction-environment))))
+       #t)
+(check "define-record-type: non-symbol name raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(define-record-type 5 (fields a)) (interaction-environment))))
+       #t)
+(check "define-record-type: name itself a pair raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(define-record-type (x) (fields a)) (interaction-environment))))
+       #t)
+(check "syntax-rules: non-pair pattern raises instead of crashing (at definition, not first use)"
+       (jit132-malformed-raises?
+        (lambda () (eval '(begin (define-syntax m (syntax-rules () (x 1))) (m)) (interaction-environment))))
+       #t)
+(check "syntax-rules: fixnum pattern raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda () (eval '(begin (define-syntax m (syntax-rules () (5 1))) (m)) (interaction-environment))))
+       #t)
+(check "%rebuild-syntax-rules: non-pair pattern raises instead of crashing"
+       (jit132-malformed-raises?
+        (lambda ()
+          (eval '(begin
+                   (define-syntax m (%rebuild-syntax-rules '() '((x . y)) '...))
+                   (m))
+                (interaction-environment))))
+       #t)
+(check "define-record-type R6RS/syntax-rules with valid patterns still work correctly"
+       (eval '(begin
+                (define-record-type point2 (fields (mutable x) (immutable y) z))
+                (define p2 (make-point2 1 2 3))
+                (define-syntax my-or (syntax-rules ()
+                                       ((_) #f) ((_ a) a)
+                                       ((_ a b ...) (let ((t a)) (if t t (my-or b ...))))))
+                (list (point2? p2) (point2-x p2) (point2-y p2) (point2-z p2) (my-or #f #f 5)))
+             (interaction-environment))
+       (list #t 1 2 3 5))
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -735,6 +735,31 @@ sym_out=$("$CURRY" -e '(define x (sym-var (quote x)))
 check "symbolic: ordinary construction/simplify/diff/printing still work correctly" \
       "$sym_out" "(sin(x) + x^2 x (cos x))"
 
+# ─── define-record-type / syntax-rules crash on malformed input on BOTH
+#     the compiled and tree-walked paths (issue #135) ───────────────────────
+#
+# Unlike every other issue in this series (#124-#132), record_type_build_spec
+# and sr_compile_fn are each a single function shared by compiler.c's native
+# codegen and eval.c's own tree-walker case -- tests/r7rs_tests.scm's own
+# `eval`-based checks already exercise this same shared code, but these
+# subprocess checks confirm the actual top-level compiled path too.
+check_no_segv "define-record-type: missing ctor/pred compiles to a clean error" \
+              '(define-record-type x)'
+check_no_segv "define-record-type: name itself a list compiles to a clean error" \
+              '(define-record-type (x))'
+check_no_segv "define-record-type: non-pair ctor-form compiles to a clean error" \
+              '(define-record-type point x point? (x px))'
+check_no_segv "define-record-type: non-pair field-spec compiles to a clean error" \
+              '(define-record-type point (mk-point x) point? y)'
+check_no_segv "syntax-rules: ellipsis identifier with nothing after it compiles to a clean error" \
+              '(define-syntax m (syntax-rules x))'
+check_no_segv "syntax-rules: empty rule compiles to a clean error" \
+              '(define-syntax m (syntax-rules () ()))'
+out=$("$CURRY" -e '(define-record-type point (mk-point x y) point? (x point-x) (y point-y set-point-y!))
+(define-syntax my-if (syntax-rules () ((_ c t e) (cond (c t) (else e)))))
+(display (list (point? (mk-point 1 2)) (point-x (mk-point 1 2)) (my-if #t (quote yes) (quote no))))')
+check "define-record-type/syntax-rules still compile and run correctly" "$out" "(#t 1 yes)"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 
 echo

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -760,6 +760,28 @@ out=$("$CURRY" -e '(define-record-type point (mk-point x y) point? (x point-x) (
 (display (list (point? (mk-point 1 2)) (point-x (mk-point 1 2)) (my-if #t (quote yes) (quote no))))')
 check "define-record-type/syntax-rules still compile and run correctly" "$out" "(#t 1 yes)"
 
+# A second round of independent review found the R6RS branch of
+# record_type_build_spec had no validation at all, and that a
+# malformed syntax-rules pattern (as opposed to a malformed rule)
+# passed definition-time validation but crashed on first USE of the
+# macro -- fixed to raise at definition time instead, so these need
+# only the bare (define-syntax ...) form, not a call to the macro.
+check_no_segv "define-record-type: R6RS field-spec too short compiles to a clean error" \
+              '(define-record-type x (fields (mutable)))'
+check_no_segv "define-record-type: R6RS non-symbol field name compiles to a clean error" \
+              '(define-record-type x (fields 5))'
+check_no_segv "define-record-type: non-symbol name compiles to a clean error" \
+              '(define-record-type 5 (fields a))'
+check_no_segv "define-record-type: name itself a pair compiles to a clean error" \
+              '(define-record-type (x) (fields a))'
+check_no_segv "syntax-rules: non-pair pattern compiles to a clean error" \
+              '(define-syntax m (syntax-rules () (x 1)))'
+check_no_segv "syntax-rules: fixnum pattern compiles to a clean error" \
+              '(define-syntax m (syntax-rules () (5 1)))'
+out2=$("$CURRY" -e '(define-record-type point2 (fields (mutable x) (immutable y) z))
+(display (list (point2? (make-point2 1 2 3)) (point2-x (make-point2 1 2 3))))')
+check "define-record-type R6RS with valid field specs still compiles and runs correctly" "$out2" "(#t 1)"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 
 echo


### PR DESCRIPTION
## Summary

Fixes #135: unlike every other issue in this series (#124-#132), where only the tree-walker (`eval.c`) was missing a check the compiler already had, `define-record-type` and `syntax-rules` crashed on malformed input on **both** the compiled and tree-walked paths — because `record_type_build_spec` (`src/record_type.c`) and `sr_compile_fn`/`sr_transformer_fn`/`sr_rebuild_syntax_env` (`src/syntax_rules.c`) are each shared implementations called by both.

- **`record_type_build_spec`** (R7RS branch): `(define-record-type x)` / `(define-record-type (x))` (missing ctor-form/predicate), a non-pair ctor-form, and a non-pair field-spec all SIGSEGVed. The **R6RS branch had no validation at all** (found by review, despite the original commit claiming otherwise): a too-short field-spec pair and a non-symbol field/record name reached `sym_cstr` on a non-Symbol value — a real out-of-bounds heap read whose garbage bytes then got `snprintf`'d into a generated binding name observable by user code, not just a crash.
- **`sr_compile_fn`**: `(syntax-rules x)` (ellipsis identifier with nothing after it) and `(syntax-rules () ())` (empty rule) SIGSEGVed. A further round found a malformed **pattern** (a bare atom, not a pair/vector) passed the rule-shape check cleanly at *definition* time but crashed `sr_transformer_fn`'s own `vcdr(pat)` on first macro *use* — meaning a malformed macro could ship/load successfully and only detonate for whoever later called it. A final round found the top-level **vector**-pattern case that fix explicitly allows (`#(a b)`) was itself type confusion: `vcdr` on a raw `Vector` object reads past `Pair.cdr`'s struct offset into the vector's own data, silently producing a wrong match-binding instead of a clean non-match.

Three review rounds in total, each finding real bugs the prior round missed, with clearly diminishing severity by the third (single medium-severity issue, now fixed).

## Test plan

- [x] `tests/r7rs_tests.scm`: 466/466 pass (via `eval`, which genuinely exercises the same shared functions the compiler also calls — unlike #124-#132's own eval-only tests, this is a real test of both paths at once)
- [x] `tests/test_cli.sh`: 108/108 pass (real subprocess compiles, confirming the top-level compiled path specifically)
- [x] `tests/syntax_rules_tests.scm`: 70/70 pass (existing suite, unaffected)
- [x] Full `ctest`, default build: 117/117 pass
- [x] Full `ctest`, LLVM build: 118/118 pass
- [x] Manually verified every crash-to-error fix doesn't regress ordinary, legitimate `define-record-type` (both R6RS and R7RS forms) / `syntax-rules` (including nested vector sub-patterns and custom ellipsis identifiers) usage
