### PR TITLE
fix(symbolic): memoize sx_simplify to close O(depth^2) CPU-exhaustion DoS (#137)

### DIFF
--- a/src/builtins_curry.c
+++ b/src/builtins_curry.c
@@ -147,7 +147,16 @@ static val_t prim_assume(int ac, val_t *av, void *ud) {
     (void)ud; (void)ac;
     if (!vis_symvar(av[0])) return V_VOID;
     uint32_t flag = sx_assumption_flag(av[1]);
-    if (flag) as_symvar(av[0])->hdr.flags |= flag;
+    if (flag) {
+        as_symvar(av[0])->hdr.flags |= flag;
+        /* Issue #137 follow-up: sx_simplify's memoization cache is
+         * keyed on rule/algebra generation only; simplification results
+         * also depend on SymVar assumption flags (sqrt(x^2) -> |x| vs.
+         * x), so a change here must invalidate the cache too -- see
+         * eval.c's S_WITH_ASSUMPTIONS's identical fix for the same
+         * class of mutation via a different entry point. */
+        sx_invalidate_simplify_cache();
+    }
     return V_VOID;
 }
 static val_t prim_can_assume(int ac, val_t *av, void *ud) {
@@ -160,7 +169,10 @@ static val_t prim_drop_assumption(int ac, val_t *av, void *ud) {
     (void)ud; (void)ac;
     if (!vis_symvar(av[0])) return V_VOID;
     uint32_t flag = sx_assumption_flag(av[1]);
-    if (flag) as_symvar(av[0])->hdr.flags &= ~flag;
+    if (flag) {
+        as_symvar(av[0])->hdr.flags &= ~flag;
+        sx_invalidate_simplify_cache(); /* see prim_assume's identical comment */
+    }
     return V_VOID;
 }
 /* ---- with-assumptions support (native compiler codegen, compiler.c) ----
@@ -178,12 +190,14 @@ static val_t prim_assumption_set(int ac, val_t *av, void *ud) {
     (void)ud; (void)ac;
     if (!vis_symvar(av[0])) return V_VOID;
     as_symvar(av[0])->hdr.flags |= (uint32_t)vunfix(av[1]);
+    sx_invalidate_simplify_cache(); /* see prim_assume's identical comment */
     return V_VOID;
 }
 static val_t prim_assumption_restore(int ac, val_t *av, void *ud) {
     (void)ud; (void)ac;
     if (!vis_symvar(av[0])) return V_VOID;
     as_symvar(av[0])->hdr.flags = (uint32_t)vunfix(av[1]);
+    sx_invalidate_simplify_cache(); /* see prim_assume's identical comment */
     return V_VOID;
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -1378,6 +1378,15 @@ tail:
             nv++;
             cl = vcdr(cl);
         }
+        /* Issue #137 follow-up (found by independent code review):
+         * sx_simplify's own memoization cache is keyed only on rule/
+         * algebra registration generation, not on SymVar assumption
+         * flags -- but simplification results (e.g. sqrt(x^2) -> |x|
+         * vs. x) also depend on those flags. Without invalidating here,
+         * a node simplified before entering this form could be served
+         * stale from cache inside the body, even though its variable's
+         * assumptions just changed. */
+        if (nv > 0) sx_invalidate_simplify_cache();
 
         val_t result = V_VOID;
         ExnHandler h;
@@ -1393,10 +1402,12 @@ tail:
             /* Restore flags before re-raising */
             for (int i = 0; i < nv; i++)
                 as_symvar(saved_vars[i])->hdr.flags = saved_flags[i];
+            if (nv > 0) sx_invalidate_simplify_cache();
             scm_raise_val(h.exn);
         }
         for (int i = 0; i < nv; i++)
             as_symvar(saved_vars[i])->hdr.flags = saved_flags[i];
+        if (nv > 0) sx_invalidate_simplify_cache();
         return result;
     }
 

--- a/src/sx_algebra.c
+++ b/src/sx_algebra.c
@@ -48,6 +48,11 @@ void sx_algebra_define(val_t op, bool commutative, bool associative,
             atab[idx].identity     = identity;
             atab[idx].absorbing    = absorbing;
             atab[idx].relations_fn = relations_fn;
+            /* Issue #137: same reasoning as sx_rule_add's identical
+             * call -- a node cached as "fully simplified" before this
+             * operator's algebra properties were (re-)defined must not
+             * keep being served stale now that they've changed. */
+            sx_invalidate_simplify_cache();
             return;
         }
     }

--- a/src/sx_rules.c
+++ b/src/sx_rules.c
@@ -164,6 +164,13 @@ val_t sx_rules_list(val_t op_filter) {
 }
 
 void sx_rules_clear(val_t ruleset) {
+    /* Issue #137 follow-up (found by independent code review): removing
+     * a rule can change what simplifying its operator does (a node
+     * cached as "simplified" under the removed rule's rewrite may no
+     * longer be a fixpoint once the rule is gone), so this needs the
+     * same invalidation sx_rule_add already does for the opposite
+     * (adding) direction. */
+    sx_invalidate_simplify_cache();
     for (int i = 0; i < RTAB_SIZE; i++) {
         if (rtab[i].op == V_VOID) continue;
         if (ruleset == V_FALSE) {

--- a/src/sx_rules.c
+++ b/src/sx_rules.c
@@ -5,6 +5,7 @@
 #include "gc.h"
 #include "builtins.h"  /* scm_cons */
 #include "eval.h"      /* apply_arr */
+#include "symbolic.h"  /* sx_invalidate_simplify_cache */
 
 /* ---- Rule struct ---- */
 
@@ -85,6 +86,12 @@ void sx_rule_add(val_t pattern, val_t pvars,
         while (tail->next) tail = tail->next;
         tail->next = r;
     }
+
+    /* Issue #137: a node sx_simplify already cached as "fully
+     * simplified" before this rule existed must not keep being served
+     * stale from that cache now that a new rule could change what
+     * simplifying its operator actually does. */
+    sx_invalidate_simplify_cache();
 }
 
 val_t sx_rule_try(val_t expr) {

--- a/src/symbolic.c
+++ b/src/symbolic.c
@@ -226,7 +226,49 @@ static bool decompose_trig_sq(val_t term,
 }
 
 
-val_t sx_simplify(val_t expr) {
+/* Issue #137: sx_simplify_impl (below) re-walks and re-simplifies its
+ * ENTIRE argument tree from scratch on every call, even subexpressions
+ * a prior call already fully simplified -- building an expression by
+ * repeatedly wrapping an already-simplified result one level at a time
+ * (e.g. `(sin e)` called N times in a loop, each call passing in the
+ * previous iteration's own result) costs O(depth^2) total work, not
+ * O(depth), since each of the N calls re-simplifies the whole current
+ * tree. This is a genuine CPU-exhaustion DoS distinct from #134's
+ * stack-depth fix -- it fires at sizes well below that guard's own
+ * threshold, confirmed during #134's own testing to burn 20-30+ seconds
+ * of CPU under a generous stack ulimit before the guard ever engages.
+ *
+ * Fixed with a generation-tagged memoization cache: SymExpr's own
+ * hdr.flags field (unused for this type otherwise, confirmed by grep)
+ * stores the g_sx_simplify_generation value in effect the last time
+ * this exact node was fully simplified; sx_simplify (the public entry
+ * point, below sx_simplify_impl) checks that tag first and returns the
+ * node UNCHANGED with no recursion at all if it matches the CURRENT
+ * generation -- turning the "wrap an already-simplified result" pattern
+ * back into O(depth) total, since each wrap only ever simplifies the
+ * ONE new outer node, never re-walking the (already-tagged) tree
+ * beneath it.
+ *
+ * The generation counter exists because simplification is not a fixed
+ * function of an expression's own shape alone: `define-rule`/
+ * `define-algebra` register new rules/algebra properties at runtime
+ * (sx_rule_add / sx_algebra_define), which can change what "fully
+ * simplified" even means for operators already in use. A bare one-bit
+ * "already simplified" tag would let a node simplified BEFORE a new
+ * rule was registered keep being served stale from cache after the
+ * registration, if a script kept building on top of it -- a real
+ * correctness regression, not just a missed optimization. Both
+ * registration functions call sx_invalidate_simplify_cache() (declared
+ * in symbolic.h), which bumps this counter, so every previously-cached
+ * tag stops matching and the next sx_simplify call on each affected
+ * node redoes the full pass under the new rule set. */
+static uint32_t g_sx_simplify_generation = 1;
+
+void sx_invalidate_simplify_cache(void) {
+    g_sx_simplify_generation++;
+}
+
+static val_t sx_simplify_impl(val_t expr) {
     /* Issue #134: sx_simplify recurses into itself once per argument of
      * every nested SymExpr node (just below, and again for the tuple
      * case) with no bound at all -- a deeply nested expression tree
@@ -934,6 +976,21 @@ val_t sx_simplify(val_t expr) {
     }
 
     return sx_make_expr(op, n, sa);
+}
+
+/* Public entry point: the memoization fast-path for issue #137 (see the
+ * long comment above sx_simplify_impl for the full rationale). Every
+ * recursive call INSIDE sx_simplify_impl's own body calls this function
+ * (not sx_simplify_impl directly), so a subexpression already tagged at
+ * the current generation is returned unchanged with no further
+ * recursion at any depth, not just at the top level. */
+val_t sx_simplify(val_t expr) {
+    if (vis_symexpr(expr) && as_symexpr(expr)->hdr.flags == g_sx_simplify_generation)
+        return expr;
+    val_t result = sx_simplify_impl(expr);
+    if (vis_symexpr(result))
+        as_symexpr(result)->hdr.flags = g_sx_simplify_generation;
+    return result;
 }
 
 /* ---- Trigonometric simplification (trigsimp) ----

--- a/src/symbolic.c
+++ b/src/symbolic.c
@@ -275,12 +275,39 @@ static bool decompose_trig_sq(val_t term,
  * on issue #137: no crash found in an actor stress test). Skipping 0 on
  * increment reserves it for "never simplified" (sx_make_expr always
  * zero-initializes hdr.flags), so a 2^32 wraparound can't make a fresh,
- * never-simplified node read as cache-valid. */
+ * never-simplified node read as cache-valid.
+ *
+ * The skip-0 step uses a compare-exchange retry loop rather than a plain
+ * fetch-add followed by a corrective second fetch-add: a second review
+ * round found that two separate atomic RMW ops leave a real window, right
+ * when the counter lands on 0 after wraparound, during which another
+ * thread's concurrent load can observe 0 before the corrective add runs --
+ * reintroducing the exact "never-simplified node misread as cached" bug
+ * this skip exists to prevent. A CAS loop makes the "then skip 0" step
+ * atomic with the increment itself, so no other thread ever observes an
+ * intermediate 0.
+ *
+ * Ordering is acquire/release, not relaxed: this generation counter is
+ * the only thing establishing a happens-before edge between "a rule/
+ * algebra/assumption mutation just happened" (an ordinary, non-atomic
+ * store, e.g. prim_assume's `hdr.flags |= flag`) and "another actor
+ * thread observes the resulting generation bump and therefore knows to
+ * recompute." Relaxed ordering would let a weakly-ordered CPU (this
+ * codebase explicitly targets arm64) reorder that ordinary store past
+ * the atomic bump, so a thread could see the new generation while still
+ * reading the OLD assumption flags/rule table -- matches the
+ * release/acquire pattern runtime.c already uses for g_jit_arith_tainted
+ * for the identical cross-thread-visibility reason, not relaxed. */
 static uint32_t g_sx_simplify_generation = 1;
 
 void sx_invalidate_simplify_cache(void) {
-    uint32_t next = __atomic_add_fetch(&g_sx_simplify_generation, 1, __ATOMIC_RELAXED);
-    if (next == 0) __atomic_add_fetch(&g_sx_simplify_generation, 1, __ATOMIC_RELAXED);
+    uint32_t cur = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_RELAXED);
+    uint32_t next;
+    do {
+        next = cur + 1;
+        if (next == 0) next = 1;
+    } while (!__atomic_compare_exchange_n(&g_sx_simplify_generation, &cur, next,
+                                          0 /* not weak */, __ATOMIC_RELEASE, __ATOMIC_RELAXED));
 }
 
 static val_t sx_simplify_impl(val_t expr) {
@@ -1000,7 +1027,7 @@ static val_t sx_simplify_impl(val_t expr) {
  * the current generation is returned unchanged with no further
  * recursion at any depth, not just at the top level. */
 val_t sx_simplify(val_t expr) {
-    uint32_t gen = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_RELAXED);
+    uint32_t gen = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_ACQUIRE);
     if (vis_symexpr(expr) && as_symexpr(expr)->hdr.flags == gen)
         return expr;
     val_t result = sx_simplify_impl(expr);

--- a/src/symbolic.c
+++ b/src/symbolic.c
@@ -262,10 +262,25 @@ static bool decompose_trig_sq(val_t term,
  * in symbolic.h), which bumps this counter, so every previously-cached
  * tag stops matching and the next sx_simplify call on each affected
  * node redoes the full pass under the new rule set. */
+/* Plain uint32_t, NOT _Atomic-qualified: __atomic_load_n/__atomic_add_fetch
+ * require a plain type (see runtime.c's identical convention/comment for
+ * g_jit_arith_tainted et al.) -- curry's own actors are real OS threads,
+ * so a script running define-rule/define-algebra/assume! on one actor
+ * while another is mid-sx_simplify needs at least a non-torn read/write
+ * here, even though the two-generations-out-of-sync worst case is just a
+ * transient over-eager cache miss (an extra full simplify pass), not a
+ * memory-safety issue -- SymExpr's own hdr.flags tag is a plain word
+ * write with no such cross-thread guarantee, matching how every other
+ * per-object flags field in this codebase is handled (see review notes
+ * on issue #137: no crash found in an actor stress test). Skipping 0 on
+ * increment reserves it for "never simplified" (sx_make_expr always
+ * zero-initializes hdr.flags), so a 2^32 wraparound can't make a fresh,
+ * never-simplified node read as cache-valid. */
 static uint32_t g_sx_simplify_generation = 1;
 
 void sx_invalidate_simplify_cache(void) {
-    g_sx_simplify_generation++;
+    uint32_t next = __atomic_add_fetch(&g_sx_simplify_generation, 1, __ATOMIC_RELAXED);
+    if (next == 0) __atomic_add_fetch(&g_sx_simplify_generation, 1, __ATOMIC_RELAXED);
 }
 
 static val_t sx_simplify_impl(val_t expr) {
@@ -985,11 +1000,12 @@ static val_t sx_simplify_impl(val_t expr) {
  * the current generation is returned unchanged with no further
  * recursion at any depth, not just at the top level. */
 val_t sx_simplify(val_t expr) {
-    if (vis_symexpr(expr) && as_symexpr(expr)->hdr.flags == g_sx_simplify_generation)
+    uint32_t gen = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_RELAXED);
+    if (vis_symexpr(expr) && as_symexpr(expr)->hdr.flags == gen)
         return expr;
     val_t result = sx_simplify_impl(expr);
     if (vis_symexpr(result))
-        as_symexpr(result)->hdr.flags = g_sx_simplify_generation;
+        as_symexpr(result)->hdr.flags = gen;
     return result;
 }
 

--- a/src/symbolic.h
+++ b/src/symbolic.h
@@ -264,6 +264,14 @@ val_t sx_diff(val_t expr, val_t var);                        /* ∂/∂var (real
 val_t sx_wirtinger(val_t expr, val_t var, bool is_dbar);     /* ∂/∂z or ∂/∂z̄ */
 val_t sx_integrate(val_t expr, val_t var);                   /* antiderivative ∫ ... dx */
 val_t sx_simplify(val_t expr);                               /* algebraic simplification */
+/* Bumps sx_simplify's own memoization generation counter (issue #137),
+ * invalidating every SymExpr node's cached "already fully simplified"
+ * tag. Must be called by anything that changes what simplification
+ * actually DOES for existing operators -- currently sx_rule_add
+ * (sx_rules.c) and sx_algebra_define (sx_algebra.c) -- so a node
+ * simplified before a new rule/algebra property was registered doesn't
+ * get silently served stale from cache after the registration. */
+void  sx_invalidate_simplify_cache(void);
 val_t sx_substitute(val_t expr, val_t var, val_t val);       /* substitute var=val */
 bool  sx_equal(val_t a, val_t b);                            /* structural equality */
 bool  sx_depends_on(val_t expr, val_t var);                  /* true if expr contains var */

--- a/tests/sx_algebra_tests.scm
+++ b/tests/sx_algebra_tests.scm
@@ -305,6 +305,37 @@
   (simplify (sqrt (expt x+ 2))) x+)
 
 ;;; ============================================================
+;;; 5. sx_simplify memoization (issue #137) -- O(depth) not O(depth^2),
+;;;    and a rule/algebra registered AFTER a node was cached still fires
+;;; ============================================================
+
+;; Building a chain of N nested (sin ...) applications one at a time,
+;; each call re-simplifying the whole existing tree so far, cost
+;; O(depth^2) before #137 -- at this depth that would have taken many
+;; seconds (or hit #134's own stack-depth guard first, depending on the
+;; ulimit in effect); after #137 it's O(depth) and fast regardless.
+;; Correctness matters more than timing here (a slow-but-correct CI
+;; environment shouldn't fail this test), so this only asserts the
+;; construction actually completes and produces a well-formed result,
+;; not a wall-clock budget.
+(define (wrap-sin n e) (if (= n 0) e (wrap-sin (- n 1) (sin e))))
+(define deep-sin (wrap-sin 200000 x))
+(assert-equal "sx_simplify memoization: deep (sin (sin ...)) chain still builds to the right op"
+  (sym-expr-op deep-sin) 'sin)
+(assert-equal "sx_simplify memoization: re-simplifying an already-simplified node is a no-op (same object back)"
+  (eq? (simplify deep-sin) deep-sin) #t)
+
+;; sx_invalidate_simplify_cache correctness: a node cached as "fully
+;; simplified" BEFORE a new rule for its own operator existed must not
+;; keep being served stale from that cache once the rule is registered.
+(define cached-before-rule (sym-expr 'sx137-op x))
+(assert-equal "sx_simplify memoization: uninterpreted op is left as-is before any rule exists"
+  (sym->string cached-before-rule) "sx137-op(x)")
+(define-rule (sx137-op ?a) -> (* 111 ?a))
+(assert-equal "sx_simplify memoization: a rule registered AFTER caching still fires on the cached node"
+  (sym->string (simplify cached-before-rule)) "111 * x")
+
+;;; ============================================================
 ;;; Report
 ;;; ============================================================
 (display "sx_algebra tests: ")

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -697,25 +697,28 @@ check "let* with 20 sequential bindings still compiles and runs correctly" "$out
 #     stack-depth guard -- deep expression construction raises a
 #     catchable stack-overflow instead of a SIGSEGV (issue #134) ────────────
 #
-# sx_simplify re-walks its ENTIRE argument tree from scratch on every
-# call (no memoization of already-simplified subexpressions), so
-# building a chain of N nested `(sin ...)` applications one at a time
-# (each call re-simplifying the whole existing tree so far) costs
-# O(depth-at-guard^2), not O(N) -- confirmed empirically to take 30+
-# seconds under a Release build with a real 64MB stack, since the
-# guard's threshold (and therefore how deep the chain gets before
-# firing) scales with the real available stack. Rather than chase an
-# ever-larger N to outrun a bigger stack (as #125/#129/#133's own
-# thresholds needed), this test explicitly constrains the CHILD
-# process's own stack via `ulimit -s` first, making the guard's
-# threshold small, deterministic, and fast regardless of the host
-# environment's default stack or build type -- confirmed reliable and
-# fast (well under a second) across both Debug and Release builds.
+# Originally built via a chain of N nested `(sin ...)` applications one
+# at a time (each call re-simplifying the whole existing tree so far),
+# which cost O(depth-at-guard^2) before issue #137 added memoization to
+# sx_simplify -- after #137, that exact construction no longer deepens
+# the real C stack at all (each wrap only ever touches the ONE new
+# outer node; the already-tagged subtree beneath it returns instantly
+# with no recursion), so it can no longer reach this guard regardless
+# of N. Switched to `up`-tuple nesting (O(1) per level, no
+# simplification pass at all, same construction #134's own r7rs_tests.scm
+# regression test for sx_depends_on/∫ already uses) consumed by `∂`
+# (sx_diff has no memoization of its own -- #137 was scoped to
+# sx_simplify only, see that issue), which still recurses the real C
+# stack once per level and reaches the guard reliably. This test
+# explicitly constrains the CHILD process's own stack via `ulimit -s`
+# first, making the guard's threshold small, deterministic, and fast
+# regardless of the host environment's default stack or build type.
 SYMDEEP_SCM="$TMPDIR_CLI/symdeep.scm"
 cat > "$SYMDEEP_SCM" << 'SYMDEEP_EOF'
 (define x (sym-var 'x))
-(define (wrap n e) (if (= n 0) e (wrap (- n 1) (sin e))))
-(guard (e (#t (display (error-message e)))) (wrap 3000 x) (display "no-crash"))
+(define (build-up n e) (if (= n 0) e (build-up (- n 1) (up e))))
+(define big (build-up 3000 x))
+(guard (e (#t (display (error-message e)))) (∂ big x) (display "no-crash"))
 SYMDEEP_EOF
 set +e
 symdeep_out=$(bash -c "ulimit -s 2048; \"$CURRY\" \"$SYMDEEP_SCM\"" 2>&1)

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -713,11 +713,22 @@ check "let* with 20 sequential bindings still compiles and runs correctly" "$out
 # explicitly constrains the CHILD process's own stack via `ulimit -s`
 # first, making the guard's threshold small, deterministic, and fast
 # regardless of the host environment's default stack or build type.
+#
+# N was originally 3000, verified against a Debug build only -- an
+# independent security review found that a Release build (smaller
+# per-recursion-level stack frames under optimization, the same
+# Debug-vs-Release threshold gap seen tuning #125/#129/#133/#134's own
+# guards) does NOT reach the guard at N=3000 under this ulimit, so the
+# "no-crash" branch fires instead and the test silently stops testing
+# anything. Re-measured directly against both a Debug and a Release
+# build here: N=3000 overflows in Debug but not Release; N=20000
+# overflows in both. N=50000 keeps a comfortable margin above that
+# while still finishing in well under a tenth of a second.
 SYMDEEP_SCM="$TMPDIR_CLI/symdeep.scm"
 cat > "$SYMDEEP_SCM" << 'SYMDEEP_EOF'
 (define x (sym-var 'x))
 (define (build-up n e) (if (= n 0) e (build-up (- n 1) (up e))))
-(define big (build-up 3000 x))
+(define big (build-up 50000 x))
 (guard (e (#t (display (error-message e)))) (∂ big x) (display "no-crash"))
 SYMDEEP_EOF
 set +e


### PR DESCRIPTION
## Summary

- Fixes #137: `sx_simplify` (the central CAS simplification function in
  `src/symbolic.c`) had no memoization, so building a deep expression one
  node at a time via `sin`/`+`/etc. cost O(depth^2) instead of O(depth) --
  each new wrapping call re-simplified the entire existing subtree from
  scratch. Fixed with a generation-tagged cache on `SymExpr.hdr.flags`:
  a node is stamped with the current global generation once fully
  simplified, and a later call on an already-tagged node returns
  immediately with no recursion at any depth.
- The generation counter is invalidated (bumped) by every place that
  changes what simplification actually does for existing operators or
  variables: `sx_rule_add`/`sx_rules_clear` (rule registration/removal),
  `sx_algebra_define` (algebra-property registration), and every entry
  point that mutates a `SymVar`'s assumption flags (`prim_assume`,
  `prim_drop_assumption`, `prim_assumption_set`, `prim_assumption_restore`,
  and both the tree-walked and compiled `with-assumptions` paths, which
  share the same primitives).
- Curry actors are real OS threads, so the counter and its skip-0-on-
  wraparound logic use a compare-exchange retry loop with acquire/release
  ordering (not a two-step fetch-add, and not relaxed ordering) -- both
  gaps were caught by a second independent code-review round and fixed in
  this same branch before opening this PR.
- `tests/test_cli.sh`'s existing #134 stack-depth regression test's
  construction pattern no longer exercises the intended code path after
  this fix (memoization means it no longer deepens the real C stack at
  all), so it was switched to an `up`-tuple + `∂` construction (unaffected
  by `sx_simplify`'s memoization) with a threshold re-verified empirically
  against both Debug and Release builds (N=50000, up from N=3000, which
  only worked in Debug).
- Added regression coverage in `tests/sx_algebra_tests.scm` for both the
  performance property (a 200000-deep `sin` chain builds and re-simplifies
  as a no-op) and correctness under cache invalidation (a rule registered
  after a node is cached still fires on that node).

## Deliberately out of scope, filed as follow-ups

Two rounds of independent review (code review + security review) surfaced
three findings judged to need their own design pass rather than a rushed
fix folded into this already-large change:

- #140 -- the generation counter is global, not per-operator, so
  interleaving cheap `define-rule`/`define-algebra` registrations with
  expression construction can still defeat memoization and reintroduce
  O(depth^2)-comparable cost; and the counter's 32-bit range can in
  principle wrap around to collide with some other still-live non-zero
  generation tag, not just 0 (which this PR does fix).
- #141 -- the underlying rule/algebra registration tables (`rtab` in
  `src/sx_rules.c`, `atab` in `src/sx_algebra.c`) are themselves completely
  unsynchronized under concurrent actor access (a pre-existing gap, not
  introduced here) -- a lost-update/torn-struct correctness hazard, not
  confirmed as memory-unsafe, but genuine UB under the C11/pthreads memory
  model.

## Test plan

- [x] `ctest --test-dir build` -- 117/117 suites pass (fresh
      `--clear-cache` run)
- [x] Manually verified the O(depth^2) -> O(depth) improvement (100000-deep
      chain: 0.037s after the fix)
- [x] Manually verified cache invalidation correctness: a rule registered
      after a node is cached still fires on that cached node
- [x] Manually verified the stack-depth regression test's new threshold
      (N=50000) triggers the guard reliably in both Debug and Release
      builds under `ulimit -s 2048`
- [x] Two independent code-review rounds and one independent
      security-review round completed; all actionable findings fixed in
      this branch, remaining design-scope findings filed as #140 and #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
