### PR TITLE
fix(symbolic): synchronize sx_rules/sx_algebra tables against concurrent actor access (#141)

### DIFF
--- a/src/sx_algebra.c
+++ b/src/sx_algebra.c
@@ -5,6 +5,7 @@
 #include "gc_semispace.h"
 #include "symbolic.h"   /* SYM_ASSUME_* flags */
 #include <string.h>
+#include <pthread.h>
 
 /* ---- Algebra table ---- */
 
@@ -12,6 +13,20 @@
 
 static AlgebraInfo atab[ATAB_SIZE];
 static int atab_initialised = 0;
+
+/* Issue #141: same reasoning as sx_rules.c's rtab_lock -- define-algebra
+ * (writer, via sx_algebra_define) can run concurrently with simplify
+ * (reader, via sx_algebra_lookup) on a different actor thread, and
+ * AlgebraInfo's five fields were being written one at a time with no
+ * barrier, so a concurrent reader could see a torn combination of old
+ * and new fields (e.g. a new `commutative` paired with a stale
+ * `relations_fn`). sx_algebra_lookup now copies a whole-struct snapshot
+ * out under the read lock (see its own comment) instead of handing back
+ * a raw pointer into the table, so the caller's later reads of that
+ * snapshot's fields -- including invoking relations_fn, an arbitrary
+ * Scheme callable -- happen outside the lock and against a single
+ * consistent copy, not a live, potentially-mid-write table slot. */
+static pthread_rwlock_t atab_lock = PTHREAD_RWLOCK_INITIALIZER;
 
 void sx_algebra_init(void) {
     memset(atab, 0, sizeof(atab));
@@ -24,20 +39,24 @@ static int atab_slot(val_t op) {
     return (int)(((uintptr_t)op >> 3) % (unsigned)ATAB_SIZE);
 }
 
-AlgebraInfo *sx_algebra_lookup(val_t op) {
-    if (!atab_initialised) return NULL;
+bool sx_algebra_lookup(val_t op, AlgebraInfo *out) {
+    if (!atab_initialised) return false;
+    pthread_rwlock_rdlock(&atab_lock);
     int start = atab_slot(op);
+    bool found = false;
     for (int i = 0; i < ATAB_SIZE; i++) {
         int idx = (start + i) % ATAB_SIZE;
-        if (atab[idx].op == op)    return &atab[idx];
-        if (atab[idx].op == V_VOID) return NULL;
+        if (atab[idx].op == op) { *out = atab[idx]; found = true; break; }
+        if (atab[idx].op == V_VOID) break;
     }
-    return NULL;
+    pthread_rwlock_unlock(&atab_lock);
+    return found;
 }
 
 void sx_algebra_define(val_t op, bool commutative, bool associative,
                        val_t identity, val_t absorbing, val_t relations_fn) {
     if (!atab_initialised) return;
+    pthread_rwlock_wrlock(&atab_lock);
     int start = atab_slot(op);
     for (int i = 0; i < ATAB_SIZE; i++) {
         int idx = (start + i) % ATAB_SIZE;
@@ -48,6 +67,7 @@ void sx_algebra_define(val_t op, bool commutative, bool associative,
             atab[idx].identity     = identity;
             atab[idx].absorbing    = absorbing;
             atab[idx].relations_fn = relations_fn;
+            pthread_rwlock_unlock(&atab_lock);
             /* Issue #137: same reasoning as sx_rule_add's identical
              * call -- a node cached as "fully simplified" before this
              * operator's algebra properties were (re-)defined must not
@@ -56,6 +76,7 @@ void sx_algebra_define(val_t op, bool commutative, bool associative,
             return;
         }
     }
+    pthread_rwlock_unlock(&atab_lock);
     /* Table full — silently ignore (extremely unlikely with 64 slots) */
 }
 

--- a/src/sx_algebra.c
+++ b/src/sx_algebra.c
@@ -81,6 +81,16 @@ void sx_algebra_define(val_t op, bool commutative, bool associative,
 }
 
 void sx_algebra_gc_scan(void) {
+    /* Issue #141 follow-up (found by independent security review): under
+     * --gc generational, a minor collection is per-thread, not a
+     * stop-the-world pause for other actors, so this scanner runs
+     * concurrently with atab_lock-protected access from other threads
+     * and was mutating atab unguarded. Takes the same write lock
+     * sx_algebra_define uses; safe against self-deadlock for the same
+     * reason sx_rules_gc_scan's identical fix is -- gc_ss_evac/gc_ss_fwd
+     * don't allocate, and neither sx_algebra_define nor
+     * sx_algebra_lookup ever allocates while holding atab_lock. */
+    pthread_rwlock_wrlock(&atab_lock);
     for (int i = 0; i < ATAB_SIZE; i++) {
         if (atab[i].op == V_VOID) continue;
         atab[i].op           = (val_t)gc_ss_evac((uintptr_t)atab[i].op);
@@ -88,6 +98,7 @@ void sx_algebra_gc_scan(void) {
         atab[i].absorbing    = (val_t)gc_ss_evac((uintptr_t)atab[i].absorbing);
         atab[i].relations_fn = (val_t)gc_ss_evac((uintptr_t)atab[i].relations_fn);
     }
+    pthread_rwlock_unlock(&atab_lock);
 }
 
 /* ---- Assumption keyword → flag ---- */

--- a/src/sx_algebra.h
+++ b/src/sx_algebra.h
@@ -27,8 +27,12 @@ void         sx_algebra_init(void);
 void         sx_algebra_define(val_t op, bool commutative, bool associative,
                                val_t identity, val_t absorbing, val_t relations_fn);
 
-/* Look up algebra info for op.  Returns NULL if not declared. */
-AlgebraInfo *sx_algebra_lookup(val_t op);
+/* Look up algebra info for op, copying it into *out. Returns false (and
+   leaves *out untouched) if op has no declaration. A snapshot copy, not a
+   pointer into the live table, so the caller's reads (including invoking
+   relations_fn) can't observe a concurrent sx_algebra_define's write
+   mid-flight -- see sx_algebra.c's atab_lock comment. */
+bool         sx_algebra_lookup(val_t op, AlgebraInfo *out);
 
 /* Semispace GC scanner. */
 void         sx_algebra_gc_scan(void);

--- a/src/sx_rules.c
+++ b/src/sx_rules.c
@@ -6,6 +6,7 @@
 #include "builtins.h"  /* scm_cons */
 #include "eval.h"      /* apply_arr */
 #include "symbolic.h"  /* sx_invalidate_simplify_cache */
+#include <pthread.h>
 
 /* ---- Rule struct ---- */
 
@@ -29,6 +30,25 @@ typedef struct {
 
 static RuleSlot rtab[RTAB_SIZE];
 static int rtab_initialised = 0;
+
+/* Issue #141: curry actors are real OS threads with no global interpreter
+ * lock, and define-rule/clear-rules! (writers, via sx_rule_add/
+ * sx_rules_clear) can run concurrently with simplify (the reader, via
+ * sx_rule_try) on a different actor. Before this lock, sx_rule_add's
+ * append (an unsynchronized "walk to tail, then write ->next") could lose
+ * a concurrent registration, and sx_rule_try's traversal could race with
+ * sx_rules_clear's unlinking. A single-writer/many-reader rwlock is
+ * enough: mutation is rare (explicit define-rule/clear-rules! calls) next
+ * to lookups (every sx_simplify call on a user-defined operator).
+ *
+ * sx_rule_try releases this lock BEFORE invoking any rule's guard_fn/
+ * action_fn (arbitrary Scheme callables) -- see the snapshot-then-release
+ * pattern there. A guard or action is free to call define-rule itself
+ * (recursively re-entering this file), and pthread_rwlock_t is not
+ * recursive: a thread that still held the read lock while attempting the
+ * write lock inside sx_rule_add would deadlock against itself on most
+ * implementations' writer-preference. */
+static pthread_rwlock_t rtab_lock = PTHREAD_RWLOCK_INITIALIZER;
 
 void sx_rules_init(void) {
     for (int i = 0; i < RTAB_SIZE; i++) rtab[i].op = V_VOID;
@@ -67,9 +87,8 @@ void sx_rule_add(val_t pattern, val_t pvars,
     val_t op = vcar(pattern);
     if (!vis_symbol(op)) return;
 
-    SxRule **chain = find_chain(op);
-    if (!chain) return; /* table full */
-
+    /* Allocate before taking the lock: GC_NEW never needs rtab_lock, and
+     * keeping allocation out of the critical section keeps it short. */
     SxRule *r = GC_NEW(SxRule);
     r->pattern   = pattern;
     r->pvars     = pvars;
@@ -77,6 +96,10 @@ void sx_rule_add(val_t pattern, val_t pvars,
     r->action_fn = action_fn;
     r->ruleset   = ruleset;
     r->next      = NULL;
+
+    pthread_rwlock_wrlock(&rtab_lock);
+    SxRule **chain = find_chain(op);
+    if (!chain) { pthread_rwlock_unlock(&rtab_lock); return; } /* table full */
 
     /* Append to end so rules fire in definition order */
     if (*chain == NULL) {
@@ -86,6 +109,7 @@ void sx_rule_add(val_t pattern, val_t pvars,
         while (tail->next) tail = tail->next;
         tail->next = r;
     }
+    pthread_rwlock_unlock(&rtab_lock);
 
     /* Issue #137: a node sx_simplify already cached as "fully
      * simplified" before this rule existed must not keep being served
@@ -94,12 +118,20 @@ void sx_rule_add(val_t pattern, val_t pvars,
     sx_invalidate_simplify_cache();
 }
 
+/* Fields sx_rule_try actually needs, copied out from under rtab_lock
+ * before any guard_fn/action_fn callback runs (see rtab_lock's comment
+ * above for why the lock cannot still be held at that point). */
+typedef struct {
+    val_t pattern, pvars, guard_fn, action_fn;
+} SxRuleSnap;
+
 val_t sx_rule_try(val_t expr) {
     if (!rtab_initialised || !vis_symexpr(expr)) return V_VOID;
 
     SymExpr *se  = as_symexpr(expr);
     val_t    op  = se->op;
 
+    pthread_rwlock_rdlock(&rtab_lock);
     int start = slot_for(op);
     SxRule *chain = NULL;
     for (int i = 0; i < RTAB_SIZE; i++) {
@@ -107,21 +139,39 @@ val_t sx_rule_try(val_t expr) {
         if (rtab[idx].op == op)   { chain = rtab[idx].head; break; }
         if (rtab[idx].op == V_VOID) break;
     }
-    if (!chain) return V_VOID;
+    int count = 0;
+    for (SxRule *r = chain; r; r = r->next) count++;
+    SxRuleSnap *snap = NULL;
+    if (count > 0) {
+        snap = (SxRuleSnap *)GC_MALLOC(sizeof(SxRuleSnap) * (size_t)count);
+        int i = 0;
+        for (SxRule *r = chain; r; r = r->next, i++) {
+            snap[i].pattern   = r->pattern;
+            snap[i].pvars     = r->pvars;
+            snap[i].guard_fn  = r->guard_fn;
+            snap[i].action_fn = r->action_fn;
+        }
+    }
+    pthread_rwlock_unlock(&rtab_lock);
 
-    for (SxRule *r = chain; r; r = r->next) {
-        val_t bindings = sx_pattern_match(r->pattern, expr);
+    for (int idx = 0; idx < count; idx++) {
+        val_t pattern   = snap[idx].pattern;
+        val_t pvars     = snap[idx].pvars;
+        val_t guard_fn  = snap[idx].guard_fn;
+        val_t action_fn = snap[idx].action_fn;
+
+        val_t bindings = sx_pattern_match(pattern, expr);
         if (bindings == V_FALSE) continue;
 
         /* Build argv in pvars order */
         int nparams = 0;
-        val_t pv = r->pvars;
+        val_t pv = pvars;
         while (vis_pair(pv)) { nparams++; pv = vcdr(pv); }
 
         val_t argv[64];
         if (nparams > 64) continue; /* safety guard */
 
-        pv = r->pvars;
+        pv = pvars;
         for (int i = 0; i < nparams; i++) {
             val_t sym = vcar(pv);
             /* Look up in bindings alist */
@@ -137,19 +187,22 @@ val_t sx_rule_try(val_t expr) {
         }
 
         /* Check guard */
-        if (r->guard_fn != V_FALSE) {
-            val_t ok = apply_arr(r->guard_fn, nparams, argv);
+        if (guard_fn != V_FALSE) {
+            val_t ok = apply_arr(guard_fn, nparams, argv);
             if (vis_false(ok)) continue;
         }
 
         /* Fire action */
-        return apply_arr(r->action_fn, nparams, argv);
+        return apply_arr(action_fn, nparams, argv);
     }
 
     return V_VOID;
 }
 
 val_t sx_rules_list(val_t op_filter) {
+    /* scm_cons never calls back into Scheme, so it is safe to hold the
+     * lock for the whole walk (unlike sx_rule_try's guard_fn/action_fn). */
+    pthread_rwlock_rdlock(&rtab_lock);
     val_t result = V_NIL;
     for (int i = 0; i < RTAB_SIZE; i++) {
         if (rtab[i].op == V_VOID) continue;
@@ -160,6 +213,7 @@ val_t sx_rules_list(val_t op_filter) {
             result = scm_cons(desc, result);
         }
     }
+    pthread_rwlock_unlock(&rtab_lock);
     return result;
 }
 
@@ -171,6 +225,7 @@ void sx_rules_clear(val_t ruleset) {
      * same invalidation sx_rule_add already does for the opposite
      * (adding) direction. */
     sx_invalidate_simplify_cache();
+    pthread_rwlock_wrlock(&rtab_lock);
     for (int i = 0; i < RTAB_SIZE; i++) {
         if (rtab[i].op == V_VOID) continue;
         if (ruleset == V_FALSE) {
@@ -190,6 +245,7 @@ void sx_rules_clear(val_t ruleset) {
             }
         }
     }
+    pthread_rwlock_unlock(&rtab_lock);
 }
 
 void sx_rules_gc_scan(void) {

--- a/src/sx_rules.c
+++ b/src/sx_rules.c
@@ -125,31 +125,33 @@ typedef struct {
     val_t pattern, pvars, guard_fn, action_fn;
 } SxRuleSnap;
 
-/* Cap on rules-per-operator this hot path will snapshot in one call.
- * Deliberately a fixed ON-STACK array, not GC_MALLOC: sx_rule_try is
- * called on every sx_simplify for a user-defined operator, so it holds
- * rtab_lock (for reading) during the count+copy above. Under --gc
- * generational, a minor collection is per-thread, not stop-the-world,
- * and sx_rules_gc_scan (which mutates rtab) takes rtab_lock for
- * WRITING -- so if a GC_MALLOC here triggered a collection while this
- * same thread still held the read lock, it would self-deadlock trying
- * to promote that read lock's owner into the scanner's write-lock wait.
- * A plain C stack array needs no allocation at all, closing that off;
- * 256 rules for a single operator is far beyond any realistic
- * define-rule use and matches this file's existing "silently cap and
- * move on" convention (see find_chain's RTAB_SIZE-bounded probe, or the
- * nparams > 64 check just below). */
-#define SX_RULE_TRY_MAX 256
-
 val_t sx_rule_try(val_t expr) {
     if (!rtab_initialised || !vis_symexpr(expr)) return V_VOID;
 
     SymExpr *se  = as_symexpr(expr);
     val_t    op  = se->op;
 
-    SxRuleSnap snap[SX_RULE_TRY_MAX];
-    int count = 0;
-
+    /* Same count/allocate-outside-lock/copy pattern as sx_rules_list,
+     * for the same reason: sx_rule_try is called on every sx_simplify
+     * for a user-defined operator, so it holds rtab_lock (for reading)
+     * during the count+copy passes below. Under --gc generational, a
+     * minor collection is per-thread, not stop-the-world, and
+     * sx_rules_gc_scan (which mutates rtab) takes rtab_lock for
+     * WRITING -- so a GC_MALLOC while this thread still held the read
+     * lock would self-deadlock trying to promote that read lock's
+     * owner into the scanner's write-lock wait. An earlier version of
+     * this function used a fixed 256-entry on-stack array instead
+     * (avoiding allocation entirely), but that silently and
+     * permanently dropped every rule past the 256th registered for one
+     * operator from ever firing again -- a real correctness regression
+     * found by independent security review (issue #145), not just a
+     * theoretical one: reachable via ordinary define-ruleset use
+     * accumulating rules for a common operator over a program's
+     * lifetime, with no diagnostic. The count+headroom approach here
+     * only truncates if the operator's rule count grows by more than
+     * 25%+8 in the microseconds between the two lock sections, which
+     * is what sx_rules_list already accepts as a best-effort snapshot
+     * bound rather than a hard, easily-hit cap. */
     pthread_rwlock_rdlock(&rtab_lock);
     int start = slot_for(op);
     SxRule *chain = NULL;
@@ -158,15 +160,33 @@ val_t sx_rule_try(val_t expr) {
         if (rtab[idx].op == op)   { chain = rtab[idx].head; break; }
         if (rtab[idx].op == V_VOID) break;
     }
-    for (SxRule *r = chain; r && count < SX_RULE_TRY_MAX; r = r->next, count++) {
-        snap[count].pattern   = r->pattern;
-        snap[count].pvars     = r->pvars;
-        snap[count].guard_fn  = r->guard_fn;
-        snap[count].action_fn = r->action_fn;
+    int count = 0;
+    for (SxRule *r = chain; r; r = r->next) count++;
+    pthread_rwlock_unlock(&rtab_lock);
+
+    if (count == 0) return V_VOID;
+
+    int cap = count + count / 4 + 8;
+    SxRuleSnap *snap = (SxRuleSnap *)GC_MALLOC(sizeof(SxRuleSnap) * (size_t)cap);
+
+    pthread_rwlock_rdlock(&rtab_lock);
+    start = slot_for(op);
+    chain = NULL;
+    for (int i = 0; i < RTAB_SIZE; i++) {
+        int idx = (start + i) % RTAB_SIZE;
+        if (rtab[idx].op == op)   { chain = rtab[idx].head; break; }
+        if (rtab[idx].op == V_VOID) break;
+    }
+    int n = 0;
+    for (SxRule *r = chain; r && n < cap; r = r->next, n++) {
+        snap[n].pattern   = r->pattern;
+        snap[n].pvars     = r->pvars;
+        snap[n].guard_fn  = r->guard_fn;
+        snap[n].action_fn = r->action_fn;
     }
     pthread_rwlock_unlock(&rtab_lock);
 
-    for (int idx = 0; idx < count; idx++) {
+    for (int idx = 0; idx < n; idx++) {
         val_t pattern   = snap[idx].pattern;
         val_t pvars     = snap[idx].pvars;
         val_t guard_fn  = snap[idx].guard_fn;

--- a/src/sx_rules.c
+++ b/src/sx_rules.c
@@ -125,11 +125,30 @@ typedef struct {
     val_t pattern, pvars, guard_fn, action_fn;
 } SxRuleSnap;
 
+/* Cap on rules-per-operator this hot path will snapshot in one call.
+ * Deliberately a fixed ON-STACK array, not GC_MALLOC: sx_rule_try is
+ * called on every sx_simplify for a user-defined operator, so it holds
+ * rtab_lock (for reading) during the count+copy above. Under --gc
+ * generational, a minor collection is per-thread, not stop-the-world,
+ * and sx_rules_gc_scan (which mutates rtab) takes rtab_lock for
+ * WRITING -- so if a GC_MALLOC here triggered a collection while this
+ * same thread still held the read lock, it would self-deadlock trying
+ * to promote that read lock's owner into the scanner's write-lock wait.
+ * A plain C stack array needs no allocation at all, closing that off;
+ * 256 rules for a single operator is far beyond any realistic
+ * define-rule use and matches this file's existing "silently cap and
+ * move on" convention (see find_chain's RTAB_SIZE-bounded probe, or the
+ * nparams > 64 check just below). */
+#define SX_RULE_TRY_MAX 256
+
 val_t sx_rule_try(val_t expr) {
     if (!rtab_initialised || !vis_symexpr(expr)) return V_VOID;
 
     SymExpr *se  = as_symexpr(expr);
     val_t    op  = se->op;
+
+    SxRuleSnap snap[SX_RULE_TRY_MAX];
+    int count = 0;
 
     pthread_rwlock_rdlock(&rtab_lock);
     int start = slot_for(op);
@@ -139,18 +158,11 @@ val_t sx_rule_try(val_t expr) {
         if (rtab[idx].op == op)   { chain = rtab[idx].head; break; }
         if (rtab[idx].op == V_VOID) break;
     }
-    int count = 0;
-    for (SxRule *r = chain; r; r = r->next) count++;
-    SxRuleSnap *snap = NULL;
-    if (count > 0) {
-        snap = (SxRuleSnap *)GC_MALLOC(sizeof(SxRuleSnap) * (size_t)count);
-        int i = 0;
-        for (SxRule *r = chain; r; r = r->next, i++) {
-            snap[i].pattern   = r->pattern;
-            snap[i].pvars     = r->pvars;
-            snap[i].guard_fn  = r->guard_fn;
-            snap[i].action_fn = r->action_fn;
-        }
+    for (SxRule *r = chain; r && count < SX_RULE_TRY_MAX; r = r->next, count++) {
+        snap[count].pattern   = r->pattern;
+        snap[count].pvars     = r->pvars;
+        snap[count].guard_fn  = r->guard_fn;
+        snap[count].action_fn = r->action_fn;
     }
     pthread_rwlock_unlock(&rtab_lock);
 
@@ -199,21 +211,59 @@ val_t sx_rule_try(val_t expr) {
     return V_VOID;
 }
 
+/* Fields sx_rules_list needs, copied out from under rtab_lock. */
+typedef struct { val_t pattern, ruleset; } SxRuleDesc;
+
 val_t sx_rules_list(val_t op_filter) {
-    /* scm_cons never calls back into Scheme, so it is safe to hold the
-     * lock for the whole walk (unlike sx_rule_try's guard_fn/action_fn). */
+    /* Unlike sx_rule_try, scm_cons never calls back into Scheme, so the
+     * usual reentrancy hazard doesn't apply here -- but scm_cons DOES
+     * allocate, and under --gc generational that can trigger a minor GC
+     * on this same thread, which runs sx_rules_gc_scan, which (below)
+     * takes rtab_lock for writing. pthread_rwlock_t is not recursive, so
+     * calling scm_cons while still holding rtab_lock (even for reading)
+     * would risk this exact thread self-deadlocking against itself the
+     * moment a collection actually triggers. Snapshot-then-release, same
+     * pattern as sx_rule_try, sidesteps it: count under the lock (no
+     * allocation), copy under the lock into an already-allocated buffer
+     * (no allocation), then build the result list with scm_cons entirely
+     * outside the lock. */
     pthread_rwlock_rdlock(&rtab_lock);
-    val_t result = V_NIL;
+    int count = 0;
     for (int i = 0; i < RTAB_SIZE; i++) {
         if (rtab[i].op == V_VOID) continue;
         if (op_filter != V_FALSE && rtab[i].op != op_filter) continue;
-        for (SxRule *r = rtab[i].head; r; r = r->next) {
-            /* Descriptor: (pattern ruleset) */
-            val_t desc = scm_cons(r->pattern, scm_cons(r->ruleset, V_NIL));
-            result = scm_cons(desc, result);
+        for (SxRule *r = rtab[i].head; r; r = r->next) count++;
+    }
+    pthread_rwlock_unlock(&rtab_lock);
+
+    /* Allocate outside the lock, with headroom in case concurrent
+     * registrations grow the table between the count pass and the copy
+     * pass below -- a copy that hits this cap simply stops early rather
+     * than overflowing, since list-rules is inherently a best-effort
+     * snapshot of a table other actors may be mutating concurrently. */
+    int cap = count + count / 4 + 8;
+    SxRuleDesc *buf = (SxRuleDesc *)GC_MALLOC(sizeof(SxRuleDesc) * (size_t)cap);
+
+    pthread_rwlock_rdlock(&rtab_lock);
+    int n = 0;
+    for (int i = 0; i < RTAB_SIZE && n < cap; i++) {
+        if (rtab[i].op == V_VOID) continue;
+        if (op_filter != V_FALSE && rtab[i].op != op_filter) continue;
+        for (SxRule *r = rtab[i].head; r && n < cap; r = r->next, n++) {
+            buf[n].pattern = r->pattern;
+            buf[n].ruleset = r->ruleset;
         }
     }
     pthread_rwlock_unlock(&rtab_lock);
+
+    val_t result = V_NIL;
+    for (int i = 0; i < n; i++) {
+        /* Descriptor: (pattern ruleset) -- consing forward over the
+         * snapshot reproduces the original single-pass loop's ordering
+         * (which built the list by prepending in visit order). */
+        val_t desc = scm_cons(buf[i].pattern, scm_cons(buf[i].ruleset, V_NIL));
+        result = scm_cons(desc, result);
+    }
     return result;
 }
 
@@ -249,6 +299,21 @@ void sx_rules_clear(val_t ruleset) {
 }
 
 void sx_rules_gc_scan(void) {
+    /* Issue #141 follow-up (found by independent security review): under
+     * --gc generational, a minor collection is per-thread, NOT a
+     * stop-the-world pause for other actors (see gc_gen.c) -- so this
+     * scanner runs concurrently with every other actor's rtab_lock-
+     * protected access, and was mutating rtab's fields completely
+     * unguarded. Takes the same write lock sx_rule_add/sx_rules_clear
+     * use. Safe against self-deadlock: gc_ss_evac/gc_ss_fwd (identity
+     * functions under Boehm, real evacuation under generational) do not
+     * allocate, and every OTHER place in this file that takes rtab_lock
+     * is now structured to never allocate while holding it either (see
+     * sx_rule_add's pre-lock GC_NEW and sx_rules_list's snapshot-then-
+     * release pattern) -- so no thread can already be holding rtab_lock
+     * at the moment its own allocation triggers the minor collection
+     * that calls this scanner. */
+    pthread_rwlock_wrlock(&rtab_lock);
     for (int i = 0; i < RTAB_SIZE; i++) {
         if (rtab[i].op == V_VOID) continue;
         rtab[i].op   = (val_t)gc_ss_evac((uintptr_t)rtab[i].op);
@@ -262,4 +327,5 @@ void sx_rules_gc_scan(void) {
             r->next      = (SxRule *)gc_ss_fwd(r->next);
         }
     }
+    pthread_rwlock_unlock(&rtab_lock);
 }

--- a/src/symbolic.c
+++ b/src/symbolic.c
@@ -352,7 +352,8 @@ static val_t sx_simplify_impl(val_t expr) {
        Built-in operators (+, *, etc.) are not in the algebra table and fall
        through to the hard-coded dispatch below. */
     {
-        AlgebraInfo *alg = sx_algebra_lookup(op);
+        AlgebraInfo alg_info;
+        AlgebraInfo *alg = sx_algebra_lookup(op, &alg_info) ? &alg_info : NULL;
         if (alg) {
             /* Absorbing element: (op ... abs ...) → abs */
             if (alg->absorbing != V_VOID) {

--- a/tests/sx_algebra_tests.scm
+++ b/tests/sx_algebra_tests.scm
@@ -409,6 +409,32 @@
 (assert-equal "rtab/atab locking: a relations_fn calling define-algebra from inside sx_algebra_lookup's caller does not self-deadlock"
   (sym->string (simplify (sym-expr 'sx141-reentrant-alg-op stress-x))) "sx141-reentrant-alg-op(stress-x)")
 
+;; sx_rule_try's first design (an on-stack SX_RULE_TRY_MAX = 256 snapshot,
+;; needed to avoid allocating while holding rtab_lock -- see the GC
+;; ext-scanner locking fix above) silently and permanently dropped every
+;; rule past the 256th registered for one operator, with no diagnostic --
+;; a real correctness regression found by independent security review
+;; (issue #145), reachable via ordinary define-ruleset use accumulating
+;; rules for a common operator, not just adversarial input. Register 300
+;; distinct guarded rules for one operator (built via eval since
+;; define-rule's pattern/guard are literal at expansion time) and confirm
+;; rules #257-300 -- the ones a fixed 256-cap would have silently excluded
+;; -- still fire.
+(let loop ((k 0))
+  (if (< k 300)
+      (begin
+        (eval (list 'define-rule (list 'sx145-many-rules-op '?a) '->
+                     (list 'quote (string->symbol (string-append "matched-" (number->string k))))
+                     '#:when (list '= '?a k))
+              (interaction-environment))
+        (loop (+ k 1)))))
+(assert-equal "sx_rule_try: rule #257 of 300 for one operator still fires (not silently dropped by a fixed snapshot cap)"
+  (sym->string (simplify (sym-expr 'sx145-many-rules-op 257))) "matched-257")
+(assert-equal "sx_rule_try: rule #299 of 300 for one operator still fires"
+  (sym->string (simplify (sym-expr 'sx145-many-rules-op 299))) "matched-299")
+(assert-equal "sx_rule_try: an early rule (#42 of 300) still fires correctly too"
+  (sym->string (simplify (sym-expr 'sx145-many-rules-op 42))) "matched-42")
+
 ;;; ============================================================
 ;;; Report
 ;;; ============================================================

--- a/tests/sx_algebra_tests.scm
+++ b/tests/sx_algebra_tests.scm
@@ -380,6 +380,35 @@
 (assert-equal "rtab/atab concurrency: concurrent define-rule/define-algebra/simplify across actors completes without crash or hang"
   #t #t)
 
+;; The concurrency stress above never actually exercises the ONE hazard
+;; def4f46's design specifically guards against: sx_rule_try must release
+;; rtab_lock before invoking a rule's action_fn/guard_fn, because
+;; pthread_rwlock_t is not recursive -- if a rule's own action called
+;; define-rule while sx_rule_try still held even a read lock (on the SAME
+;; thread, no other actor involved), sx_rule_add's attempt to take the
+;; write lock would self-deadlock. Single-threaded and deterministic,
+;; unlike the stress test above, so a future change that moved the
+;; unlock later would fail this reliably instead of only sometimes.
+(define-rule (sx141-reentrant-op ?a)
+  -> (begin (define-rule (sx141-reentrant-op2 ?b) -> (* 3 ?b))
+            (* 2 ?a)))
+(assert-equal "rtab/atab locking: an action_fn calling define-rule from inside sx_rule_try does not self-deadlock"
+  (sym->string (simplify (sym-expr 'sx141-reentrant-op stress-x))) "2 * stress-x")
+(assert-equal "rtab/atab locking: the rule registered by that reentrant action_fn actually took effect"
+  (sym->string (simplify (sym-expr 'sx141-reentrant-op2 stress-x))) "3 * stress-x")
+
+;; Same hazard, algebra side: a relations_fn calling define-algebra while
+;; sx_algebra_lookup's caller (sx_simplify_impl) still holds a snapshot
+;; obtained under atab_lock's read lock -- sx_algebra_lookup itself has
+;; already released the lock by the time relations_fn runs, so this must
+;; not deadlock either.
+(define-algebra 'sx141-reentrant-alg-op
+  #:relations (lambda (expr)
+                (define-algebra 'sx141-reentrant-alg-op2 #:commutative #t)
+                expr))
+(assert-equal "rtab/atab locking: a relations_fn calling define-algebra from inside sx_algebra_lookup's caller does not self-deadlock"
+  (sym->string (simplify (sym-expr 'sx141-reentrant-alg-op stress-x))) "sx141-reentrant-alg-op(stress-x)")
+
 ;;; ============================================================
 ;;; Report
 ;;; ============================================================

--- a/tests/sx_algebra_tests.scm
+++ b/tests/sx_algebra_tests.scm
@@ -336,6 +336,51 @@
   (sym->string (simplify cached-before-rule)) "111 * x")
 
 ;;; ============================================================
+;;; 6. rtab/atab concurrency (issue #141) -- concurrent define-rule/
+;;;    define-algebra/simplify calls across several actors must not
+;;;    crash or hang. This doesn't assert a specific outcome (the race
+;;;    this closes was a lost-update/torn-struct correctness hazard, not
+;;;    a memory-safety one -- see issue #141), just that the rwlocks
+;;;    added around rtab (sx_rules.c) and atab (sx_algebra.c) don't
+;;;    themselves introduce a deadlock (e.g. sx_rule_try's guard_fn/
+;;;    action_fn callbacks running while still holding rtab_lock would
+;;;    self-deadlock the first time a guard/action called define-rule).
+;;; ============================================================
+(define stress-x (sym-var 'stress-x))
+
+(define (writer-loop n)
+  (if (> n 0)
+      (begin
+        (define-rule (sx141-stress-op ?a) -> (* 2 ?a))
+        (writer-loop (- n 1)))))
+
+(define (reader-loop n)
+  (if (> n 0)
+      (begin
+        (simplify (sym-expr 'sx141-stress-op stress-x))
+        (reader-loop (- n 1)))))
+
+(define (algebra-writer-loop n)
+  (if (> n 0)
+      (begin
+        (define-algebra 'sx141-stress-alg-op #:commutative #t)
+        (algebra-writer-loop (- n 1)))))
+
+(define sx141-n 3000)
+(define w1 (spawn (lambda () (writer-loop sx141-n))))
+(define w2 (spawn (lambda () (writer-loop sx141-n))))
+(define r1 (spawn (lambda () (reader-loop sx141-n))))
+(define r2 (spawn (lambda () (reader-loop sx141-n))))
+(define a1 (spawn (lambda () (algebra-writer-loop sx141-n))))
+
+(let sx141-wait ()
+  (if (or (actor-alive? w1) (actor-alive? w2) (actor-alive? r1)
+          (actor-alive? r2) (actor-alive? a1))
+      (sx141-wait)))
+(assert-equal "rtab/atab concurrency: concurrent define-rule/define-algebra/simplify across actors completes without crash or hang"
+  #t #t)
+
+;;; ============================================================
 ;;; Report
 ;;; ============================================================
 (display "sx_algebra tests: ")


### PR DESCRIPTION
## Summary

- Fixes #141: `src/sx_rules.c`'s rule table (`rtab`) and `src/sx_algebra.c`'s
  algebra table (`atab`) were read and written with zero synchronization,
  despite curry actors being real OS threads with no global interpreter
  lock. Found during the security review of #137's `sx_simplify`
  memoization fix. Before this PR:
  - `sx_rule_add` appended to a rule chain via an unsynchronized
    walk-to-tail-then-write, so two concurrent registrations for the same
    operator could lose one registration.
  - `sx_algebra_define` wrote `AlgebraInfo`'s five fields one at a time
    with no barrier, so a concurrent reader could observe a torn
    combination of old and new fields.
  - `sx_rules_clear` unlinked nodes concurrently with `sx_rule_try`'s
    unsynchronized traversal of the same list.
- Fixed with a `pthread_rwlock_t` per table (single-writer/many-reader).
  The hot-path readers (`sx_rule_try`, `sx_algebra_lookup`) snapshot the
  data they need under the read lock and release it BEFORE invoking any
  user-supplied Scheme callable (`guard_fn`/`action_fn`/`relations_fn`),
  since `pthread_rwlock_t` is not recursive and one of those callables
  could itself call `define-rule`/`define-algebra`, re-entering this code
  on the same thread.
- A second, more subtle gap surfaced by security review: `rtab`/`atab`'s
  GC "extension scanner" callbacks (`sx_rules_gc_scan`/
  `sx_algebra_gc_scan`) turned out to be live code under the
  `--gc generational` backend (not dead/unreachable as first assumed —
  `gc_ss_register_ext_scanner` is a thin alias to the real scanner
  registry), and that backend's minor collections are per-thread, not
  stop-the-world for other actors — so these scanners were mutating the
  tables completely unguarded against the very locks just added. Fixed by
  having both scanners take their table's write lock, which in turn
  required removing the last two places that allocated while holding a
  read lock (`sx_rule_try`, `sx_rules_list`) to avoid a self-deadlock
  (a thread's own allocation triggering the minor GC whose scanner then
  wants the write lock on that same thread).
- That restructuring initially used a fixed 256-entry on-stack array in
  `sx_rule_try` to avoid allocating under the lock — a follow-up review
  found this silently and permanently dropped every rule past the 256th
  registered for one operator, with no diagnostic (issue #145, fixed in
  this same PR: switched to the same count/allocate-outside-lock/copy
  pattern already used and reviewed in `sx_rules_list`).
- Four independent review rounds (alternating code review and security
  review) were run against this branch as it evolved; all actionable
  findings are fixed here.

## Deliberately out of scope, filed as follow-ups

- #143 — `modules.c`'s module registry has the identical
  unsynchronized-mutation-under-a-live-GC-scanner pattern found here for
  `rtab`/`atab`, but is a different subsystem/data structure.
- #144 — a heap-corruption SIGSEGV under `--gc generational` with heavy
  concurrent rtab/atab traffic, found incidentally during review. Bisected
  and confirmed to **predate** this branch entirely (reproduces on `main`
  before #137/#141, just manifesting as a different symptom) — unrelated
  to this PR's locking work.
- #146 — `sx_rules_gc_scan`/`sx_algebra_gc_scan` now pay O(table size)
  under a write lock on every minor GC, a real throughput cliff under
  `--gc generational` as the tables grow. Fixing this properly needs an
  incremental/remembered-set-style scanning scheme (real architecture
  work); `--gc generational` is documented experimental, not the default
  backend, and the default Boehm backend never invokes these scanners at
  all.

## Test plan

- [x] `ctest --test-dir build` — 117/117 suites pass (fresh
      `--clear-cache` run, default Boehm backend)
- [x] Added regression tests in `tests/sx_algebra_tests.scm`: a
      multi-actor concurrency stress test (define-rule/define-algebra/
      simplify racing across actors, no crash/hang), two deterministic
      reentrant-callback tests (an action/relations_fn calling
      define-rule/define-algebra from inside itself, no self-deadlock),
      and a 300-rule test confirming rules past the old 256-cap fire
      correctly
- [x] Manually verified the GC-scanner locking fix under
      `--gc generational` with a tight nursery (8K-32K) across many
      repeated runs of a 7-12 actor concurrency stress script — no hang,
      no crash
- [x] Manually bisected issue #144 against `main`@37c4c8f to confirm it
      predates this branch
- [x] Four independent review rounds (code + security, alternating)
      across the branch's evolution; all actionable findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
