### PR TITLE
fix(modules): synchronize the module registry against concurrent actor access (#143)

### DIFF
--- a/src/modules.c
+++ b/src/modules.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <pthread.h>
 #ifdef __linux__
 #  include <unistd.h>
 #  include <limits.h>
@@ -35,6 +36,29 @@ typedef struct ModuleEntry {
 
 static ModuleEntry *registry = NULL;
 
+/* Issue #143: found during review of #141's identical fix for
+ * sx_rules.c's rtab / sx_algebra.c's atab -- curry actors are real OS
+ * threads with no global interpreter lock, and this registry (like
+ * those tables) was read and written with zero synchronization,
+ * despite `import` being reachable from any actor concurrently.
+ * registry_insert's prepend ("e->next = registry; registry = e;") is
+ * an unsynchronized read-modify-write on the shared head pointer: two
+ * concurrent inserts can both read the same old head, and whichever
+ * write loses silently drops that entry from the list forever (the
+ * exact same lost-update sx_rule_add's identical unsynchronized append
+ * had). Single-writer/many-reader, matching sx_rules.c/sx_algebra.c's
+ * rtab_lock/atab_lock design: mutation (module import) is comparatively
+ * rare next to lookups.
+ *
+ * Unlike rtab/atab, this registry has no removal function at all
+ * (modules are never unloaded), so there is no unlink-vs-traversal
+ * hazard to worry about, and no per-entry field is ever mutated after
+ * publish except by scan_module_registry's GC evac/fwd fixups -- so
+ * registry_lookup's traversal never calls back into arbitrary Scheme
+ * code, and needs no snapshot-then-release pattern the way
+ * sx_rule_try's guard_fn/action_fn callbacks did. */
+static pthread_rwlock_t module_registry_lock = PTHREAD_RWLOCK_INITIALIZER;
+
 static bool names_equal(val_t a, val_t b) {
     while (vis_pair(a) && vis_pair(b)) {
         if (vcar(a) != vcar(b)) return false;
@@ -44,17 +68,28 @@ static bool names_equal(val_t a, val_t b) {
 }
 
 static Module *registry_lookup(val_t name) {
+    pthread_rwlock_rdlock(&module_registry_lock);
+    Module *found = NULL;
     for (ModuleEntry *e = registry; e; e = e->next)
-        if (names_equal(e->name, name)) return e->module;
-    return NULL;
+        if (names_equal(e->name, name)) { found = e->module; break; }
+    pthread_rwlock_unlock(&module_registry_lock);
+    return found;
 }
 
 static void registry_insert(val_t name, Module *mod) {
+    /* Allocate before taking the lock, same reasoning as sx_rule_add:
+     * gc_alloc_raw_pinned is itself an allocation, which under
+     * --gc generational can trigger a minor GC whose ext scanner
+     * (scan_module_registry, below) takes this same lock for writing --
+     * pthread_rwlock_t is not recursive, so allocating while already
+     * holding the lock (even for reading) could self-deadlock. */
     ModuleEntry *e = (ModuleEntry *)gc_alloc_raw_pinned(sizeof(ModuleEntry));
     e->name   = name;
     e->module = mod;
+    pthread_rwlock_wrlock(&module_registry_lock);
     e->next   = registry;
     registry  = e;
+    pthread_rwlock_unlock(&module_registry_lock);
 }
 
 /* ---- Module search path ---- */
@@ -222,10 +257,24 @@ static val_t strip_for(val_t spec) {
 /* ---- GC scanner for module registry ---- */
 
 static void scan_module_registry(void) {
+    /* Issue #143 (found the same way as sx_rules_gc_scan/
+     * sx_algebra_gc_scan's identical fix in #141): under --gc
+     * generational, a minor collection is per-thread, not a
+     * stop-the-world pause for other actors, so this scanner can run
+     * concurrently with module_registry_lock-protected access from
+     * other threads and was mutating entries unguarded. Takes the same
+     * write lock registry_insert uses. Safe against self-deadlock:
+     * gc_ss_evac/gc_ss_fwd don't allocate, and registry_insert's own
+     * allocation happens before it takes the lock (see its comment),
+     * so no thread can already be holding this lock at the moment its
+     * own allocation triggers the minor collection that runs this
+     * scanner. */
+    pthread_rwlock_wrlock(&module_registry_lock);
     for (ModuleEntry *e = registry; e; e = e->next) {
         e->name   = (val_t)gc_ss_evac((uintptr_t)e->name);
         e->module = (Module *)gc_ss_fwd(e->module);
     }
+    pthread_rwlock_unlock(&module_registry_lock);
 }
 
 /* ---- Public API ---- */

--- a/tests/module_isolation_tests.scm
+++ b/tests/module_isolation_tests.scm
@@ -179,5 +179,36 @@
 (check "r6rs except: excluded name not visible even inside the importing library"
   (r6-except-run) 'unbound-as-expected)
 
+;;; ── Module registry concurrency (issue #143) ────────────────────────────
+;;; modules.c's registry (the name-list -> Module* linked list backing
+;;; every `import`) was read and written with zero synchronization,
+;;; despite curry actors being real OS threads with no global interpreter
+;;; lock -- registry_insert's unsynchronized "read old head, write new
+;;; head" prepend could lose a concurrent registration, the same lost-
+;;; update sx_rule_add had before #141's identical fix for sx_rules.c's
+;;; rtab. Several actors concurrently importing modules must not crash or
+;;; hang. (Deliberately run only under the default Boehm backend: the
+;;; same underlying script -- concurrent module import with no sx_rules/
+;;; sx_algebra involved at all -- was separately found to trip an
+;;; unrelated, pre-existing corruption bug under `--gc generational`,
+;;; confirmed to reproduce identically without this locking fix and
+;;; tracked as issue #144, not something this test is meant to catch.)
+(define (importer-loop n)
+  (if (> n 0)
+      (begin
+        (import (srfi 1))
+        (import (srfi 128))
+        (importer-loop (- n 1)))))
+(define mreg-a1 (spawn (lambda () (importer-loop 500))))
+(define mreg-a2 (spawn (lambda () (importer-loop 500))))
+(define mreg-a3 (spawn (lambda () (importer-loop 500))))
+(define mreg-a4 (spawn (lambda () (importer-loop 500))))
+(let mreg-wait ()
+  (if (or (actor-alive? mreg-a1) (actor-alive? mreg-a2)
+          (actor-alive? mreg-a3) (actor-alive? mreg-a4))
+      (mreg-wait)))
+(check "module registry concurrency: concurrent import across actors completes without crash or hang"
+  #t #t)
+
 (display (string-append (number->string pass) " passed, " (number->string fail) " failed")) (newline)
 (if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

- Fixes #143: `src/modules.c`'s module registry (a name-list -> `Module*`
  linked list backing every `import`) was read and written with zero
  synchronization, despite curry actors being real OS threads with no
  global interpreter lock. Found during review of #141's identical fix for
  `sx_rules.c`'s `rtab`/`sx_algebra.c`'s `atab`: `registry_insert`'s
  prepend (`e->next = registry; registry = e;`) is an unsynchronized
  read-modify-write on the shared head pointer, so two concurrent inserts
  can race and silently drop one registration forever -- the same
  lost-update `sx_rule_add` had before #141.
- Fixed with a `pthread_rwlock_t` (single-writer/many-reader), applying
  the same design #141 already went through four review rounds to
  validate:
  - `registry_insert` allocates its `ModuleEntry` **before** taking the
    write lock (not while holding it), avoiding the self-deadlock hazard
    #141 found where an allocation under the lock could trigger a minor GC
    whose ext-scanner then wants the same lock for writing.
  - `registry_lookup` holds the read lock for its whole traversal --
    unlike #141's `sx_rule_try`, this never calls back into arbitrary
    Scheme code (verified by both review agents), so no
    snapshot-then-release pattern was needed here.
  - `scan_module_registry` (the GC ext-scanner, confirmed live under
    `--gc generational` by the #141 investigation, not dead code) now
    takes the write lock for its scan, mirroring `sx_rules_gc_scan`/
    `sx_algebra_gc_scan`'s identical fix.
  - Unlike `rtab`/`atab`, this registry has no removal function at all
    (modules are never unloaded), so there's no unlink-vs-traversal hazard
    to close -- a narrower fix than #141's.
- Two independent review rounds (code + security) ran against this
  branch; both found the fix itself sound (no self-deadlock, no new
  memory-safety issue, clean under a 400-run stress test and a 24-actor/
  17-module stress test, both under the default Boehm backend).

## Found along the way, filed as separate follow-ups (not fixed here)

- #144 (updated) -- the same "concurrent module import" script, with zero
  `sx_rules`/`sx_algebra` involvement, was separately found to trip the
  already-known, pre-existing `--gc generational` corruption bug.
  Confirmed via bisection to reproduce identically on `main` before this
  fix -- not something this PR introduces or could fix.
- #148 -- a TSan-confirmed data race in `modules_import`'s no-export-list
  re-export path (`src/modules.c:545-550`), which reads an `EnvFrame`'s
  `size`/`syms`/`vals` with no lock while `env_define` mutates the same
  frame under its own per-frame lock on another thread. Pre-existing,
  unrelated to the registry lock added here.
- #149 -- `modules_try_load`'s C-module (`.so`/`.dylib`) path has no
  re-check after a racing concurrent load, unlike the `.sld`/`.scm` path's
  existing `self_reg` re-check -- two actors racing to first-import the
  same C module can each end up with their own independently-initialized
  `Module*` instance. Pre-existing check-then-act race, this PR's lock
  only fixes the underlying list corruption, not this higher-level
  duplicate-instantiation gap.
- #150 -- `registry_lookup` returns a bare `Module*` that outlives the
  lock; under `--gc generational` (where `Module` is movable, per
  `scan_module_registry`'s own `gc_ss_fwd` call), a minor GC could
  relocate it out from under a caller still holding the raw pointer.
  Pre-existing pattern, generational-GC-wide, not specific to this fix.

## Test plan

- [x] `ctest --test-dir build` -- 117/117 suites pass (fresh
      `--clear-cache` run, default Boehm backend)
- [x] Added a concurrency regression test (`tests/module_isolation_tests.scm`):
      4 actors concurrently importing modules, asserting completion
      without crash/hang -- deliberately Boehm-only (see #144 above for
      why)
- [x] Two independent review rounds (code + security), including a
      400-fresh-process stress run and a 24-actor/17-module/25s stress
      run, both clean under the default backend
- [x] Manually confirmed the underlying registry-corruption fix is
      structurally identical to #141's already-four-times-reviewed design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
