### PR TITLE
fix(modules,env): synchronize modules_import's no-export-list walk against concurrent env_define (#148)

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -299,6 +299,31 @@ val_t *frame_lookup(EnvFrame *f, val_t sym) {
     return frame_lookup_versioned(f, sym, NULL);
 }
 
+uint32_t frame_snapshot_bindings(EnvFrame *f, val_t **out_syms, val_t **out_vals) {
+    if (!frame_is_global(f)) {
+        uint32_t n = f->size;
+        val_t *syms = (val_t *)gc_alloc_raw_pinned(n * sizeof(val_t));
+        val_t *vals = (val_t *)gc_alloc_raw_pinned(n * sizeof(val_t));
+        memcpy(syms, f->syms, n * sizeof(val_t));
+        memcpy(vals, f->vals, n * sizeof(val_t));
+        *out_syms = syms; *out_vals = vals;
+        return n;
+    }
+    for (;;) {
+        uint32_t v1 = atomic_load_explicit((_Atomic uint32_t *)&f->version, memory_order_acquire);
+        if (v1 & 1) continue;
+        uint32_t n = f->size;
+        val_t *syms = (val_t *)gc_alloc_raw_pinned(n * sizeof(val_t));
+        val_t *vals = (val_t *)gc_alloc_raw_pinned(n * sizeof(val_t));
+        memcpy(syms, f->syms, n * sizeof(val_t));
+        memcpy(vals, f->vals, n * sizeof(val_t));
+        uint32_t v2 = atomic_load_explicit((_Atomic uint32_t *)&f->version, memory_order_acquire);
+        if (v2 != v1) continue;
+        *out_syms = syms; *out_vals = vals;
+        return n;
+    }
+}
+
 /* ---- Environment ---- */
 
 val_t env_new_root(void) {

--- a/src/env.h
+++ b/src/env.h
@@ -34,6 +34,19 @@ val_t           *frame_lookup(struct EnvFrame *f, val_t sym);          /* NULL i
  * out_ver is fine when the caller doesn't need it. */
 val_t           *frame_lookup_versioned(struct EnvFrame *f, val_t sym, uint32_t *out_ver);
 
+/* Copies out every (sym, val) pair currently in this ONE frame (not its
+ * parent chain) into freshly allocated arrays, returning the count. For a
+ * root frame (frame_is_global — reachable from more than one actor, see
+ * env.c's big seqlock comment) this is validated against a concurrent
+ * frame_define the same lock-free way frame_lookup_versioned validates a
+ * single lookup, retrying if a structural write was in progress or landed
+ * mid-copy; a plain memcpy for every other (single-thread-owned) frame.
+ * Needed by anything that must walk a WHOLE frame's bindings rather than
+ * look up one symbol at a time — e.g. modules.c's no-export-list import
+ * path, which used to index f->syms[i]/f->vals[i] directly with no
+ * synchronization at all. */
+uint32_t         frame_snapshot_bindings(struct EnvFrame *f, val_t **out_syms, val_t **out_vals);
+
 /* ---- Environment operations ---- */
 
 /* Create a new root (global) environment */

--- a/src/modules.c
+++ b/src/modules.c
@@ -541,11 +541,29 @@ val_t modules_import(val_t spec, val_t env) {
     } else {
         /* No export list: every binding in the module's own environment is
          * importable (C modules, plain .scm files loaded without
-         * define-library, and always-on builtin module aliases). */
+         * define-library, and always-on builtin module aliases).
+         *
+         * Issue #148 (TSan-confirmed): mod->env is a root frame
+         * (env_new_root(), same shape as GLOBAL_ENV), and root frames are
+         * exactly the ones env.c's seqlock protocol exists for -- another
+         * actor can still be executing this module's own top-level body
+         * (defining bindings into mod->env one at a time via frame_define)
+         * while this actor imports it, e.g. a define-library that
+         * self-registers before its body finishes running, then a second
+         * concurrent importer's self_reg re-check (modules_try_load) picks
+         * up the partially-loaded module. Indexing f->syms[i]/f->vals[i]
+         * directly here bypassed that protocol entirely -- a plain,
+         * unsynchronized read racing frame_define's unsynchronized
+         * f->syms/f->vals reallocation (frame_grow) and rehash. Uses
+         * frame_snapshot_bindings (env.c) instead, the same seqlock-
+         * validated copy frame_lookup_versioned already does for a single
+         * symbol, just for the whole frame at once. */
         EnvFrame *f = mod->env;
         while (f) {
-            for (uint32_t i = 0; i < f->size; i++)
-                import_binding(f->syms[i], f->vals[i], spec, filter, env);
+            val_t *syms, *vals;
+            uint32_t n = frame_snapshot_bindings(f, &syms, &vals);
+            for (uint32_t i = 0; i < n; i++)
+                import_binding(syms[i], vals[i], spec, filter, env);
             f = f->parent;
         }
     }

--- a/src/modules.c
+++ b/src/modules.c
@@ -543,21 +543,31 @@ val_t modules_import(val_t spec, val_t env) {
          * importable (C modules, plain .scm files loaded without
          * define-library, and always-on builtin module aliases).
          *
-         * Issue #148 (TSan-confirmed): mod->env is a root frame
-         * (env_new_root(), same shape as GLOBAL_ENV), and root frames are
-         * exactly the ones env.c's seqlock protocol exists for -- another
-         * actor can still be executing this module's own top-level body
-         * (defining bindings into mod->env one at a time via frame_define)
-         * while this actor imports it, e.g. a define-library that
-         * self-registers before its body finishes running, then a second
-         * concurrent importer's self_reg re-check (modules_try_load) picks
-         * up the partially-loaded module. Indexing f->syms[i]/f->vals[i]
-         * directly here bypassed that protocol entirely -- a plain,
-         * unsynchronized read racing frame_define's unsynchronized
-         * f->syms/f->vals reallocation (frame_grow) and rehash. Uses
-         * frame_snapshot_bindings (env.c) instead, the same seqlock-
-         * validated copy frame_lookup_versioned already does for a single
-         * symbol, just for the whole frame at once. */
+         * Issue #148 (TSan-confirmed): walking here can reach GLOBAL_ENV
+         * itself -- directly, since every (scheme base)/(scheme write)/
+         * etc. alias IS GLOBAL_ENV (modules_register_builtin), and
+         * indirectly, since a plain .scm/.sld module loaded without
+         * define-library gets mod->env = env_extend(GLOBAL_ENV), so the
+         * parent-chain walk below reaches it too. GLOBAL_ENV is a root
+         * frame (parent == NULL) and the one frame env.c's seqlock
+         * protocol exists to protect, because it is the one frame actors
+         * genuinely share: any other actor's ordinary top-level (define
+         * ...) calls frame_define on this exact frame while this actor
+         * is mid-import, with no relationship between the two beyond both
+         * happening to run concurrently. (An earlier version of this
+         * comment described a different, define-library-self-registration
+         * scenario as the trigger; that path does not actually expose a
+         * partially-loaded module today -- registry_insert only runs
+         * after a define-library body's whole clause-processing loop
+         * finishes. GLOBAL_ENV's own ordinary concurrent mutation is the
+         * real and sufficient hazard, and is what the regression test in
+         * tests/module_isolation_tests.scm actually exercises.) Indexing
+         * f->syms[i]/f->vals[i] directly here bypassed that protocol
+         * entirely -- a plain, unsynchronized read racing frame_define's
+         * unsynchronized f->syms/f->vals reallocation (frame_grow) and
+         * rehash. Uses frame_snapshot_bindings (env.c) instead, the same
+         * seqlock-validated copy frame_lookup_versioned already does for
+         * a single symbol, just for the whole frame at once. */
         EnvFrame *f = mod->env;
         while (f) {
             val_t *syms, *vals;

--- a/tests/module_isolation_tests.scm
+++ b/tests/module_isolation_tests.scm
@@ -210,5 +210,45 @@
 (check "module registry concurrency: concurrent import across actors completes without crash or hang"
   #t #t)
 
+;;; ── modules_import's no-export-list env walk (issue #148) ──────────────
+;;; The test above imports srfi 1/128, which both declare explicit
+;;; (export ...) clauses -- so it never actually exercises has_exports =
+;;; false's code path (modules_import's raw f->syms[i]/f->vals[i] walk,
+;;; TSan-confirmed racing frame_define's unsynchronized frame_grow/
+;;; frame_hash_rehash). (scheme base) and its sibling aliases ARE
+;;; registered with has_exports = false (modules_register_builtin,
+;;; modules.c) and alias GLOBAL_ENV directly -- so importing (scheme
+;;; base) walks GLOBAL_ENV's own frame chain via exactly the vulnerable
+;;; path, and GLOBAL_ENV is the one frame actually reachable from more
+;;; than one actor thread (env.c's own seqlock design doc). This test
+;;; imports (scheme base) repeatedly from two actors while two other
+;;; actors concurrently grow GLOBAL_ENV with fresh top-level defines
+;;; (forcing real frame_grow/rehash calls mid-import), which reliably
+;;; reproduced the race under ThreadSanitizer before the fix
+;;; (frame_snapshot_bindings, env.c) and does not after.
+(define (mreg148-definer-loop n tag)
+  (if (> n 0)
+      (begin
+        (eval (list 'define
+                     (string->symbol (string-append "mreg148-" (symbol->string tag) "-" (number->string n)))
+                     n)
+              (interaction-environment))
+        (mreg148-definer-loop (- n 1) tag))))
+(define (mreg148-importer-loop n)
+  (if (> n 0)
+      (begin
+        (import (scheme base))
+        (mreg148-importer-loop (- n 1)))))
+(define mreg148-d1 (spawn (lambda () (mreg148-definer-loop 2000 'a))))
+(define mreg148-d2 (spawn (lambda () (mreg148-definer-loop 2000 'b))))
+(define mreg148-i1 (spawn (lambda () (mreg148-importer-loop 300))))
+(define mreg148-i2 (spawn (lambda () (mreg148-importer-loop 300))))
+(let mreg148-wait ()
+  (if (or (actor-alive? mreg148-d1) (actor-alive? mreg148-d2)
+          (actor-alive? mreg148-i1) (actor-alive? mreg148-i2))
+      (mreg148-wait)))
+(check "modules_import no-export-list walk: importing (scheme base) while GLOBAL_ENV grows concurrently completes without crash or hang"
+  #t #t)
+
 (display (string-append (number->string pass) " passed, " (number->string fail) " failed")) (newline)
 (if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

- Fixes #148: `modules_import`'s "no export list" branch (re-exporting
  every binding in an imported module when it declared no explicit
  `(export ...)` clause -- this includes every `(scheme base)`/
  `(scheme write)`/etc. alias, since those are registered with
  `has_exports = false` pointing directly at `GLOBAL_ENV`) walked the
  module's `EnvFrame` chain with a raw, completely unsynchronized loop,
  indexing `f->syms[i]`/`f->vals[i]` directly.
- `src/env.c` already has a carefully-designed seqlock protocol for
  exactly this situation: root frames (`parent == NULL`, which includes
  `GLOBAL_ENV` and every `define-library`'s own top-level frame) are the
  only `EnvFrame`s reachable from more than one actor thread, and
  `frame_define`/`frame_lookup_versioned` already coordinate around a
  `f->version` seqlock so a reader never observes a torn intermediate
  state during a concurrent `frame_grow`/`frame_hash_rehash`.
  `modules_import`'s raw walk bypassed that protocol entirely.
- Found via independent code review of an unrelated fix (#143), using
  ThreadSanitizer: a read at `modules.c:547` racing a write inside
  `frame_define_unlocked` from another actor's concurrent top-level
  `define`.
- Fixed by adding `frame_snapshot_bindings` (`env.c`/`env.h`): the exact
  same seqlock-validated read `frame_lookup_versioned` already does for
  one symbol, generalized to copy an entire frame's `(sym, val)` pairs in
  one consistency-checked pass, retrying the whole copy if a concurrent
  write was in progress or landed mid-copy. A plain `memcpy` for every
  other (single-thread-owned) frame, matching the existing fast path.
- Verified directly with ThreadSanitizer, not just by reasoning: built a
  TSan variant, confirmed the exact `modules.c:547` race reproduces on
  the immediate parent commit and is absent after this fix, using the
  same regression workload both times.

## Review

Two independent review rounds (code + security) ran against this branch.
Both came back clean on the fix itself -- no torn reads, correct
`frame_is_global` branching, correct allocator choice, no crash/hang/
corruption across heavy adversarial TSan stress (16 actors, ~150k
combined operations). Two things surfaced along the way:

- An inaccurate comment (this branch's own): the original comment
  described a `define-library`-self-registration race as the trigger,
  but tracing the actual code shows that path doesn't currently expose a
  partial module -- the real, sufficient hazard is simpler (`GLOBAL_ENV`
  itself, mutated by ordinary concurrent top-level `define`s). Corrected
  in a follow-up commit on this branch.
- Two pre-existing, inherited characteristics of `env.c`'s seqlock design
  (not introduced by this fix, only more exposed by it): a theoretical
  memory-ordering gap in the plain release-store seqlock bump (no crash
  observed on this hardware/compiler, but not airtight per the strict C11
  memory model), and an unbounded-retry livelock risk under sustained
  contention on a very large namespace. Filed as #153 for a proper design
  pass (stronger ordering and/or a bounded-retry fallback), not attempted
  here.
- #152 was also filed (by the code-review agent): the REPL's `,env`
  command has the identical unfixed bug pattern (raw, unsynchronized walk
  of `GLOBAL_ENV`'s frame) -- out of scope for this PR, a separate call
  site.

## Test plan

- [x] `ctest --test-dir build` -- 117/117 suites pass (fresh
      `--clear-cache` run)
- [x] Added a regression test (`tests/module_isolation_tests.scm`): two
      actors importing `(scheme base)` while two others concurrently
      define fresh top-level bindings, forcing real `frame_grow`/
      `frame_hash_rehash` calls mid-import
- [x] Verified under ThreadSanitizer with a clean before/after
      comparison: the specific race reproduces on the parent commit and
      is gone on this branch, using the identical stress workload
- [x] Two independent review rounds (code + security), including
      additional adversarial TSan stress beyond the committed regression
      test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
