### PR TITLE
fix(main): synchronize REPL ,env against concurrent GLOBAL_ENV mutation (#152)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -348,9 +348,23 @@ static void eval_port_exprs(val_t port, bool print) {
                     continue;
                 }
                 if (!strcmp(name, "env")) {
+                    /* Issue #152 (same pattern as #148's modules_import
+                     * fix): GLOBAL_ENV is a root frame actors can mutate
+                     * concurrently via ordinary top-level define while
+                     * the REPL sits idle at its prompt -- reading
+                     * f->size/f->syms directly here raced frame_define's
+                     * unsynchronized frame_grow/frame_hash_rehash the
+                     * same way modules_import's raw walk did. Uses
+                     * frame_snapshot_bindings (env.c), the same
+                     * seqlock-validated whole-frame copy #148 added;
+                     * values aren't needed here, only names, so the
+                     * paired vals array from the snapshot is unused. */
                     EnvFrame *f = as_env(GLOBAL_ENV);
-                    for (uint32_t i = 0; i < f->size; i++) {
-                        scm_display(f->syms[i], PORT_STDOUT);
+                    val_t *syms, *vals;
+                    uint32_t n = frame_snapshot_bindings(f, &syms, &vals);
+                    (void)vals;
+                    for (uint32_t i = 0; i < n; i++) {
+                        scm_display(syms[i], PORT_STDOUT);
                         scm_newline(PORT_STDOUT);
                     }
                     continue;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,18 @@ endif()
 add_test(NAME cli
     COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cli.sh
             $<TARGET_FILE:curry>)
+# Issue #152's ,env regression subtest races two actors against a busy-wait
+# poll loop (env152-loop) whose termination depends on both actors actually
+# finishing -- the same open-ended-hang risk shape actors/websocket/ros
+# already carry an explicit TIMEOUT for below, and for the same reason: a
+# real hang here (e.g. a livelock in env.c's seqlock retry loop under
+# sustained writer contention, see issue #153) would otherwise block only
+# up to CI's 30-minute job-level timeout with no isolated, diagnosable
+# ctest-level signal. cli normally completes in under 70s (observed up to
+# ~70s in CI's own websocket-retry runs, ~25s locally); 300s gives
+# generous headroom above that while still turning an open-ended hang into
+# a fast, clearly-labeled TIMEOUT instead.
+set_tests_properties(cli PROPERTIES TIMEOUT 300)
 add_test(NAME debugger
     COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_debugger.sh
             $<TARGET_FILE:curry>)

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -44,6 +44,33 @@ check_contains() {
     fi
 }
 
+# Like check_contains, but greps a FILE directly instead of piping a shell
+# variable's contents through printf | grep -q. Independent security review
+# of issue #152's ,env regression test found that check_contains's
+# printf '%s' "$haystack" | grep -qF pattern is flaky (~1-in-4 to 1-in-5,
+# on macOS specifically) once $haystack is large (tens of KB) and
+# multi-byte-heavy (curry's Akkadian/cuneiform symbol names in this case) --
+# traced to a timing-sensitive interaction with macOS's shipped BSD grep
+# 2.6.0-FreeBSD (~2010) and -q's early-exit-on-first-match behavior when fed
+# a large buffer through a pipe under load, NOT a bug in curry itself
+# (verified: the byte sequence being searched for was always present,
+# byte-for-byte, in curry's actual output on every observed failure --
+# replaying the identical captured bytes through the same grep command
+# afterward always succeeded). Writing output straight to a file and
+# grepping the file sidesteps the pipe entirely.
+check_contains_file() {
+    local label="$1" file="$2" needle="$3"
+    if grep -qF -- "$needle" "$file"; then
+        echo "PASS: $label"
+        (( pass++ )) || true
+    else
+        echo "FAIL: $label (string not found)"
+        echo "  looking for: $needle"
+        echo "  in file: $file"
+        (( fail++ )) || true
+    fi
+}
+
 check_file_exists() {
     local label="$1" path="$2"
     if [ -f "$path" ]; then
@@ -832,11 +859,12 @@ ENV152_EOF
 # actively running (spawn returns immediately; the REPL reads and runs the
 # next line -- ,env -- with no wait in between), then the wait-script drains
 # both actors before ,quit so the process doesn't exit mid-definition.
-env152_out=$(printf '%s\n,env\n,env\n%s\n,quit\n' "$(cat "$ENV_SPAWN_SCM")" "$(cat "$ENV_WAIT_SCM")" | "$CURRY" -i 2>&1)
-check_contains ",env survives concurrent GLOBAL_ENV mutation from other actors (issue #152) -- spawn completed" \
-  "$env152_out" "env152-spawned"
-check_contains ",env survives concurrent GLOBAL_ENV mutation from other actors (issue #152) -- actors ran to completion afterward" \
-  "$env152_out" "env152-defines-done"
+ENV152_OUT="$TMPDIR_CLI/env152_out.txt"
+printf '%s\n,env\n,env\n%s\n,quit\n' "$(cat "$ENV_SPAWN_SCM")" "$(cat "$ENV_WAIT_SCM")" | "$CURRY" -i > "$ENV152_OUT" 2>&1
+check_contains_file ",env survives concurrent GLOBAL_ENV mutation from other actors (issue #152) -- spawn completed" \
+  "$ENV152_OUT" "env152-spawned"
+check_contains_file ",env survives concurrent GLOBAL_ENV mutation from other actors (issue #152) -- actors ran to completion afterward" \
+  "$ENV152_OUT" "env152-defines-done"
 
 # ─── Summary ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -796,6 +796,48 @@ out2=$("$CURRY" -e '(define-record-type point2 (fields (mutable x) (immutable y)
 (display (list (point2? (make-point2 1 2 3)) (point2-x (make-point2 1 2 3))))')
 check "define-record-type R6RS with valid field specs still compiles and runs correctly" "$out2" "(#t 1)"
 
+# ─── ,env REPL command vs concurrent GLOBAL_ENV mutation (issue #152) ──────────
+#
+# The REPL's ,env command used to read GLOBAL_ENV's frame->size/frame->syms
+# directly with no synchronization, racing any actor's concurrent top-level
+# (define ...) the same way modules_import's no-export-list import walk did
+# before issue #148's fix -- both bypassed env.c's seqlock protocol, the
+# only thing making GLOBAL_ENV safe to read while another actor's
+# frame_define is reallocating its syms/vals/hidx arrays (frame_grow/
+# frame_hash_rehash). Fixed by switching ,env to frame_snapshot_bindings
+# (env.c), the same whole-frame seqlock-validated copy #148 introduced.
+# Spawns several actors continuously defining fresh top-level globals while
+# ,env runs repeatedly, verifying the REPL survives without crashing or
+# hanging (piped stdin driving -i, matching this file's existing pattern
+# for REPL command tests above).
+ENV_SPAWN_SCM="$TMPDIR_CLI/env152_spawn.scm"
+cat > "$ENV_SPAWN_SCM" << 'ENV152_EOF'
+(define (definer-loop n tag)
+  (if (> n 0)
+      (begin
+        (eval (list 'define (string->symbol (string-append "env152-" (symbol->string tag) "-" (number->string n))) n)
+              (interaction-environment))
+        (definer-loop (- n 1) tag))))
+(define env152-d1 (spawn (lambda () (definer-loop 20000 'a))))
+(define env152-d2 (spawn (lambda () (definer-loop 20000 'b))))
+(display "env152-spawned")(newline)
+ENV152_EOF
+ENV_WAIT_SCM="$TMPDIR_CLI/env152_wait.scm"
+cat > "$ENV_WAIT_SCM" << 'ENV152_EOF'
+(let env152-loop ()
+  (if (or (actor-alive? env152-d1) (actor-alive? env152-d2)) (env152-loop)))
+(display "env152-defines-done")(newline)
+ENV152_EOF
+# ,env is issued as its own stdin line WHILE the two actors above are still
+# actively running (spawn returns immediately; the REPL reads and runs the
+# next line -- ,env -- with no wait in between), then the wait-script drains
+# both actors before ,quit so the process doesn't exit mid-definition.
+env152_out=$(printf '%s\n,env\n,env\n%s\n,quit\n' "$(cat "$ENV_SPAWN_SCM")" "$(cat "$ENV_WAIT_SCM")" | "$CURRY" -i 2>&1)
+check_contains ",env survives concurrent GLOBAL_ENV mutation from other actors (issue #152) -- spawn completed" \
+  "$env152_out" "env152-spawned"
+check_contains ",env survives concurrent GLOBAL_ENV mutation from other actors (issue #152) -- actors ran to completion afterward" \
+  "$env152_out" "env152-defines-done"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 
 echo


### PR DESCRIPTION
## Summary

- Fixes #152: the REPL's `,env` command (`src/main.c`) read `GLOBAL_ENV`'s
  `frame->size`/`frame->syms` directly with zero synchronization -- the
  same bug pattern #148 fixed in `modules_import`'s no-export-list import
  walk. `GLOBAL_ENV` is a root frame actors can mutate concurrently via
  ordinary top-level `(define ...)` even while the REPL sits idle at its
  prompt, racing `frame_define`'s unsynchronized `frame_grow`/
  `frame_hash_rehash`. Found by an independent reviewer while auditing the
  codebase for other unfixed instances of #148's pattern.
- Fixed by switching `,env` to `frame_snapshot_bindings` (added by #148,
  unchanged here) -- the same seqlock-validated whole-frame copy
  `frame_lookup_versioned` already does for a single symbol lookup, just
  generalized to the whole frame.
- Added a regression test to `tests/test_cli.sh`: spawns two actors
  continuously defining fresh top-level globals via `eval`, then issues
  `,env` as the immediately-next stdin line (not after waiting for the
  actors to finish, which would defeat the point) -- confirmed by
  inspecting the interleaved output that `,env` genuinely runs while the
  actors are still mid-loop.

## Review

Two independent review rounds (code + security) ran against the core fix
(ce3d22c). Both came back clean on the C change itself -- correct reuse of
`frame_snapshot_bindings`, no new race under heavy TSan stress, no other
unfixed instance of the pattern elsewhere in `main.c`'s REPL commands.
Two real, actionable things surfaced, both fixed in follow-up commits on
this branch:

- The `cli` ctest entry had no `TIMEOUT` property, unlike `actors`/
  `websocket`/`ros`, which already carry one for exactly this "rare,
  non-deterministic hang" risk shape (the new `,env` subtest has the same
  busy-wait-depends-on-two-actors-finishing shape). Added
  `TIMEOUT 300`.
- The new regression test itself was flaky (~1-in-4 to 1-in-5 on macOS,
  confirmed and root-caused by the security reviewer): `check_contains`'s
  `printf '%s' "$haystack" | grep -qF` pattern is timing-sensitive once
  `$haystack` is large and multi-byte-heavy, piped through macOS's shipped
  BSD grep. Confirmed NOT a curry bug -- the byte-level content was always
  correct on every observed failure. Fixed by adding
  `check_contains_file` (writes output straight to a file, greps the file
  directly) and switching this test to use it. Verified with 18
  consecutive clean `test_cli.sh` runs afterward.
- Also chased down an apparent "run 13 hangs" observation from a batch of
  local test runs: it wasn't a real hang, just the outer polling tool's
  own 5-minute cap being hit by *cumulative* runtime across many
  sequential ~25-30s runs. An isolated run completed cleanly in under 30s.

## Test plan

- [x] `ctest --test-dir build` -- 117/117 suites pass (fresh
      `--clear-cache` run)
- [x] `bash tests/test_cli.sh ./build/curry` -- 18 consecutive clean runs,
      0 failures (post the flaky-test fix)
- [x] Two independent review rounds on the core C fix (code + security),
      including ThreadSanitizer stress testing and byte-level output
      inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
