### PR TITLE
fix(modules): re-check registry before inserting a freshly-loaded C module (#149)

### DIFF
--- a/src/modules.c
+++ b/src/modules.c
@@ -404,12 +404,40 @@ static Module *modules_try_load(val_t name_list) {
         /* Try .so first */
         snprintf(full, sizeof(full), "%s/%s.so", search_dirs[i], path_base);
         mod = load_c_module(name_list, full);
-        if (mod) { registry_insert(name_list, mod); return mod; }
+        if (mod) {
+            /* Issue #149: two actors racing to first-import the same
+             * not-yet-loaded C module can both see registry_lookup return
+             * NULL above and both proceed to load_c_module -- each doing
+             * its own dlopen + curry_module_init, independently. Without
+             * this re-check (the exact same pattern the .sld/.scm branch
+             * below already uses, for a same-load rather than cross-actor
+             * reason -- a define-library body self-registering during its
+             * own load), whichever registry_insert ran last would win as
+             * the identity every FUTURE lookup resolves to, while each
+             * racing importer still kept and used the Module* it
+             * personally created, leaving them bound to two different
+             * "singleton" instances. This doesn't undo curry_module_init
+             * having run twice if the race was already lost by the time
+             * we get here (that side effect already happened, and is a
+             * known, accepted consequence -- same as the .sld/.scm path's
+             * duplicate-load tolerance), but it does make every actor
+             * converge on the SAME Module* going forward. */
+            Module *self_reg = registry_lookup(name_list);
+            if (self_reg) return self_reg;
+            registry_insert(name_list, mod);
+            return mod;
+        }
 
         /* Try .dylib (macOS) */
         snprintf(full, sizeof(full), "%s/%s.dylib", search_dirs[i], path_base);
         mod = load_c_module(name_list, full);
-        if (mod) { registry_insert(name_list, mod); return mod; }
+        if (mod) {
+            /* Same reasoning as the .so branch just above. */
+            Module *self_reg = registry_lookup(name_list);
+            if (self_reg) return self_reg;
+            registry_insert(name_list, mod);
+            return mod;
+        }
 
         /* Try .sld (Scheme library definition) */
         snprintf(full, sizeof(full), "%s/%s.sld", search_dirs[i], path_base);

--- a/tests/module_isolation_tests.scm
+++ b/tests/module_isolation_tests.scm
@@ -250,5 +250,50 @@
 (check "modules_import no-export-list walk: importing (scheme base) while GLOBAL_ENV grows concurrently completes without crash or hang"
   #t #t)
 
+;;; ── C-module (.so/.dylib) concurrent first-import race (issue #149) ────
+;;; modules_try_load's .so/.dylib branch used to lack the re-check step
+;;; the .sld/.scm branches already had (checking the registry again after
+;;; a successful load, before inserting, and preferring whatever's already
+;;; there): two actors racing to first-import the same not-yet-loaded C
+;;; module could each independently dlopen + run curry_module_init, then
+;;; each registry_insert its own Module* -- whichever insert ran last won
+;;; as the identity every future lookup resolves to, while the OTHER
+;;; racing importer still kept and used the Module* it personally
+;;; created, leaving actors bound to two different "singleton" module
+;;; instances. Many actors each doing exactly one FIRST-EVER import of
+;;; the same not-yet-loaded C module (curry json, unused elsewhere in
+;;; this file, so this is a genuine first load) maximizes simultaneous
+;;; race-window contention. Doesn't assert instance identity (no
+;;; primitive exposes Module* to Scheme) -- like #141/#143/#148's own
+;;; concurrency tests, this checks the fix doesn't introduce a NEW hazard
+;;; (crash/hang) under heavy contention on the actual vulnerable path.
+(define cmod149-actors
+  (list (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))
+        (spawn (lambda () (import (curry json))))))
+(define (cmod149-all-done? lst)
+  (or (null? lst)
+      (and (not (actor-alive? (car lst))) (cmod149-all-done? (cdr lst)))))
+(let cmod149-wait () (if (cmod149-all-done? cmod149-actors) 'done (cmod149-wait)))
+(check "C-module concurrent first-import race: 16 actors racing to first-load the same .so module completes without crash or hang"
+  #t #t)
+;; Confirm the module actually works afterward regardless of which racing
+;; actor's load "won" -- a basic functional smoke test, not just "didn't crash".
+(check "C-module concurrent first-import race: the module is actually usable afterward"
+  (json-stringify (list->vector (list 1 2 3))) "[1,2,3]")
+
 (display (string-append (number->string pass) " passed, " (number->string fail) " failed")) (newline)
 (if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

- Fixes #149: `modules_try_load`'s `.so`/`.dylib` branches inserted a
  freshly-loaded `Module` into the module registry unconditionally, unlike
  the `.sld`/`.scm` branches just below them, which already re-check the
  registry after loading and prefer whatever is already there before
  inserting. That existing check was originally there for a same-load
  reason (a `define-library` body self-registering as a side effect of
  evaluating the file), but the mechanism is agnostic to *who* registered
  first -- so it incidentally also closes a cross-actor concurrency race.
- Two actors racing to first-import the same not-yet-loaded C module could
  both see `registry_lookup` return `NULL`, both independently `dlopen` +
  run `curry_module_init`, and both `registry_insert` their own `Module*`
  -- whichever insert ran last "won" as what future lookups resolve to,
  while the other racing actor kept using the `Module*` it personally
  created. Two actors ending up bound to two different "singleton"
  instances of what's supposed to be one process-wide module.
- Fixed by applying the identical re-check-then-prefer-existing pattern
  already used for `.sld`/`.scm` to the `.so`/`.dylib` branches. This does
  not undo `curry_module_init` having run twice if the race was already
  lost by the time the re-check happens (that side effect already
  occurred, and is a known, accepted consequence matching the `.sld`/
  `.scm` path's own existing tolerance) -- it makes every racing actor
  converge on the same `Module*` afterward.

## Review

Two independent review rounds (code + security) ran against this branch.
Both came back clean:

- Code review confirmed the fix is structurally identical to the existing
  `.sld`/`.scm` pattern (no copy-paste error), walked the actual race
  interleaving to confirm it's closed, checked `load_c_module` for any
  state beyond the `Module*` that a discarded "loser" instance could leak
  or corrupt (none -- `dlopen` handles are never closed for ANY module,
  winner or loser, matching this codebase's existing "modules are never
  unloaded" design), and verified 8/8 repeated test runs plus a full
  117/117 ctest pass.
- Security review stress-tested under ThreadSanitizer across 8 different
  C modules racing simultaneous first-imports (~1,150+ racing attempts
  over 18 rounds): zero races, crashes, or hangs attributable to this
  fix. Confirmed `dlopen`/`dlsym`/`dlclose` have no curry-specific wrapper
  or shared state beyond the already-locked module registry, and found no
  spurious "module not found" failures from the fix's interaction with
  the pre-existing (unchanged) failure-fallthrough path.
- Along the way, the security review surfaced an unrelated, pre-existing
  bug: `curl_global_init` (in the http/graphql/storage modules) is called
  from an unguarded lazy `static int inited` check, not thread-safe per
  libcurl's own documentation, triggered by racing *uses* of a module
  after import rather than racing imports -- filed as #156, not addressed
  here.

## Test plan

- [x] `ctest --test-dir build` -- 117/117 suites pass (fresh
      `--clear-cache` run)
- [x] Added a regression test (`tests/module_isolation_tests.scm`): 16
      actors each doing exactly one first-ever import of a not-previously-
      loaded C module, maximizing simultaneous race-window contention,
      verifying no crash/hang and that the module actually works
      afterward regardless of which racing actor's load won
- [x] Two independent review rounds (code + security), including
      ThreadSanitizer stress testing across 8 different C modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
