### PR TITLE
fix(network,websocket): bind ephemeral ports in websocket/websocket_server/ros tests (issue #110)

### DIFF
--- a/docs/reference/module-network.md
+++ b/docs/reference/module-network.md
@@ -45,6 +45,22 @@ stream, so not a port) — close it with `tcp-close`. Each accepted
 connection from `tcp-accept` is a port pair like `tcp-connect`'s, closed
 with `close-port` on each end.
 
+```scheme
+(socket-local-port sock)   ; the actual port a socket is bound to
+```
+
+Pass `0` as `tcp-listen`'s (or SRFI-106 `make-server-socket`'s) `port` to
+ask the OS for an arbitrary free ephemeral port instead of a hardcoded
+one — the standard way to avoid port-collision flakiness when a test or
+short-lived server doesn't care which specific port it gets, just that it
+gets *a* free one. Since the OS picks the port, you don't know which one
+until after `bind()` has already happened; `socket-local-port` reads it
+back via `getsockname`. Works on any socket handle from `tcp-listen`,
+`udp-socket`, or SRFI-106's `make-client-socket`/`make-server-socket`/
+`socket-accept` (they all share the same underlying representation).
+`(curry websocket)`'s `ws-listener-port` is the equivalent for a
+`ws-listen` listener.
+
 ### TLS client
 
 ```scheme

--- a/docs/reference/module-websocket.md
+++ b/docs/reference/module-websocket.md
@@ -61,7 +61,11 @@ Returned verbatim from the request line — a query string, if the client sent o
 
 ### `(ws-listen port)` → listener
 
-Binds and listens on `port`. Doesn't block, doesn't accept anything yet — mirrors `(curry network)`'s own `tcp-listen`.
+Binds and listens on `port`. Doesn't block, doesn't accept anything yet — mirrors `(curry network)`'s own `tcp-listen`. Pass `0` to ask the OS for an arbitrary free ephemeral port instead of a hardcoded one; use `ws-listener-port` to find out which one it picked.
+
+### `(ws-listener-port listener)` → fixnum
+
+The actual port `listener` is bound to — needed after `(ws-listen 0)`, since you don't know which ephemeral port the OS assigned until after the underlying `bind()` has already happened. Equivalent to `(curry network)`'s `socket-local-port` applied to the listener's own socket.
 
 ### `(ws-accept listener)` → ws
 

--- a/lib/curry/modules/curry/websocket.scm
+++ b/lib/curry/modules/curry/websocket.scm
@@ -19,11 +19,19 @@
 ;;; live data to a browser-side frontend (e.g. React/whatever) without
 ;;; needing curry to also speak HTTP.
 (define-library (curry websocket)
-  (import (scheme base) (scheme write) (srfi s106 sockets) (curry crypto) (curry sync))
+  (import (scheme base) (scheme write) (srfi s106 sockets) (curry crypto) (curry sync)
+          ;; Just for socket-local-port, used by ws-listener-port below --
+          ;; a curry-specific extension (querying a bound socket's actual
+          ;; local port, needed to support listening on an OS-assigned
+          ;; ephemeral port rather than a hardcoded one) that isn't part of
+          ;; the SRFI-106 spec, so it isn't exported from
+          ;; (srfi s106 sockets) itself (see that file's own header
+          ;; comment on staying spec-faithful).
+          (curry network))
   (export
     ws-connect ws-send! ws-send-binary! ws-recv! ws-close! ws-closed?
     ws? ws-path
-    ws-listen ws-accept ws-listener? ws-listener-close!)
+    ws-listen ws-accept ws-listener? ws-listener-close! ws-listener-port)
   (begin
 
     ;; A GUID fixed by RFC 6455 itself -- concatenated with the client's
@@ -192,6 +200,14 @@
     ;; ---- Server: ws-listen / ws-accept
 
     (define (ws-listen port) (%make-ws-listener (make-server-socket port)))
+
+    ;; The actual port a listener is bound to -- needed when ws-listen was
+    ;; called with 0 (ask the OS for an arbitrary free ephemeral port,
+    ;; instead of a hardcoded one that risks colliding with another
+    ;; process, e.g. a lingering listener from a previous test run under
+    ;; parallel CI load), since the caller doesn't learn which port that
+    ;; actually is until after the underlying bind() has already happened.
+    (define (ws-listener-port listener) (socket-local-port (%ws-listener-socket listener)))
 
     (define (ws-listener-close! listener) (socket-close (%ws-listener-socket listener)))
 

--- a/modules/network/srfi106.c
+++ b/modules/network/srfi106.c
@@ -179,6 +179,37 @@ static curry_val fn_socket_accept(int ac, curry_val *av, void *ud) {
     return net_sock_to_val(client);
 }
 
+/* (socket-local-port socket) -> fixnum
+ *
+ * The actual port a socket is bound to, read back via getsockname --
+ * needed for a server socket created with a "0" service/port (the
+ * standard way to ask the OS for an arbitrary free ephemeral port
+ * instead of a hardcoded one): the caller doesn't learn what port that
+ * actually is until after bind() has already happened, since the OS
+ * picks it. Not part of SRFI 106 itself (that spec offers no way to
+ * query a bound socket's local address at all), but registered under
+ * the same "socket-*" naming convention as the rest of this file's
+ * primitives -- see docs/reference for how (curry websocket)'s ws-listen
+ * and the ros_tests.scm/websocket_tests.scm/websocket_server_tests.scm
+ * suites use this to bind an ephemeral port instead of a fixed one,
+ * closing out issue #110's CI port-contention flakiness at the root
+ * rather than only papering over it with a ctest-level timeout. */
+static curry_val fn_socket_local_port(int ac, curry_val *av, void *ud) {
+    (void)ud; (void)ac;
+    int fd = net_extract_fd(av[0], "socket-local-port");
+    struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
+    if (getsockname(fd, (struct sockaddr *)&addr, &addrlen) != 0)
+        curry_error("socket-local-port: getsockname failed: %s", strerror(errno));
+    uint16_t port;
+    if (addr.ss_family == AF_INET6)
+        port = ntohs(((struct sockaddr_in6 *)&addr)->sin6_port);
+    else if (addr.ss_family == AF_INET)
+        port = ntohs(((struct sockaddr_in *)&addr)->sin_port);
+    else
+        curry_error("socket-local-port: not an AF_INET/AF_INET6 socket");
+    return curry_make_fixnum(port);
+}
+
 static curry_val fn_socket_send(int ac, curry_val *av, void *ud) {
     (void)ud;
     int fd = net_extract_fd(av[0], "socket-send");
@@ -304,6 +335,7 @@ void curry_srfi106_module_init(CurryVM *vm) {
     curry_define_fn(vm, "make-server-socket", fn_make_server_socket, 1, 4, NULL);
     curry_define_fn(vm, "socket?",             fn_socket_p,          1, 1, NULL);
     curry_define_fn(vm, "socket-accept",       fn_socket_accept,     1, 1, NULL);
+    curry_define_fn(vm, "socket-local-port",   fn_socket_local_port, 1, 1, NULL);
     curry_define_fn(vm, "socket-send",         fn_socket_send,       2, 3, NULL);
     curry_define_fn(vm, "socket-recv",         fn_socket_recv,       2, 3, NULL);
     curry_define_fn(vm, "socket-shutdown",     fn_socket_shutdown,   2, 2, NULL);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,17 +120,27 @@ add_test(NAME case_lambda COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR
 add_test(NAME websocket COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/websocket_tests.scm)
 add_test(NAME websocket_server COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/websocket_server_tests.scm)
 add_test(NAME ros COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/ros_tests.scm)
-# Observed in CI (macos-latest, Release, under ctest -j full-suite
-# contention, twice in a row on 2026-08-31): the "websocket" test hung
-# completely silent for 28+ minutes until the whole job was cancelled --
-# no output, no failure, nothing -- while "ros" (the same run) failed fast
-# and cleanly with "tcp-listen: bind failed on port 17995", pointing at
-# port contention between these fixed-port networking tests under
-# parallel CI load as the likely root cause, not yet fixed. Same
-# treatment as the "actors" test's own documented rare-hang TIMEOUT just
-# above: turn a future recurrence into a fast, diagnosable CTest TIMEOUT
-# instead of a silent 28+ minute CI hang. See issue for the underlying
-# investigation this doesn't attempt to fix.
+# Issue #110: observed in CI (macos-latest, Release, under ctest -j
+# full-suite contention, twice in a row on 2026-08-31) -- the "websocket"
+# test hung completely silent for 28+ minutes until the whole job was
+# cancelled, while "ros" (the same run) failed fast and cleanly with
+# "tcp-listen: bind failed on port 17995". Root cause: these three tests
+# each bound fixed, hardcoded port numbers, inherently vulnerable to
+# collision under parallel CI load against another process (a lingering
+# listener from a previous run, a system service, another test) already
+# bound to the same port. Fixed at the root (not just papered over): all
+# three now bind port 0 (an OS-assigned ephemeral port) and read back the
+# actual port via socket-local-port/ws-listener-port
+# (modules/network/srfi106.c, lib/curry/modules/curry/websocket.scm) --
+# verified by holding all six of the OLD hardcoded ports busy from an
+# external process and confirming all three suites still pass cleanly,
+# since none of them depend on any fixed port anymore.
+#
+# The TIMEOUT below is kept anyway as defense-in-depth, matching the
+# "actors" test's own identical treatment just above for its unrelated
+# rare hang: even with the port-contention root cause closed, an
+# open-ended hang from some OTHER cause is still better caught as a fast,
+# diagnosable CTest TIMEOUT than a silent 28+ minute CI stall.
 set_tests_properties(websocket websocket_server ros PROPERTIES TIMEOUT 60)
 add_test(NAME srfi_95_78_212 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_95_78_212_tests.scm)
 add_test(NAME srfi_141 COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/srfi_141_tests.scm)

--- a/tests/ros_tests.scm
+++ b/tests/ros_tests.scm
@@ -18,7 +18,6 @@
              (display "  expected ") (write expected) (newline)
              (set! fail (+ fail 1)))))
 
-(define test-port 17995)
 (define ws-guid "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
 
 ;;; ---- minimal from-scratch server-side WS handshake + text framing ----
@@ -91,7 +90,11 @@
 
 ;;; ---- the mock rosbridge server: a fixed scripted exchange ----
 
-(define listener (tcp-listen test-port))
+;; Issue #110: a hardcoded port collides under CI parallel load. 0 asks
+;; the OS for an arbitrary free ephemeral port; socket-local-port reads
+;; back which one it actually picked.
+(define listener (tcp-listen 0))
+(define test-port (socket-local-port listener))
 (define seen (make-hash-table)) ; label -> decoded JSON message, for later checks
 (define server-done (make-semaphore 0))
 
@@ -188,8 +191,8 @@
 ;;; ---- regression: a dropped connection must wake a no-timeout
 ;;; ros-call-service instead of hanging it forever ----
 
-(define close-test-port 17990)
-(define close-test-listener (tcp-listen close-test-port))
+(define close-test-listener (tcp-listen 0))
+(define close-test-port (socket-local-port close-test-listener))
 
 ;; Accepts the WS handshake, then closes immediately without ever
 ;; answering the call_service the client is about to send.

--- a/tests/websocket_server_tests.scm
+++ b/tests/websocket_server_tests.scm
@@ -25,7 +25,6 @@
              (display "  expected ") (write expected) (newline)
              (set! fail (+ fail 1)))))
 
-(define test-port 17988)
 (define ws-guid "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
 
 ;;; ---- minimal from-scratch client-side handshake + framing ----
@@ -106,7 +105,11 @@
 
 ;;; ---- the real server under test: ws-listen / ws-accept ----
 
-(define listener (ws-listen test-port))
+;; Issue #110: a hardcoded port collides under CI parallel load. 0 asks
+;; the OS for an arbitrary free ephemeral port; ws-listener-port reads
+;; back which one it actually picked.
+(define listener (ws-listen 0))
+(define test-port (ws-listener-port listener))
 
 (define server-thread
   (spawn (lambda ()
@@ -180,7 +183,8 @@
 ;; into unbounded memory growth or a hang -- a client that sends a huge
 ;; unterminated "line" (or, separately, unboundedly many header lines)
 ;; must get a clean, bounded-cost rejection instead.
-(define cap-listener (ws-listen 17987))
+(define cap-listener (ws-listen 0))
+(define cap-port (ws-listener-port cap-listener))
 (define cap-done (make-semaphore 0))
 (define cap-result #f)
 
@@ -191,7 +195,7 @@
                (set! cap-result (list 'no-error conn))))
            (sem-post! cap-done))))
 
-(let* ((sock (make-client-socket "127.0.0.1" 17987))
+(let* ((sock (make-client-socket "127.0.0.1" cap-port))
        (out (socket-output-port sock)))
   ;; 20,000 bytes, no newline at all -- well past the per-line cap,
   ;; with the connection kept open so a missing cap would hang forever
@@ -207,7 +211,8 @@
 ;; 2. RFC 6455 5.1: a server MUST reject an unmasked frame from a
 ;; client (masking is a security requirement, not wire-format
 ;; decoration -- see the module's own comment on %ws-protocol-error!).
-(define mask-listener (ws-listen 17986))
+(define mask-listener (ws-listen 0))
+(define mask-port (ws-listener-port mask-listener))
 (define mask-done (make-semaphore 0))
 (define mask-result #f)
 
@@ -218,7 +223,7 @@
                (set! mask-result (list 'no-error (ws-recv! conn)))))
            (sem-post! mask-done))))
 
-(let* ((sock (make-client-socket "127.0.0.1" 17986))
+(let* ((sock (make-client-socket "127.0.0.1" mask-port))
        (in (socket-input-port sock))
        (out (socket-output-port sock))
        (key "dGhlIHNhbXBsZSBub25jZQ=="))

--- a/tests/websocket_tests.scm
+++ b/tests/websocket_tests.scm
@@ -24,7 +24,6 @@
              (display "  expected ") (write expected) (newline)
              (set! fail (+ fail 1)))))
 
-(define test-port 17996)
 (define ws-guid "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
 
 ;;; ---- minimal from-scratch server-side handshake + framing ----
@@ -108,7 +107,13 @@
 
 ;;; ---- the mock server actor: canned protocol exchange for the test ----
 
-(define listener (tcp-listen test-port))
+;; Issue #110: a hardcoded port collides under CI parallel load (another
+;; process, or a lingering listener from a previous test run, already
+;; bound to it). 0 asks the OS for an arbitrary free ephemeral port;
+;; socket-local-port reads back which one it actually picked, since that
+;; isn't known until after bind() has already happened.
+(define listener (tcp-listen 0))
+(define test-port (socket-local-port listener))
 
 (define server-thread
   (spawn (lambda ()
@@ -192,8 +197,8 @@
 ;;; A server-to-client frame with the mask bit set is a protocol
 ;;; violation the client must reject, not silently unmask and accept.
 
-(define mask-test-port 17995)
-(define mask-listener (tcp-listen mask-test-port))
+(define mask-listener (tcp-listen 0))
+(define mask-test-port (socket-local-port mask-listener))
 
 (define mask-server-thread
   (spawn (lambda ()


### PR DESCRIPTION
## Summary

- Fixes #110 at the root, not just its symptom. The `websocket`,
  `websocket_server`, and `ros` ctest suites each bound fixed, hardcoded
  TCP port numbers, inherently vulnerable to collision under `ctest -j`
  parallel execution against another process already bound to the same
  port. CI had observed this both as a fast, clean `tcp-listen: bind
  failed on port N` and as a much worse silent 28+ minute hang (no
  timeout anywhere in the accept path). A ctest-level `TIMEOUT` was
  previously added as an explicit stopgap, not a fix -- the issue itself
  named the real fix: bind port 0 for an OS-assigned ephemeral port, then
  read back which port that actually was.
- `tcp-listen` and SRFI-106's `make-server-socket` already accepted `0`
  for this. What was missing was a way to query the actual bound port
  afterward, since the OS picks it at `bind()` time. Added:
  - `socket-local-port` (`modules/network/srfi106.c`): a new primitive
    querying a socket's bound local port via `getsockname`. Not part of
    the SRFI-106 spec, so registered directly under `(curry network)`
    rather than `(srfi s106 sockets)`'s own export list, keeping that
    file's stated spec-faithfulness intact. Works on any socket handle
    sharing curry's `(socket . bytevector-packed-fd)` representation --
    `tcp-listen`, `udp-socket`, and every SRFI-106 socket constructor.
  - `ws-listener-port` (`lib/curry/modules/curry/websocket.scm`): the
    equivalent for a `ws-listen` listener.
- All three test files now bind `0` and derive their actual port via
  these new accessors immediately afterward, instead of a literal port
  number anywhere.

## Verification

Didn't just confirm the tests still pass -- reproduced the exact original
failure condition and confirmed it's actually closed: held all six of the
OLD hardcoded ports busy from an external process (the precise CI
collision scenario #110 described) and ran all three suites against that;
all pass cleanly, since none of them depend on any fixed port anymore.
Also ran the full parallel `ctest` suite (the actual failure-triggering
condition -- "under `ctest -j` full-suite contention") repeatedly, clean
every time.

The `TIMEOUT` on these three tests is kept as defense-in-depth (matching
the `actors` test's own identical treatment for an unrelated rare hang)
-- even with the port-contention root cause closed, an open-ended hang
from some other cause is still better caught as a fast, diagnosable
`TIMEOUT` than a silent CI stall.

## Review

Two independent review rounds (code + security) ran against this branch.
Both came back clean on the fix's own scope:

- Code review traced `getsockname`'s family handling (`AF_INET`/`AF_INET6`,
  confirmed both branches are genuinely reachable given `tcp-listen`'s
  always-`AF_INET6` dual-stack sockets vs. SRFI-106's `AF_UNSPEC`-default
  `make-server-socket`), confirmed the shared socket-handle representation
  claim by tracing `network_internal.h`, verified correct ordering at all
  6 call sites, confirmed no hardcoded ports remain, and independently
  reproduced the port-contention-immunity result described above.
- Security review probed `socket-local-port` as new FFI-adjacent surface:
  invalid/closed/reused fds, AF_UNIX handling (curry never creates such
  sockets; the function's family-driven branch would reject one cleanly
  regardless), a port-object-over-non-socket-fd case, and confirmed every
  edge case terminates in a clean `curry_error`, never a crash. It also
  surfaced a genuine, **pre-existing** memory-safety bug in
  `net_val_to_sock` (an unrelated, unchanged helper this new primitive
  happens to call through) -- filed separately as #158 rather than folded
  in here, since fixing it in this PR would only cover the one new call
  site, not the five pre-existing ones sharing the same defect.

## Test plan

- [x] `ctest --test-dir build` -- 117/117 suites pass (fresh
      `--clear-cache` run), verified across multiple full-parallel runs
- [x] All three affected test files run standalone multiple times, clean
- [x] Reproduced the original CI collision scenario directly (all 6 old
      hardcoded ports held busy externally) and confirmed it no longer
      affects any of the three suites
- [x] Two independent review rounds (code + security), including the
      security review's own adversarial probing of the new C primitive
      as untrusted-input-adjacent surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
