### PR TITLE
fix(network): reject malformed raw socket handles across all raw-handle primitives (#158)

### DIFF
--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -131,7 +131,7 @@ static curry_val fn_tcp_listen(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_tcp_accept(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    sock_t server = val_to_sock(av[0]);
+    sock_t server = net_checked_val_to_sock(av[0], "tcp-accept");
     struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
     sock_t client = accept((int)server, (struct sockaddr *)&addr, &addrlen);
     if (client == SOCK_INVALID) curry_error("tcp-accept: accept failed");
@@ -156,7 +156,7 @@ static curry_val fn_tcp_accept(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_tcp_close(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    sock_close(val_to_sock(av[0]));
+    sock_close(net_checked_val_to_sock(av[0], "tcp-close"));
     return curry_void();
 }
 
@@ -174,7 +174,7 @@ static curry_val fn_udp_socket(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_udp_bind(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    sock_t fd = val_to_sock(av[0]);
+    sock_t fd = net_checked_val_to_sock(av[0], "udp-bind");
     int port = (int)curry_fixnum(av[1]);
     struct sockaddr_in6 addr = {0};
     addr.sin6_family = AF_INET6;
@@ -187,7 +187,7 @@ static curry_val fn_udp_bind(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_udp_send(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    sock_t fd = val_to_sock(av[0]);
+    sock_t fd = net_checked_val_to_sock(av[0], "udp-send");
     uint32_t dlen = curry_bytevector_length(av[1]);
     uint8_t *data = malloc(dlen > 0 ? dlen : 1);
     if (!data) curry_error("udp-send: out of memory");
@@ -211,7 +211,7 @@ static curry_val fn_udp_send(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_udp_recv(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    sock_t fd = val_to_sock(av[0]);
+    sock_t fd = net_checked_val_to_sock(av[0], "udp-recv");
     int maxbytes = (int)curry_fixnum(av[1]);
     if (maxbytes <= 0) curry_error("udp-recv: maxbytes must be positive");
     uint8_t *buf = malloc((size_t)maxbytes);

--- a/modules/network/network_internal.h
+++ b/modules/network/network_internal.h
@@ -49,9 +49,28 @@ static inline sock_t net_val_to_sock(curry_val v) {
     return fd;
 }
 
+/* Issue #158: a curry script can construct ANY pair shaped like a raw
+ * socket handle -- e.g. (cons 'socket 42) or (cons 'socket (make-bytevector 0)) --
+ * since this check previously only looked at the car. net_val_to_sock
+ * unconditionally reads sizeof(sock_t) bytes from the cdr with no bounds
+ * check of its own (curry_bytevector_ref does no bounds check either), so
+ * a too-short bytevector was a genuine out-of-bounds heap read whose
+ * garbage result became an fd fed straight into a real syscall. A cdr
+ * that isn't a bytevector at all was worse: curry_bytevector_length/
+ * curry_bytevector_ref assume their argument already IS one (as_bytes
+ * does an unchecked cast), so misinterpreting an arbitrary heap object's
+ * header as a Bytevector's is its own type-confusion bug, not just an
+ * out-of-bounds length read. Now verifies both: the cdr must actually be
+ * a bytevector, and it must be EXACTLY sizeof(sock_t) bytes -- not just
+ * "at least", since a too-long bytevector silently accepted here would
+ * only ever have its first sizeof(sock_t) bytes read anyway, so exact
+ * match is the only value that unambiguously round-trips through
+ * net_sock_to_val's own construction. */
 static inline bool net_is_raw_socket_handle(curry_val v) {
-    return curry_is_pair(v) && curry_is_symbol(curry_car(v)) &&
-           strcmp(curry_symbol(curry_car(v)), "socket") == 0;
+    if (!curry_is_pair(v) || !curry_is_symbol(curry_car(v))) return false;
+    if (strcmp(curry_symbol(curry_car(v)), "socket") != 0) return false;
+    curry_val bv = curry_cdr(v);
+    return curry_is_bytevector(bv) && curry_bytevector_length(bv) == sizeof(sock_t);
 }
 
 /* Accepts either a raw socket handle (tcp-listen's/udp-socket's/SRFI-106

--- a/modules/network/network_internal.h
+++ b/modules/network/network_internal.h
@@ -84,4 +84,25 @@ static inline int net_extract_fd(curry_val v, const char *who) {
     return fd;
 }
 
+/* Issue #158 follow-up (found by independent code review of the fix
+ * above): net_val_to_sock itself is still unconditionally called
+ * directly -- bypassing net_is_raw_socket_handle's validation entirely
+ * -- by every network.c primitive that only ever accepts a raw handle,
+ * never a port (tcp-accept, tcp-close, udp-bind, udp-send, udp-recv):
+ * they call the raw #define val_to_sock (== net_val_to_sock) on av[0]
+ * with no check at all, reachable directly from Scheme since these are
+ * ordinary user-callable builtins. Reproduced as an actual SIGSEGV, not
+ * just a benign clean error, for a malformed handle like
+ * (cons 'socket 42) passed to tcp-close/udp-bind. Those primitives
+ * can't use net_extract_fd (which also silently accepts a port, wrong
+ * for functions that make no sense on anything but a raw handle -- see
+ * srfi106.c's fn_socket_close, which already gets this right with its
+ * own inline net_is_raw_socket_handle check for the identical reason).
+ * This is that same check, factored out so five call sites don't each
+ * duplicate it. */
+static inline sock_t net_checked_val_to_sock(curry_val v, const char *who) {
+    if (!net_is_raw_socket_handle(v)) curry_error("%s: not a socket handle", who);
+    return net_val_to_sock(v);
+}
+
 #endif /* CURRY_NETWORK_INTERNAL_H */

--- a/tests/network_tests.scm
+++ b/tests/network_tests.scm
@@ -192,6 +192,47 @@
 (check "udp-send from unbound socket" (utf8->string (car received2)) "world")
 
 ;;; ════════════════════════════════════════════════════════════
+;;; Malformed raw socket handle rejection (issue #158)
+;;; ════════════════════════════════════════════════════════════
+;;;
+;;; net_val_to_sock (network_internal.h) unconditionally read
+;;; sizeof(sock_t) bytes from a raw socket handle's bytevector with no
+;;; length check of its own, and net_is_raw_socket_handle never checked
+;;; the cdr was even a bytevector at all -- a curry script constructing
+;;; a pair merely SHAPED like a raw socket handle (car the symbol
+;;; 'socket) could trigger an out-of-bounds heap read (too-short/empty
+;;; bytevector) or a type-confused read (a non-bytevector cdr entirely),
+;;; whose garbage result then fed straight into a real syscall as an fd.
+;;; Every one of these must now be rejected cleanly at the type-check
+;;; level (net_is_raw_socket_handle), before ever reaching
+;;; net_val_to_sock, rather than crashing, reading adjacent heap memory,
+;;; or silently proceeding with a garbage fd.
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+(check "socket-local-port rejects a too-short bytevector cdr (was an OOB heap read)"
+  (raises? (lambda () (socket-local-port (cons 'socket (make-bytevector 1 5))))) #t)
+(check "socket-local-port rejects an empty bytevector cdr (was an OOB heap read)"
+  (raises? (lambda () (socket-local-port (cons 'socket (make-bytevector 0))))) #t)
+(check "socket-local-port rejects a non-bytevector cdr (was a type-confused read)"
+  (raises? (lambda () (socket-local-port (cons 'socket 42)))) #t)
+(check "socket-local-port rejects a too-long bytevector cdr"
+  (raises? (lambda () (socket-local-port (cons 'socket (make-bytevector 16 0))))) #t)
+;; A correctly-sized bytevector holding a garbage fd value is NOT a
+;; malformed-handle rejection -- it passes the shape/length check (as it
+;; must, since a real socket handle has exactly this shape) and instead
+;; fails later at the actual syscall (getsockname: Bad file descriptor),
+;; a different and already-correct error path this fix doesn't change.
+(check "socket-local-port on a correctly-sized garbage fd still raises (via the syscall, not the shape check)"
+  (raises? (lambda () (socket-local-port (cons 'socket (make-bytevector 4 255))))) #t)
+;; A genuine socket handle (from tcp-listen) must still work normally --
+;; the stricter check must not reject legitimate handles.
+(let* ((l (tcp-listen 0)))
+  (check "socket-local-port still works on a genuine tcp-listen handle"
+    (> (socket-local-port l) 0) #t)
+  (tcp-close l))
+
+;;; ════════════════════════════════════════════════════════════
 ;;; Summary
 ;;; ════════════════════════════════════════════════════════════
 

--- a/tests/network_tests.scm
+++ b/tests/network_tests.scm
@@ -232,6 +232,34 @@
     (> (socket-local-port l) 0) #t)
   (tcp-close l))
 
+;;; The above only covered socket-local-port (an SRFI-106 primitive
+;;; already routed through net_extract_fd). Independent code review
+;;; found the fix was INCOMPLETE: network.c's tcp-accept, tcp-close,
+;;; udp-bind, udp-send, and udp-recv each called net_val_to_sock
+;;; directly (via the raw #define val_to_sock alias) with NO check at
+;;; all, entirely bypassing net_is_raw_socket_handle -- reproduced as an
+;;; actual SIGSEGV (not just a clean error) for tcp-close/udp-bind on a
+;;; malformed handle. Fixed by routing all five through a new shared
+;;; net_checked_val_to_sock helper (network_internal.h) instead of the
+;;; raw, unchecked val_to_sock/net_val_to_sock. Every one of these must
+;;; now reject a malformed handle cleanly too, not just crash-free but
+;;; via guard-catchable error, same as socket-local-port above.
+(check "tcp-accept rejects a non-bytevector cdr (was an unchecked type-confused read)"
+  (raises? (lambda () (tcp-accept (cons 'socket "x")))) #t)
+(check "tcp-close rejects a non-bytevector cdr (was a reproducible SIGSEGV)"
+  (raises? (lambda () (tcp-close (cons 'socket 42)))) #t)
+(check "udp-bind rejects a non-bytevector cdr (was a reproducible SIGSEGV)"
+  (raises? (lambda () (udp-bind (cons 'socket 42) 0))) #t)
+(check "udp-send rejects an empty bytevector cdr (was an unchecked OOB read feeding sendto)"
+  (raises? (lambda () (udp-send (cons 'socket (make-bytevector 0)) (make-bytevector 1) "127.0.0.1" 9)))
+  #t)
+(check "udp-recv rejects an empty bytevector cdr (was an unchecked OOB read feeding recvfrom)"
+  (raises? (lambda () (udp-recv (cons 'socket (make-bytevector 0)) 10))) #t)
+;; Genuine handles must still work normally on all five -- confirmed
+;; implicitly by every other test in this file (tcp-accept/tcp-close via
+;; § 1/§ 2, udp-bind/udp-send/udp-recv via § 4), all of which already ran
+;; successfully above using real tcp-listen/udp-socket handles.
+
 ;;; ════════════════════════════════════════════════════════════
 ;;; Summary
 ;;; ════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Fixes #158: `net_val_to_sock` (`modules/network/network_internal.h`)
  unconditionally read `sizeof(sock_t)` bytes from a raw socket handle's
  bytevector with no bounds check, and `net_is_raw_socket_handle` -- the
  gate deciding whether a value even reaches `net_val_to_sock` -- only
  checked that the value was a pair whose car was the symbol `socket`,
  never validating the cdr at all. A curry script could construct
  `(cons 'socket (make-bytevector 0))` (out-of-bounds heap read) or
  `(cons 'socket 42)` (type confusion -- `curry_bytevector_length`/`ref`
  assume their argument already IS a bytevector via an unchecked cast).
- Fixed `net_is_raw_socket_handle` to verify both the cdr is actually a
  bytevector and that it's exactly `sizeof(sock_t)` bytes.
- **A follow-up commit closes a real gap independent review found**: five
  primitives in `modules/network/network.c` (`tcp-accept`, `tcp-close`,
  `udp-bind`, `udp-send`, `udp-recv`) called `net_val_to_sock` directly via
  a raw `#define val_to_sock` alias, entirely bypassing the strengthened
  check -- reproduced as an actual SIGSEGV via `(tcp-close (cons 'socket 42))`.
  Fixed with a shared `net_checked_val_to_sock` helper routing all five
  through the same validation, deliberately not `net_extract_fd` (which
  also accepts ports, wrong for functions that only ever make sense on a
  raw handle -- matching `srfi106.c`'s pre-existing `fn_socket_close`).

## Review

Two full review rounds (code + security, each run twice -- once against
the initial fix, once against the completion fix) ran against this
branch:

- Round 1 found the network.c bypass (both reviewers independently
  reproduced the same SIGSEGV).
- Round 2 (after the completion fix) came back clean on both sides:
  code review exhaustively grepped for any remaining raw
  `val_to_sock`/`net_val_to_sock` reference and found none; security
  review ran a full adversarial matrix (16 primitives × ~12 malformed
  input shapes) under ASan/UBSan with zero crashes or sanitizer reports.
- Two genuinely separate, unrelated bugs were found and filed as
  follow-ups along the way, not folded into this PR: #160 (raw handles
  trust an arbitrary fd number, a design tradeoff needing its own
  decision) and #161 (the identical unchecked-cast bug class, but on
  `socket-send`/`udp-send`'s `data` argument -- confirmed exploitable,
  same root cause, different call sites, needs its own fix).

## Test plan

- [x] `ctest --test-dir build` -- 117/117 suites pass (fresh
      `--clear-cache` run), verified across multiple runs in both review
      rounds
- [x] Added regression coverage to `tests/network_tests.scm` for all six
      previously-vulnerable primitives (`socket-local-port` plus the five
      `network.c` ones), confirming clean rejection of malformed handles
      and that genuine handles still work normally
- [x] Both the original SIGSEGVs (`tcp-close`, `udp-bind` on a malformed
      handle) independently reproduced pre-fix and confirmed resolved
      post-fix by two separate reviewers
- [x] Full adversarial matrix under ASan/UBSan (security review round 2):
      16 primitives, ~12 malformed input shapes each, zero crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
