### PR TITLE
fix(http,graphql,storage): synchronize curl_global_init against concurrent actors (#156)

### DIFF
--- a/modules/graphql/graphql.c
+++ b/modules/graphql/graphql.c
@@ -33,6 +33,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <curl/curl.h>
+#include <pthread.h>
+
+/* Issue #156: curl_global_init is not safe to call concurrently from
+ * multiple threads (libcurl's own documentation). This call site had no
+ * guard at all -- called unconditionally on every graphql-client
+ * construction -- so two actors both constructing their first client
+ * concurrently raced on it directly. pthread_once guarantees the
+ * wrapped call runs exactly once, thread-safely, regardless of how many
+ * threads race to call it at the same time. Same pattern as
+ * modules/http/http.c's identical fix. */
+static pthread_once_t g_curl_init_once = PTHREAD_ONCE_INIT;
+static void curl_init_once_fn(void) { curl_global_init(CURL_GLOBAL_ALL); }
 
 /* ---- Response buffer ---- */
 
@@ -247,7 +259,7 @@ static curry_val fn_graphql_client(int ac, curry_val *av, void *ud) {
     (void)ud;
     GQLClient *c = calloc(1, sizeof(GQLClient));
     c->url = strdup(curry_string(av[0]));
-    curl_global_init(CURL_GLOBAL_ALL);
+    pthread_once(&g_curl_init_once, curl_init_once_fn);
 
     c->headers = NULL;
     /* Optional headers alist */

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -37,6 +37,19 @@
 #include <string.h>
 #include <stdlib.h>
 #include <curl/curl.h>
+#include <pthread.h>
+
+/* Issue #156: curl_global_init is documented by libcurl as NOT safe to
+ * call concurrently from multiple threads. Curry actors are real OS
+ * threads with no global interpreter lock, so two actors both making
+ * their first http-request concurrently used to race on this module's
+ * own lazy "static int curl_inited" check below -- an unsynchronized
+ * read-then-write, the same class of bug as an unguarded double-checked
+ * init anywhere else. pthread_once guarantees the wrapped call runs
+ * exactly once, thread-safely, regardless of how many threads race to
+ * call it at the same time. */
+static pthread_once_t g_curl_init_once = PTHREAD_ONCE_INIT;
+static void curl_init_once_fn(void) { curl_global_init(CURL_GLOBAL_ALL); }
 
 typedef struct { char *data; size_t len; size_t cap; } Buf;
 
@@ -178,8 +191,7 @@ static const char *resolve_body(int ac, curry_val *av, int idx,
 static CURLcode do_request(const char *method, const char *url, curry_val hdrs_v,
                             const char *body, size_t body_len,
                             Buf *resp, HdrList *hdrs, long *code_out) {
-    static int curl_inited = 0;
-    if (!curl_inited) { curl_global_init(CURL_GLOBAL_ALL); curl_inited = 1; }
+    pthread_once(&g_curl_init_once, curl_init_once_fn);
 
     CURL *curl = curl_easy_init();
     if (!curl) curry_error("http: failed to init curl");

--- a/modules/storage/storage.c
+++ b/modules/storage/storage.c
@@ -27,6 +27,22 @@
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <curl/curl.h>
+#include <pthread.h>
+
+/* Issue #156: curl_global_init is not safe to call concurrently from
+ * multiple threads (libcurl's own documentation). Both call sites below
+ * (fn_swift_client, fn_azure_client) had no guard at all -- called
+ * unconditionally on every client construction -- so two actors each
+ * constructing their first client (whether both Swift, both Azure, or
+ * one of each) concurrently raced on it directly. pthread_once
+ * guarantees the wrapped call runs exactly once, thread-safely,
+ * regardless of how many threads race to call it at the same time; one
+ * shared guard for both call sites in this file, since they're both
+ * calling into the same underlying libcurl global state. Same pattern
+ * as modules/http/http.c and modules/graphql/graphql.c's identical
+ * fixes. */
+static pthread_once_t g_curl_init_once = PTHREAD_ONCE_INIT;
+static void curl_init_once_fn(void) { curl_global_init(CURL_GLOBAL_ALL); }
 
 /* ---- Memory buffer for curl responses ---- */
 
@@ -88,7 +104,7 @@ static curry_val fn_swift_client(int ac, curry_val *av, void *ud) {
     cs->username  = strdup(curry_string(av[1]));
     cs->password  = strdup(curry_string(av[2]));
     cs->project   = strdup(curry_string(av[3]));
-    curl_global_init(CURL_GLOBAL_ALL);
+    pthread_once(&g_curl_init_once, curl_init_once_fn);
     return client_to_val(cs);
 }
 
@@ -266,7 +282,7 @@ static curry_val fn_azure_client(int ac, curry_val *av, void *ud) {
     cs->access_key  = strdup(curry_string(av[0]));  /* account name */
     cs->secret_key  = strdup(curry_string(av[1]));  /* account key (base64) */
     cs->region      = strdup("core.windows.net");
-    curl_global_init(CURL_GLOBAL_ALL);
+    pthread_once(&g_curl_init_once, curl_init_once_fn);
     return client_to_val(cs);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -245,6 +245,17 @@ if(BUILD_MODULE_CRYPTO AND TARGET curry_crypto AND BUILD_MODULE_HTTP AND TARGET 
     set_tests_properties(s3 PROPERTIES ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
+# Issue #156: curl_global_init (libcurl, not thread-safe to call
+# concurrently) was called unsynchronized from http.c/graphql.c/
+# storage.c. graphql-client/swift-client/azure-client all reach the
+# call directly in their constructor, no network access needed --
+# http-request's own race needs a real request and skips cleanly if
+# there's no network (see the test file's own header comment).
+if(BUILD_MODULE_HTTP AND TARGET curry_http AND BUILD_MODULE_GRAPHQL AND TARGET curry_graphql AND BUILD_MODULE_STORAGE AND TARGET curry_storage)
+    add_test(NAME curl_global_init_race COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/curl_global_init_race_tests.scm)
+    set_tests_properties(curl_global_init_race PROPERTIES ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
 # Pure-Scheme scientific I/O modules (fits/netcdf) plus the FFI-based hdf5
 # wrapper (requires BUILD_FFI=ON to compile; libhdf5 itself is a
 # runtime-only dlopen dependency, so hdf5_tests.scm skips cleanly if it's

--- a/tests/curl_global_init_race_tests.scm
+++ b/tests/curl_global_init_race_tests.scm
@@ -1,0 +1,100 @@
+;;; curl_global_init_race_tests.scm — issue #156 regression.
+;;;
+;;; modules/http/http.c, modules/graphql/graphql.c, and
+;;; modules/storage/storage.c each called curl_global_init with no
+;;; synchronization at all (http.c had a racy hand-rolled "static int
+;;; curl_inited" check; graphql.c/storage.c had no guard whatsoever,
+;;; calling it unconditionally on every client construction). libcurl's
+;;; own documentation states curl_global_init is NOT safe to call
+;;; concurrently from multiple threads. Curry actors are real OS threads
+;;; with no global interpreter lock, so two actors both constructing
+;;; their first client (http, GraphQL, Swift, or Azure) concurrently
+;;; raced on this directly. Fixed with a pthread_once_t guard per module
+;;; (shared between fn_swift_client/fn_azure_client in storage.c, since
+;;; they call into the same underlying libcurl global state).
+;;;
+;;; graphql-client/swift-client/azure-client all call curl_global_init
+;;; directly in their constructor with no network access needed to
+;;; reach that call -- so the race for those three is exercised by
+;;; concurrent CONSTRUCTION alone, no live network required. Only
+;;; http-request's race (inside do_request, called per-request, not at
+;;; construction) needs an actual request -- skips cleanly if there's no
+;;; network access, matching this suite's own established convention
+;;; (see network_tests.scm's TLS section).
+
+(import (scheme base) (curry sync))
+(import (curry http))
+(import (curry graphql))
+(import (curry storage))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (all-done? actors)
+  (or (null? actors)
+      (and (not (actor-alive? (car actors))) (all-done? (cdr actors)))))
+
+(define (run-concurrently thunks)
+  (let ((actors (map spawn thunks)))
+    (let loop () (if (all-done? actors) 'done (loop)))))
+
+;;; ════════════════════════════════════════════════════════════
+;;; graphql-client / swift-client / azure-client: concurrent first
+;;; construction races curl_global_init directly, no network needed.
+;;; ════════════════════════════════════════════════════════════
+
+(run-concurrently
+  (list (lambda () (graphql-client "http://localhost:1/graphql"))
+        (lambda () (graphql-client "http://localhost:1/graphql"))
+        (lambda () (swift-client "http://localhost:1" "u" "p" "proj"))
+        (lambda () (swift-client "http://localhost:1" "u" "p" "proj"))
+        (lambda () (azure-client "account" "a2V5"))
+        (lambda () (azure-client "account" "a2V5"))
+        (lambda () (graphql-client "http://localhost:1/graphql"))
+        (lambda () (swift-client "http://localhost:1" "u" "p" "proj"))))
+(check "concurrent graphql-client/swift-client/azure-client construction completes without crash or hang"
+  #t #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; http-request: concurrent first request races curl_global_init
+;;; inside do_request. Skips cleanly if there's no network access.
+;;; ════════════════════════════════════════════════════════════
+
+(define (network-reachable?)
+  (guard (e (#t #f))
+    (let ((r (http-request "GET" "http://example.com")))
+      (and (pair? r) #t))))
+
+(if (not (network-reachable?))
+    (begin (display "SKIP: no network access — skipping http-request concurrency test") (newline))
+    (begin
+      (run-concurrently
+        (list (lambda () (http-request "GET" "http://example.com"))
+              (lambda () (http-request "GET" "http://example.com"))
+              (lambda () (http-request "GET" "http://example.com"))
+              (lambda () (http-request "GET" "http://example.com"))
+              (lambda () (http-request "GET" "http://example.com"))
+              (lambda () (http-request "GET" "http://example.com"))
+              (lambda () (http-request "GET" "http://example.com"))
+              (lambda () (http-request "GET" "http://example.com"))))
+      (check "concurrent first http-request calls across actors complete without crash or hang"
+        #t #t)))
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

- Fixes #156: `curl_global_init` (libcurl) is documented as NOT safe to
  call concurrently from multiple threads. Curry actors are real OS
  threads with no global interpreter lock, and three call sites were
  exposed:
  - `modules/http/http.c`'s `do_request` had a racy hand-rolled
    `static int curl_inited = 0; if (!curl_inited) { ...; curl_inited = 1; }`
    double-checked init.
  - `modules/graphql/graphql.c`'s `fn_graphql_client` called it
    unconditionally on every construction, no guard at all.
  - `modules/storage/storage.c`'s `fn_swift_client`/`fn_azure_client`
    (two functions, same file) likewise had no guard.
- Fixed with a `pthread_once_t` per module (one shared between
  `fn_swift_client`/`fn_azure_client` in storage.c, since both call into
  the same underlying libcurl global state). `pthread_once` guarantees
  the wrapped call runs exactly once, thread-safely, regardless of how
  many threads race to call it.
- Considered and rejected two alternatives (detailed in the commit
  message): moving the call into `curry_module_init` (would just move
  the race to concurrent first-import, per #149's own finding that
  import isn't guaranteed single-threaded either), and a single
  process-wide guard shared across all three modules (would require
  adding libcurl as a new mandatory core-executable dependency, since
  http/graphql/storage are three separate, independently-optional `.so`
  targets and only the core executable is genuinely shared across all of
  them -- real unwanted scope creep for this fix).

## Review

Two independent review rounds (code + security) ran against this
branch, both clean:

- Code review built the exact pre-fix commit under ThreadSanitizer and
  reproduced a genuine TSan-detected data race on `do_request`'s
  `curl_inited` (confirming the bug was real, not theoretical), then
  confirmed zero TSan warnings on the fixed commit across the same
  stress plus a deliberately-mixed cross-module stress.
- Security review confirmed `pthread_once`'s POSIX guarantee holds
  (a thread cannot return from `pthread_once` until the winning thread's
  init has fully completed, verified against the platform's own man
  page), confirmed `curl_easy_init()` is never called before
  `pthread_once` returns in any of the three files, and investigated the
  disclosed residual cross-module race: on this system, libcurl reports
  `CURL_VERSION_THREADSAFE` (its own internal locking around
  `curl_global_init`, added in curl ≥7.84 for exactly this class of bug),
  meaning the accepted residual gap is likely a non-issue in practice on
  modern libcurl builds, though not guaranteed on every platform.
- One genuinely separate, unrelated bug was found by the stress testing
  and filed as a follow-up, not folded into this PR: #162 (`vm.c`'s
  global-variable inline cache races when actors share a compiled
  closure).

## Test plan

- [x] `ctest --test-dir build` -- 118/118 suites pass (fresh
      `--clear-cache` run, new suite included), verified across multiple
      runs
- [x] Added a regression test (`tests/curl_global_init_race_tests.scm`,
      registered under the same module-availability guard `s3`'s test
      already uses): concurrent client construction across 8 actors for
      graphql/swift/azure (no network needed), plus concurrent
      `http-request` calls across 8 actors (skips cleanly without
      network access)
- [x] Independent TSan reproduction of the original race (pre-fix) and
      confirmation it's gone (post-fix)
- [x] Confirmed no other `curl_global_init` call site exists anywhere in
      the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMiu9qzTUm6gzKJA2zkrQC
