### PR TITLE
fix(network,crypto,storage): reject non-bytevector arguments across the same unchecked-cast bug class (#161)

### DIFF
--- a/modules/crypto/crypto.c
+++ b/modules/crypto/crypto.c
@@ -33,6 +33,11 @@ static const char b64_table[] =
 
 static curry_val fn_base64_encode(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
+    /* Issue #161: same unchecked as_bytes()-cast hazard #158/#161 already
+     * fixed for the network module's socket-send/udp-send -- every
+     * function in this file taking a bytevector argument straight from
+     * Scheme had the identical gap. */
+    if (!curry_is_bytevector(av[0])) curry_error("base64-encode: argument must be a bytevector");
     uint32_t inlen = curry_bytevector_length(av[0]);
     size_t outlen = 4 * ((inlen + 2) / 3) + 1;
     char *out = malloc(outlen);
@@ -194,6 +199,8 @@ static void md5_final(MD5Ctx *ctx, uint8_t *digest) {
 
 static curry_val fn_md5(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
+    /* Issue #161: same fix as fn_base64_encode above. */
+    if (!curry_is_bytevector(av[0])) curry_error("md5: argument must be a bytevector");
     MD5Ctx ctx; md5_init(&ctx);
     uint32_t n = curry_bytevector_length(av[0]);
     uint8_t *tmp = malloc(n);
@@ -216,6 +223,9 @@ static curry_val fn_md5_hex(int ac, curry_val *av, void *ud) {
 /* ---- SHA-1, SHA-256, HMAC via OpenSSL EVP ---- */
 
 static curry_val hash_via_evp(const EVP_MD *md, curry_val bv_in) {
+    /* Issue #161: same fix as fn_base64_encode above -- shared by
+     * fn_sha1/fn_sha256, both of which pass av[0] straight through. */
+    if (!curry_is_bytevector(bv_in)) curry_error("sha1/sha256: argument must be a bytevector");
     uint32_t inlen = curry_bytevector_length(bv_in);
     uint8_t *in = malloc(inlen);
     for (uint32_t i = 0; i < inlen; i++) in[i] = curry_bytevector_ref(bv_in, i);
@@ -252,6 +262,10 @@ static curry_val fn_sha256_hex(int ac,curry_val *av,void *ud){ (void)ud; return 
 
 static curry_val fn_hmac_sha256(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
+    /* Issue #161: same fix as fn_base64_encode above -- two arguments
+     * here, both need the check. */
+    if (!curry_is_bytevector(av[0])) curry_error("hmac-sha256: key must be a bytevector");
+    if (!curry_is_bytevector(av[1])) curry_error("hmac-sha256: data must be a bytevector");
     uint32_t klen = curry_bytevector_length(av[0]);
     uint32_t dlen = curry_bytevector_length(av[1]);
     uint8_t *key  = malloc(klen), *data = malloc(dlen);

--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -188,6 +188,11 @@ static curry_val fn_udp_bind(int ac, curry_val *av, void *ud) {
 static curry_val fn_udp_send(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
     sock_t fd = net_checked_val_to_sock(av[0], "udp-send");
+    /* Issue #161: same hazard as srfi106.c's identical fix in
+     * fn_socket_send -- the socket HANDLE is validated just above, but
+     * this data argument never was. Confirmed reproducible SIGSEGV via
+     * (udp-send some-socket 42 host port). */
+    if (!curry_is_bytevector(av[1])) curry_error("udp-send: data must be a bytevector");
     uint32_t dlen = curry_bytevector_length(av[1]);
     uint8_t *data = malloc(dlen > 0 ? dlen : 1);
     if (!data) curry_error("udp-send: out of memory");

--- a/modules/network/srfi106.c
+++ b/modules/network/srfi106.c
@@ -213,6 +213,13 @@ static curry_val fn_socket_local_port(int ac, curry_val *av, void *ud) {
 static curry_val fn_socket_send(int ac, curry_val *av, void *ud) {
     (void)ud;
     int fd = net_extract_fd(av[0], "socket-send");
+    /* Issue #161: the socket HANDLE (av[0], just above) is validated via
+     * net_extract_fd, but this data argument never was -- curry_bytevector_
+     * length/data (src/api.c) do an unchecked as_bytes() cast assuming
+     * their argument already IS a bytevector, the identical hazard #158
+     * closed for the handle. Confirmed reproducible SIGSEGV via
+     * (socket-send some-socket 42). */
+    if (!curry_is_bytevector(av[1])) curry_error("socket-send: data must be a bytevector");
     uint32_t len = curry_bytevector_length(av[1]);
     const uint8_t *data = curry_bytevector_data(av[1]);
     int flags = ac > 2 ? (int)curry_fixnum(av[2]) : 0;

--- a/modules/storage/storage.c
+++ b/modules/storage/storage.c
@@ -167,6 +167,10 @@ static curry_val fn_swift_put(int ac, curry_val *av, void *ud) {
     const char *object    = curry_string(av[2]);
     const char *ct = (ac > 4 && !curry_is_bool(av[4])) ? curry_string(av[4]) : "application/octet-stream";
 
+    /* Issue #161: same unchecked as_bytes()-cast hazard fixed elsewhere
+     * (network module's socket-send/udp-send, crypto.c's hash/base64
+     * functions) -- this data argument was never validated either. */
+    if (!curry_is_bytevector(av[3])) curry_error("swift-put!: data must be a bytevector");
     size_t blen = curry_bytevector_length(av[3]);
     char *body = malloc(blen);
     for (uint32_t i = 0; i < (uint32_t)blen; i++) body[i] = (char)curry_bytevector_ref(av[3], i);
@@ -366,6 +370,8 @@ static curry_val fn_azure_put(int ac, curry_val *av, void *ud) {
     (void)ud;
     ClientState *cs = val_to_client(av[0]);
     const char *ct = (ac > 4 && !curry_is_bool(av[4])) ? curry_string(av[4]) : "application/octet-stream";
+    /* Issue #161: same fix as fn_swift_put above. */
+    if (!curry_is_bytevector(av[3])) curry_error("azure-put!: data must be a bytevector");
     size_t blen = curry_bytevector_length(av[3]);
     char *body = malloc(blen);
     for (uint32_t i = 0; i < (uint32_t)blen; i++) body[i]=(char)curry_bytevector_ref(av[3],i);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,6 +235,13 @@ if(BUILD_MODULE_PIPER AND TARGET curry_piper)
     set_tests_properties(piper PROPERTIES ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
+# No dedicated (curry crypto) suite existed before issue #161's fix --
+# only akkadian_tests.scm's Akkadian-alias checks exercised it, and only
+# incidentally.
+if(BUILD_MODULE_CRYPTO AND TARGET curry_crypto)
+    add_test(NAME crypto COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/crypto_tests.scm)
+endif()
+
 # (curry s3) imports (curry crypto) for HMAC-SHA256/SHA-256 and
 # (curry http) for the actual requests -- both needed to even import,
 # regardless of whether a live S3-compatible endpoint is reachable

--- a/tests/akkadian_tests.scm
+++ b/tests/akkadian_tests.scm
@@ -943,12 +943,25 @@
 (check "PR cunei: 𒌝𒋻𒌋 (base64-encode)" (𒌝𒋻𒌋 (string->utf8 "hi")) "aGk=")
 (check-true "PR translit: ṭuppu-turrum binding (base64-decode)" (procedure? ṭuppu-turrum))
 (check-true "PR cunei: 𒌝𒄀𒌋 binding (base64-decode)" (procedure? 𒌝𒄀𒌋))
-(check "PR translit: kunukku-maḫrûm-ṭuppam (md5-hex)" (kunukku-maḫrûm-ṭuppam "hi") (md5-hex "hi"))
-(check "PR cunei: 𒁀𒃲𒁹𒌝 (md5-hex)" (𒁀𒃲𒁹𒌝 "hi") (md5-hex "hi"))
-(check "PR translit: kunukku-ištēn-ṭuppam (sha1-hex)" (kunukku-ištēn-ṭuppam "hi") (sha1-hex "hi"))
-(check "PR cunei: 𒁀𒃲𒀸𒌝 (sha1-hex)" (𒁀𒃲𒀸𒌝 "hi") (sha1-hex "hi"))
-(check "PR translit: kunukku-kabtum-ṭuppam (sha256-hex)" (kunukku-kabtum-ṭuppam "hi") (sha256-hex "hi"))
-(check "PR cunei: 𒁀𒃲𒆠𒌝 (sha256-hex)" (𒁀𒃲𒆠𒌝 "hi") (sha256-hex "hi"))
+;; md5-hex/sha1-hex/sha256-hex are documented as taking a bytevector
+;; (docs/reference/module-crypto.md), not a raw string -- these six
+;; checks passed a bare string before issue #161's fix added a proper
+;; curry_is_bytevector check to md5/sha1/sha256. That's not just a
+;; stricter-argument-type change: reinterpreting a String object's own
+;; header layout as if it were a Bytevector's silently computed a WRONG
+;; hash (confirmed: (md5-hex "hi") returned a bogus 33-hex-char result
+;; under the old unchecked code, not MD5("hi")'s real, correct
+;; 49f68a5c8493ec2c0bf489821c21fc3b) -- these checks only ever "passed"
+;; because both sides of each comparison shared the identical wrong
+;; interpretation, not because either side computed anything correct.
+;; Fixed to pass (string->utf8 "hi") on both sides, matching
+;; base64-encode's own already-correct usage just above.
+(check "PR translit: kunukku-maḫrûm-ṭuppam (md5-hex)" (kunukku-maḫrûm-ṭuppam (string->utf8 "hi")) (md5-hex (string->utf8 "hi")))
+(check "PR cunei: 𒁀𒃲𒁹𒌝 (md5-hex)" (𒁀𒃲𒁹𒌝 (string->utf8 "hi")) (md5-hex (string->utf8 "hi")))
+(check "PR translit: kunukku-ištēn-ṭuppam (sha1-hex)" (kunukku-ištēn-ṭuppam (string->utf8 "hi")) (sha1-hex (string->utf8 "hi")))
+(check "PR cunei: 𒁀𒃲𒀸𒌝 (sha1-hex)" (𒁀𒃲𒀸𒌝 (string->utf8 "hi")) (sha1-hex (string->utf8 "hi")))
+(check "PR translit: kunukku-kabtum-ṭuppam (sha256-hex)" (kunukku-kabtum-ṭuppam (string->utf8 "hi")) (sha256-hex (string->utf8 "hi")))
+(check "PR cunei: 𒁀𒃲𒆠𒌝 (sha256-hex)" (𒁀𒃲𒆠𒌝 (string->utf8 "hi")) (sha256-hex (string->utf8 "hi")))
 (check-true "PR translit: kunukku-kabti-pirišti binding (hmac-sha256)" (procedure? kunukku-kabti-pirišti))
 (check-true "PR cunei: 𒁀𒃲𒆠𒉡 binding (hmac-sha256)" (procedure? 𒁀𒃲𒆠𒉡))
 

--- a/tests/crypto_tests.scm
+++ b/tests/crypto_tests.scm
@@ -1,0 +1,79 @@
+;;; crypto_tests.scm — (curry crypto) basic correctness + issue #161
+;;; regression (unchecked bytevector-argument type confusion).
+;;;
+;;; No dedicated test file existed for this module before -- only
+;;; akkadian_tests.scm's Akkadian-alias checks exercised it at all, and
+;;; only incidentally. Added alongside the #161 fix since that fix is
+;;; specifically about these functions rejecting non-bytevector
+;;; arguments cleanly instead of crashing, which deserves its own
+;;; regression coverage independent of the alias tests.
+
+(import (scheme base) (curry crypto))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+;;; ── Basic correctness (known-answer tests) ──────────────────────────────
+
+(check "base64-encode known answer" (base64-encode (string->utf8 "hi")) "aGk=")
+(check "md5-hex known answer (MD5(\"hi\") per RFC test vectors)"
+  (md5-hex (string->utf8 "hi")) "49f68a5c8493ec2c0bf489821c21fc3b")
+(check "sha1-hex known answer"
+  (sha1-hex (string->utf8 "hi")) "c22b5f9178342609428d6f51b2c5af4c0bde6a42")
+(check "sha256-hex known answer"
+  (sha256-hex (string->utf8 "hi")) "8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4")
+(check "hmac-sha256 produces a 32-byte bytevector"
+  (bytevector-length (hmac-sha256 (string->utf8 "key") (string->utf8 "data"))) 32)
+
+;;; ── Issue #161: unchecked bytevector-argument type confusion ────────────
+;;;
+;;; base64-encode/md5/sha1/sha256 (via a shared hash_via_evp helper)/
+;;; hmac-sha256 all took their bytevector argument(s) straight from
+;;; Scheme with no curry_is_bytevector check -- curry_bytevector_length/
+;;; curry_bytevector_ref do an unchecked as_bytes() cast assuming their
+;;; argument already IS a bytevector, the identical hazard #158 closed
+;;; for socket handles. This was not merely a crash risk: passing a raw
+;;; STRING (rather than the documented bytevector) didn't error under
+;;; the old code, it silently computed a WRONG hash by misinterpreting
+;;; the String object's own header layout as a Bytevector's -- confirmed
+;;; (md5-hex "hi") returned a bogus result under the pre-fix code, not
+;;; MD5("hi")'s real value. Every one of these must now reject a
+;;; non-bytevector argument cleanly.
+(check "base64-encode rejects a non-bytevector argument (was silent wrong output)"
+  (raises? (lambda () (base64-encode 42))) #t)
+(check "base64-encode rejects a raw string (documented as bytevector-only)"
+  (raises? (lambda () (base64-encode "hi"))) #t)
+(check "md5 rejects a non-bytevector argument (was a reproducible SIGSEGV)"
+  (raises? (lambda () (md5 42))) #t)
+(check "md5-hex rejects a raw string (was silently wrong, not just uncaught)"
+  (raises? (lambda () (md5-hex "hi"))) #t)
+(check "sha1 rejects a non-bytevector argument"
+  (raises? (lambda () (sha1 42))) #t)
+(check "sha256 rejects a non-bytevector argument"
+  (raises? (lambda () (sha256 42))) #t)
+(check "hmac-sha256 rejects a non-bytevector key"
+  (raises? (lambda () (hmac-sha256 42 (string->utf8 "data")))) #t)
+(check "hmac-sha256 rejects a non-bytevector data argument"
+  (raises? (lambda () (hmac-sha256 (string->utf8 "key") 42))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/network_tests.scm
+++ b/tests/network_tests.scm
@@ -261,6 +261,25 @@
 ;; successfully above using real tcp-listen/udp-socket handles.
 
 ;;; ════════════════════════════════════════════════════════════
+;;; Issue #161 (second finding): socket-send/udp-send's DATA argument
+;;; (as opposed to the SOCKET HANDLE argument #158/above already
+;;; covers) was never checked either -- curry_bytevector_length/data do
+;;; the identical unchecked as_bytes() cast on whatever was passed,
+;;; reproduced as an actual SIGSEGV via (socket-send some-socket 42)/
+;;; (udp-send some-socket 42 host port). Fixed with a curry_is_bytevector
+;;; check in both fn_socket_send (srfi106.c) and fn_udp_send (network.c).
+;;; ════════════════════════════════════════════════════════════
+(check "udp-send rejects a non-bytevector data argument (was a reproducible SIGSEGV)"
+  (raises? (lambda () (udp-send (udp-socket) 42 "127.0.0.1" 9))) #t)
+(let* ((s1 (udp-socket)) (s2 (udp-socket)))
+  (udp-bind s2 19193)
+  (check "socket-send rejects a non-bytevector data argument (was a reproducible SIGSEGV)"
+    (raises? (lambda () (socket-send s1 42))) #t)
+  (tcp-close s1) (tcp-close s2))
+;; Genuine bytevector data must still work normally -- confirmed
+;; implicitly by udp-send's own successful use throughout § 4 above.
+
+;;; ════════════════════════════════════════════════════════════
 ;;; Summary
 ;;; ════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Closes #161.

`fn_socket_send` (`modules/network/srfi106.c`) and `fn_udp_send` (`modules/network/network.c`) took a `data` argument passed straight to `curry_bytevector_length`/`curry_bytevector_data` with no `curry_is_bytevector` check — those API functions (`src/api.c`) do an unchecked `as_bytes()` cast assuming the argument already IS a bytevector, the same hazard #158 closed for the socket *handle* argument. Confirmed reproducible SIGSEGV via `(socket-send some-socket 42)` / `(udp-send some-socket 42 host port)`.

A broader grep (as the issue itself recommended) found four more genuinely vulnerable call sites with the identical one-line fix:
- `modules/crypto/crypto.c`: `fn_base64_encode`, `fn_md5`, `hash_via_evp` (shared by sha1/sha256), `fn_hmac_sha256` (both args)
- `modules/storage/storage.c`: `fn_swift_put`/`fn_azure_put`'s `data` argument

`modules/rpi/rpi.c` and `modules/http/http.c`'s `resolve_body` were checked and already correct — not touched.

Fixing crypto.c surfaced that the old unchecked behavior wasn't just a crash risk: passing a raw string instead of a bytevector never raised an error, it silently computed a **wrong hash**, by misinterpreting a String's header layout as a Bytevector's. `(md5-hex "hi")` returned a bogus non-MD5 result under the old code. `tests/akkadian_tests.scm`'s own Akkadian-alias regression tests had been passing a raw string on *both* sides of each comparison for exactly this reason, so the bug never surfaced — fixed those six checks to use `(string->utf8 "hi")`, matching the `base64-encode` check right above them.

Added `tests/crypto_tests.scm` (no dedicated suite existed before) with known-answer values cross-checked against `shasum`/`openssl dgst`, plus regression coverage for all six fixed functions. Extended `tests/network_tests.scm` for the data-argument case.

## Review

Two independent fresh subagents reviewed this (code review + security review, no shared context with the implementing session, per this repo's CLAUDE.md policy):

- Both confirmed the six fixed sites are correctly placed, correctly worded, and clean under adversarial testing (fixnum/string/pair/vector/boolean/procedure against every fixed function — all raise cleanly, no crashes).
- Both independently rebuilt the parent commit and reproduced the "silently wrong hash" claim (`(md5-hex "hi")` → bogus value, confirmed against Python `hashlib`/`openssl dgst`/`shasum`).
- Both independently verified every known-answer value in the new `crypto_tests.scm`.
- **Both also found this bug class is bigger than this PR's scope**: an unchecked-handle variant (as opposed to unchecked-*data*) across most other C modules (redis, mqtt, git, graphql, sqlite, neo4j, posix, sync, vecdb, ldap — several confirmed via reproducible SIGSEGV, e.g. `(redis-close! (cons 'redis-conn 42))`), plus a **critical unchecked core builtin** (`bytevector-length` — no import needed, wild-pointer dereference from a bare fixnum), plus a **distinct root-cause bug** in `image.c` (a forged image vector causes a real out-of-bounds heap *write*, not just a read). None of these are touched by this PR — filed separately as #165, #166, #167 so they get proper standalone fixes rather than scope creep here.

## Test plan

- [x] `./build/curry --clear-cache tests/crypto_tests.scm` — 13/13 pass
- [x] `./build/curry --clear-cache tests/network_tests.scm` — 29/29 pass
- [x] `./build/curry --clear-cache tests/akkadian_tests.scm` — 1733/1733 pass
- [x] `ctest --test-dir build --output-on-failure` — 119/119 suites pass (fresh `--clear-cache` run)
- [x] Manual repro of all 6 original crash sites, confirmed fixed
- [x] Two independent review agents (code + security), findings addressed (in-scope: none needed further changes; out-of-scope: filed as #165/#166/#167)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
