### PR TITLE
fix(builtins): bytevector-length had no type check at all (#166)

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1557,7 +1557,11 @@ static val_t prim_make_bytes(int ac, val_t *av, void *ud) {
     memset(b->data,fill,n);
     return vptr(b);
 }
-static val_t prim_bytes_length(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vfix(as_bytes(av[0])->len);}
+static val_t prim_bytes_length(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_bytes(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "bytevector-length: not a bytevector");
+    return vfix(as_bytes(av[0])->len);
+}
 static val_t prim_bytes_u8_ref(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
     if (!vis_bytes(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "bytevector-u8-ref: not a bytevector");

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -961,6 +961,17 @@
 (check "bytevector-u8-ref"  (bytevector-u8-ref bv 2) 255)
 (check "bytevector-u8-ref 0" (bytevector-u8-ref bv 0) 0)
 (check "bytevector-length"  (bytevector-length bv) 4)
+;; Issue #166: bytevector-length had no type check at all -- as_bytes()
+;; casts the raw argument straight to a Bytevector* and dereferences ->len,
+;; so a fixnum/boolean argument's tagged bit pattern was dereferenced as a
+;; pointer (confirmed reproducible SIGSEGV pre-fix), not merely a wrong
+;; value like the string case below.
+(check "bytevector-length rejects a fixnum (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (bytevector-length 42)) 'raised)
+(check "bytevector-length rejects a boolean (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (bytevector-length #t)) 'raised)
+(check "bytevector-length rejects a string (was silently returning a wrong value)"
+       (guard (exn (#t 'raised)) (bytevector-length "hi")) 'raised)
 (check "bytevector?"  (bytevector? bv) #t)
 (check "bytevector? no" (bytevector? "str") #f)
 (check "bytevector-copy out-of-range raises instead of crashing"


### PR DESCRIPTION
## Summary

Closes #166.

`prim_bytes_length` (`src/builtins.c`) did `return vfix(as_bytes(av[0])->len);` with **zero type check** — unlike every sibling bytevector primitive (`bytevector-u8-ref`, `bytevector-copy`, `bytevector-append`, etc.), all of which check first. This is R7RS core, always bound in `GLOBAL_ENV`, reachable with no import needed.

Worse than the #158/#161 pattern of misinterpreting one heap object as another: since a fixnum/boolean/char argument is an *immediate* value (not a heap pointer), the raw tagged bit pattern gets dereferenced directly as a pointer. Confirmed reproducible SIGSEGV via `(bytevector-length 42)` / `(bytevector-length #t)`.

Fixed by adding the same `vis_bytes()` check + `scm_raise_code(EC_WRONG_TYPE_ARGUMENT, ...)` every sibling primitive already uses. Added regression coverage to `tests/r7rs_tests.scm`.

## Review

Two independent fresh subagents (code review + security review, per this repo's CLAUDE.md policy):

- Both rebuilt and adversarially tested `bytevector-length` against every value-tag category (fixnum, bignum, rational, flonum, booleans, char, `'()`, pair, vector, string, symbol, primitive, closure, port, hash-table) — all non-bytevector cases raise cleanly, real bytevectors are unaffected.
- Both confirmed `vis_bytes` is a sound, tag-checked test (not foolable).
- Both did a broader grep for the same "unchecked `as_TYPE()` cast" pattern across the codebase and found it recurs elsewhere — **filed separately, not in this PR's scope**:
  - #169 — `modules/qt6/qt6.cpp`: `make-gl-texture`/`gl-texture-update!`/`gfx-draw-image!` have the same unchecked-cast gap on their data arguments.
  - #170 — several more **core** builtins with zero type check: `string-length`, `error-object-message`/`-irritants`/`-code`, `close-port`/`close-input-port`/`close-output-port`, and the entire `hash-table-*` family (8 entry points) — all confirmed reproducible SIGSEGVs, same severity class as this issue.

## Test plan

- [x] `./build/curry --clear-cache tests/r7rs_tests.scm` — 469/469 pass
- [x] `ctest --test-dir build --output-on-failure` — 119/119 suites pass (fresh `--clear-cache` run)
- [x] Manual repro of the original crash, confirmed fixed
- [x] Two independent review agents (code + security) — both confirmed the fix is correct and complete for its scope; broader findings filed as #169/#170

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
