### PR TITLE
fix(builtins): add missing type checks to string-length, error-object-*, close-port, and hash-table-* (#170)

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -896,6 +896,7 @@ static void str_invalidate_cache(String *s);
 
 static val_t prim_string_length(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
+    if (!vis_string(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "string-length: not a string");
     /* UTF-8 character count (not byte length) — cached, see str_nchars. */
     String *s = as_str(av[0]);
     return vfix(str_nchars(s));
@@ -2096,7 +2097,12 @@ static val_t prim_file_exists_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud;
     return vbool(access(str_data(as_str(av[0])), F_OK) == 0);
 }
 
-static val_t prim_close_port(int ac, val_t *av, void *ud) {(void)ac;(void)ud; port_close(av[0]); return V_VOID;}
+static val_t prim_close_port(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_port(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "close-port: not a port");
+    port_close(av[0]);
+    return V_VOID;
+}
 static val_t prim_input_port_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(vis_port(av[0])&&port_is_input(av[0]));}
 static val_t prim_input_port_open_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(vis_port(av[0])&&port_is_input(av[0])&&!(as_port(av[0])->flags&PORT_CLOSED));}
 static val_t prim_output_port_open_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(vis_port(av[0])&&port_is_output(av[0])&&!(as_port(av[0])->flags&PORT_CLOSED));}
@@ -2390,10 +2396,22 @@ static val_t prim_eval(int ac, val_t *av, void *ud) {
     return eval(av[0], env);
 }
 static val_t prim_interaction_env(int ac, val_t *av, void *ud) { (void)ac;(void)av;(void)ud; return GLOBAL_ENV; }
-static val_t prim_error_message(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return as_err(av[0])->message;}
+static val_t prim_error_message(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_error(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "error-object-message: not an error object");
+    return as_err(av[0])->message;
+}
 static val_t prim_error_object_p(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(vis_error(av[0]));}
-static val_t prim_error_irritants(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return as_err(av[0])->irritants;}
-static val_t prim_error_code(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return as_err(av[0])->code;}
+static val_t prim_error_irritants(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_error(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "error-object-irritants: not an error object");
+    return as_err(av[0])->irritants;
+}
+static val_t prim_error_code(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_error(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "error-object-code: not an error object");
+    return as_err(av[0])->code;
+}
 static val_t prim_raise(int ac, val_t *av, void *ud) {(void)ac;(void)ud; scm_raise_val(av[0]);}
 static val_t prim_raise_continuable(int ac, val_t *av, void *ud) {(void)ac;(void)ud; scm_raise_val(av[0]);}
 static val_t prim_error_to_string(int ac, val_t *av, void *ud) {
@@ -2656,14 +2674,46 @@ static val_t prim_set_find(int ac, val_t *av, void *ud) {
 
 /* ---- Hash tables ---- */
 static val_t prim_make_hash(int ac, val_t *av, void *ud) {(void)ud; int cmp=ac>0?(int)vunfix(av[0]):SET_CMP_EQUAL; return hash_make(cmp);}
-static val_t prim_hash_set(int ac, val_t *av, void *ud) {(void)ac;(void)ud; hash_set(av[0],av[1],av[2]); return V_VOID;}
-static val_t prim_hash_ref(int ac, val_t *av, void *ud) {(void)ud; val_t def=ac>2?av[2]:V_FALSE; return hash_ref(av[0],av[1],def);}
-static val_t prim_hash_del(int ac, val_t *av, void *ud) {(void)ac;(void)ud; hash_delete(av[0],av[1]); return V_VOID;}
-static val_t prim_hash_has(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vbool(hash_has(av[0],av[1]));}
-static val_t prim_hash_keys(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return hash_keys(av[0]);}
-static val_t prim_hash_vals(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return hash_values(av[0]);}
-static val_t prim_hash_to_alist(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return hash_to_alist(av[0]);}
-static val_t prim_hash_size(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return vfix(hash_size(av[0]));}
+static val_t prim_hash_set(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_hash(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "hash-table-set!: not a hash table");
+    hash_set(av[0],av[1],av[2]); return V_VOID;
+}
+static val_t prim_hash_ref(int ac, val_t *av, void *ud) {
+    (void)ud;
+    if (!vis_hash(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "hash-table-ref: not a hash table");
+    val_t def=ac>2?av[2]:V_FALSE; return hash_ref(av[0],av[1],def);
+}
+static val_t prim_hash_del(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_hash(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "hash-table-delete!: not a hash table");
+    hash_delete(av[0],av[1]); return V_VOID;
+}
+static val_t prim_hash_has(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_hash(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "hash-table-exists?: not a hash table");
+    return vbool(hash_has(av[0],av[1]));
+}
+static val_t prim_hash_keys(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_hash(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "hash-table-keys: not a hash table");
+    return hash_keys(av[0]);
+}
+static val_t prim_hash_vals(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_hash(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "hash-table-values: not a hash table");
+    return hash_values(av[0]);
+}
+static val_t prim_hash_to_alist(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_hash(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "hash-table->alist: not a hash table");
+    return hash_to_alist(av[0]);
+}
+static val_t prim_hash_size(int ac, val_t *av, void *ud) {
+    (void)ac;(void)ud;
+    if (!vis_hash(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "hash-table-size: not a hash table");
+    return vfix(hash_size(av[0]));
+}
 
 /* ---- Actors ---- */
 static val_t prim_spawn(int ac, val_t *av, void *ud) {

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -74,6 +74,12 @@
 
 ;;; Strings
 (check "string-length" (string-length "hello") 5)
+;; Issue #170: string-length had no type check at all -- as_str() cast its
+;; argument straight to a String* with no vis_string() guard, unlike every
+;; other string primitive (confirmed reproducible SIGSEGV via
+;; (string-length 42) pre-fix).
+(check "string-length rejects a fixnum (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-length 42)) 'raised)
 (check "string-ref" (string-ref "hello" 1) #\e)
 (check "string-ref multibyte" (string-ref "héllo" 1) #\é)
 (check "string-ref negative index raises"
@@ -1060,6 +1066,14 @@
   "foobar")
 (check "input-port?"  (input-port?  (open-input-string "")) #t)
 (check "output-port?" (output-port? (open-output-string)) #t)
+;; Issue #170: close-port/close-input-port/close-output-port had no
+;; vis_port() check at either the builtin or port_close() layer -- as_port()
+;; cast straight to a Port*, confirmed reproducible SIGSEGV via
+;; (close-port 42) pre-fix.
+(check "close-port rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (close-port 42)) 'raised)
+(check "close-port still works on a real port"
+       (begin (close-port (open-output-string)) 'ok) 'ok)
 
 ;;; Error objects
 (define captured-error
@@ -1068,6 +1082,15 @@
 (check "error-message"         (error-message captured-error) "bad input")
 (check "error-object-irritants" (error-object-irritants captured-error) '(42 "extra"))
 (check "error-object? non-err" (error-object? 42) #f)
+;; Issue #170: error-object-message/-irritants/-code had no vis_error()
+;; check -- as_err() cast straight to an ErrorObj*, confirmed reproducible
+;; SIGSEGV via (error-object-message 42) pre-fix.
+(check "error-object-message rejects a non-error argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (error-object-message 42)) 'raised)
+(check "error-object-irritants rejects a non-error argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (error-object-irritants 42)) 'raised)
+(check "error-object-code rejects a non-error argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (error-object-code 42)) 'raised)
 (check "raise-continuable"
   (with-exception-handler
     (lambda (e) (+ e 1))
@@ -1103,6 +1126,26 @@
 (check "hash-table-delete!" (hash-table-exists? h "x") #f)
 (check "hash-table-keys"   (length (hash-table-keys h)) 1)
 (check "hash-table-values" (hash-table-values h) '(20))
+;; Issue #170: the entire hash-table-* family (set!/ref/delete!/exists?/
+;; keys/values/->alist/size) had NO type check whatsoever on their table
+;; argument -- as_hash() cast straight to a Hashtable*, confirmed
+;; reproducible SIGSEGV via e.g. (hash-table-size 42) pre-fix.
+(check "hash-table-set! rejects a non-hash-table argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (hash-table-set! 42 'a 'b)) 'raised)
+(check "hash-table-ref rejects a non-hash-table argument"
+       (guard (exn (#t 'raised)) (hash-table-ref 42 'a)) 'raised)
+(check "hash-table-delete! rejects a non-hash-table argument"
+       (guard (exn (#t 'raised)) (hash-table-delete! 42 'a)) 'raised)
+(check "hash-table-exists? rejects a non-hash-table argument"
+       (guard (exn (#t 'raised)) (hash-table-exists? 42 'a)) 'raised)
+(check "hash-table-keys rejects a non-hash-table argument"
+       (guard (exn (#t 'raised)) (hash-table-keys 42)) 'raised)
+(check "hash-table-values rejects a non-hash-table argument"
+       (guard (exn (#t 'raised)) (hash-table-values 42)) 'raised)
+(check "hash-table->alist rejects a non-hash-table argument"
+       (guard (exn (#t 'raised)) (hash-table->alist 42)) 'raised)
+(check "hash-table-size rejects a non-hash-table argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (hash-table-size 42)) 'raised)
 
 ;;; Force / promises
 (define p-lazy (make-promise (+ 1 2)))


### PR DESCRIPTION
## Summary

Closes #170.

Found during independent security review of #166's fix (`bytevector-length` had zero type check). Reviewing every `prim_*` in `src/builtins.c` for the same shape of bug — an `as_TYPE(av[i])` cast with no preceding `vis_TYPE(av[i])` check — found four more groups, all reachable from plain, no-import-needed R7RS-core code, all confirmed reproducible SIGSEGV pre-fix:

- `string-length` — `as_str()` with no `vis_string()` check.
- `error-object-message`/`error-message`, `error-object-irritants`, `error-object-code` — `as_err()` with no `vis_error()` check.
- `close-port`/`close-input-port`/`close-output-port` — `port_close()` called unconditionally at both the builtin and `port.c` layer.
- The entire `hash-table-*` family (`-set!`/`-ref`/`-delete!`/`-exists?`/`-keys`/`-values`/`->alist`/`-size`) — 8 always-bound core entry points, none type-checked at all.

All fixed with the same `vis_TYPE()` + `scm_raise_code(EC_WRONG_TYPE_ARGUMENT, ...)` idiom every other checked primitive already uses. No behavior change on the correct-argument path. Regression tests added to `tests/r7rs_tests.scm` alongside each function's existing section.

## Review

Two independent fresh subagents (code review + security review, per this repo's CLAUDE.md policy):

- Both rebuilt and confirmed all 15 originally-reported repros now raise cleanly, correct-argument paths are unaffected, and adversarial testing across many more argument types (pairs, vectors, booleans, symbols, chars, closures, ports, ...) found nothing that still slips through.
- Both confirmed double-close on an already-closed port doesn't crash, and `error-object-*` correctly rejects a `raise`d non-condition payload.
- Both did a further sweep for the same pattern and each found more, **filed separately, not in this PR's scope**:
  - #172 (code review) — `string-contains` has the identical missing-check bug, right next to the correctly-guarded `substring`/`write-string` in the same file.
  - #173 (security review) — a much larger sweep found the string comparison/conversion family (`string->symbol`, `string=?`/`<?`/etc., `string-append`, `string-for-each`), nearly the entire port I/O primitive layer (`read-char`, `write-char`, `display`, `read-line`, etc., plus `port.c`'s own internals), and the entire native `set-*` family (hash-table's exact sibling data structure) all have the same zero-type-check pattern.

## Test plan

- [x] `./build/curry --clear-cache tests/r7rs_tests.scm` — 483/483 pass
- [x] `ctest --test-dir build --output-on-failure` — 119/119 suites pass (fresh `--clear-cache` run)
- [x] Manual repro of all 15 original crash sites, confirmed fixed
- [x] Two independent review agents (code + security) — both confirmed the fix is correct and complete for its scope; broader findings filed as #172/#173

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
