### PR TITLE
fix(builtins): string-contains had no type check on either argument (#172)

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1180,6 +1180,8 @@ static val_t prim_substring(int ac, val_t *av, void *ud) {
 }
 static val_t prim_string_contains(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
+    if (!vis_string(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "string-contains: not a string");
+    if (!vis_string(av[1])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "string-contains: not a string");
     const char *haystack=str_data(as_str(av[0])), *needle=str_data(as_str(av[1]));
     const char *p = strstr(haystack, needle);
     return p ? vfix((intptr_t)(p - haystack)) : V_FALSE;

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -921,6 +921,13 @@
 (check "string<?"       (string<? "abc" "abd") #t)
 (check "string-contains" (string-contains "hello world" "world") 6)
 (check "string-contains miss" (string-contains "hello" "xyz") #f)
+;; Issue #172: string-contains had no vis_string() check on either
+;; argument -- as_str() cast straight to a String*, confirmed reproducible
+;; SIGSEGV via (string-contains 42 "x") / (string-contains "x" 42) pre-fix.
+(check "string-contains rejects a non-string haystack (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-contains 42 "x")) 'raised)
+(check "string-contains rejects a non-string needle (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-contains "x" 42)) 'raised)
 (check "make-string"    (make-string 3 #\x) "xxx")
 (check "make-string negative size raises instead of crashing"
        (guard (exn (#t 'raised)) (make-string -1)) 'raised)


### PR DESCRIPTION
## Summary

Closes #172.

Found during independent code review of #170's fix. `prim_string_contains` cast both arguments straight to `String*` via `as_str()` with no `vis_string()` guard on either, right next to `prim_substring`/`prim_write_string` in the same file which both check correctly. Same bug class as #166/#170. Confirmed reproducible SIGSEGV via `(string-contains 42 "x")` and `(string-contains "x" 42)`.

Fixed with the same `vis_string()` + `scm_raise_code(EC_WRONG_TYPE_ARGUMENT, ...)` idiom used throughout the file. Regression tests added to `tests/r7rs_tests.scm`.

## Review

Two independent fresh subagents (code review + security review):

- Both confirmed the fix is correctly placed, idiomatically consistent, and adversarially clean (tested 10 wrong-type categories against both argument positions — 20 combinations, all raise cleanly).
- Code review did a line-by-line pass of `src/builtins_curry.c` and `src/numtheory.c` (not just re-trusting prior "exhaustive" claims) — found no new gaps; confirmed two-string-argument Scheme-level functions like `string-prefix?`/`string-index` are defined in Scheme, not C, so they're outside this bug class.
- Security review spot-checked #173's claims (string family, port I/O family, `set-*` family) against current `main` — all still reproduce exactly as filed, confirming #173 remains accurate and ready to pick up next.

## Test plan

- [x] `./build/curry --clear-cache tests/r7rs_tests.scm` — 485/485 pass
- [x] `ctest --test-dir build --output-on-failure` — 119/119 suites pass (fresh `--clear-cache` run)
- [x] Manual repro of both original crash sites, confirmed fixed
- [x] Two independent review agents (code + security) — both confirmed the fix is correct and complete; no new findings beyond what #173 already tracks

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
