### PR TITLE
fix(builtins,port,set): add missing type checks to string comparison family, port I/O layer, and set-* family (#173)

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -130,6 +130,7 @@ val_t scm_string_copy(val_t sv) {
 }
 
 val_t scm_string_append(val_t a, val_t b) {
+    if (!vis_string(a) || !vis_string(b)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "string-append: not a string");
     String *sa = as_str(a), *sb = as_str(b);
     uint32_t len = sa->len + sb->len;
     String *r = (String *)gc_alloc_atomic(sizeof(String) + len + 1);
@@ -141,11 +142,13 @@ val_t scm_string_append(val_t a, val_t b) {
 }
 
 val_t scm_string_to_symbol(val_t sv) {
+    if (!vis_string(sv)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "string->symbol: not a string");
     String *s = as_str(sv);
     return sym_intern(str_data(s), s->len);
 }
 
 val_t scm_symbol_to_string(val_t sym) {
+    if (!vis_symbol(sym)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "symbol->string: not a symbol");
     const char *name = sym_cstr(sym);
     uint32_t len = sym_len(sym);
     String *s = (String *)gc_alloc_atomic(sizeof(String) + len + 1);
@@ -1054,6 +1057,7 @@ static val_t prim_string_copy(int ac, val_t *av, void *ud) {
 }
 static val_t prim_string_append(int ac, val_t *av, void *ud) {
     (void)ud; if(ac==0) { String *e=CURRY_NEW_ATOM(String); e->hdr.type=T_STRING; e->hdr.flags=0; e->len=0; e->hash=0; e->orig_cap=0; e->ext=NULL; e->data[0]=0; return vptr(e); }
+    if (!vis_string(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "string-append: not a string");
     val_t r = av[0];
     for(int i=1;i<ac;i++) r = scm_string_append(r, av[i]);
     return r;
@@ -1097,6 +1101,8 @@ static val_t prim_string_for_each(int ac, val_t *av, void *ud) {
     (void)ud;
     val_t proc = av[0];
     int nstrs = ac - 1;
+    for (int i = 0; i < nstrs; i++)
+        if (!vis_string(av[i+1])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "string-for-each: not a string");
     /* Collect ports for each string */
     val_t *ports = (val_t *)alloca((size_t)nstrs * sizeof(val_t));
     for (int i = 0; i < nstrs; i++) {
@@ -1159,11 +1165,22 @@ static val_t prim_list_to_string(int ac, val_t *av, void *ud) {
 }
 static val_t prim_string_to_symbol(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return scm_string_to_symbol(av[0]);}
 static val_t prim_symbol_to_string(int ac, val_t *av, void *ud) {(void)ac;(void)ud; return scm_symbol_to_string(av[0]);}
+/* Comparison primitives (string=?/<?/etc, string-ci=?/<?/etc) take a
+ * variable-length chain of arguments and all compare adjacent pairs; check
+ * every argument up front rather than relying on the pairwise loop to touch
+ * each one, since that loop never re-validates an element already consumed
+ * as the *left* side of a prior pair. */
+static void check_all_strings(int ac, val_t *av, const char *who) {
+    for (int i = 0; i < ac; i++)
+        if (!vis_string(av[i])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%s: not a string", who);
+}
 static val_t prim_string_eq(int ac, val_t *av, void *ud) {
-    (void)ud; for(int i=1;i<ac;i++) { String *a=as_str(av[i-1]),*b=as_str(av[i]); if(a->len!=b->len||memcmp(str_data(a),str_data(b),a->len)!=0) return V_FALSE; } return V_TRUE;
+    (void)ud; check_all_strings(ac, av, "string=?");
+    for(int i=1;i<ac;i++) { String *a=as_str(av[i-1]),*b=as_str(av[i]); if(a->len!=b->len||memcmp(str_data(a),str_data(b),a->len)!=0) return V_FALSE; } return V_TRUE;
 }
 static val_t prim_string_lt(int ac, val_t *av, void *ud) {
-    (void)ud; for(int i=1;i<ac;i++) { if(strcmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))>=0) return V_FALSE; } return V_TRUE;
+    (void)ud; check_all_strings(ac, av, "string<?");
+    for(int i=1;i<ac;i++) { if(strcmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))>=0) return V_FALSE; } return V_TRUE;
 }
 static val_t prim_substring(int ac, val_t *av, void *ud) {
     (void)ud;
@@ -1691,9 +1708,9 @@ static val_t prim_digit_value(int ac, val_t *av, void *ud) {
 }
 
 /* Strings — missing comparators */
-static val_t prim_string_le(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(strcmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))>0) return V_FALSE; return V_TRUE;}
-static val_t prim_string_gt(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(strcmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))<=0) return V_FALSE; return V_TRUE;}
-static val_t prim_string_ge(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(strcmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))<0) return V_FALSE; return V_TRUE;}
+static val_t prim_string_le(int ac, val_t *av, void *ud) {(void)ud; check_all_strings(ac, av, "string<=?"); for(int i=1;i<ac;i++) if(strcmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))>0) return V_FALSE; return V_TRUE;}
+static val_t prim_string_gt(int ac, val_t *av, void *ud) {(void)ud; check_all_strings(ac, av, "string>?"); for(int i=1;i<ac;i++) if(strcmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))<=0) return V_FALSE; return V_TRUE;}
+static val_t prim_string_ge(int ac, val_t *av, void *ud) {(void)ud; check_all_strings(ac, av, "string>=?"); for(int i=1;i<ac;i++) if(strcmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))<0) return V_FALSE; return V_TRUE;}
 
 /* Case-insensitive string comparisons (scheme char library) */
 static int str_ci_cmp(const char *a, const char *b) {
@@ -1704,11 +1721,11 @@ static int str_ci_cmp(const char *a, const char *b) {
     }
     return tolower((unsigned char)*a) - tolower((unsigned char)*b);
 }
-static val_t prim_string_ci_eq(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))!=0) return V_FALSE; return V_TRUE;}
-static val_t prim_string_ci_lt(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))>=0) return V_FALSE; return V_TRUE;}
-static val_t prim_string_ci_le(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))>0) return V_FALSE; return V_TRUE;}
-static val_t prim_string_ci_gt(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))<=0) return V_FALSE; return V_TRUE;}
-static val_t prim_string_ci_ge(int ac, val_t *av, void *ud) {(void)ud; for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))<0) return V_FALSE; return V_TRUE;}
+static val_t prim_string_ci_eq(int ac, val_t *av, void *ud) {(void)ud; check_all_strings(ac, av, "string-ci=?"); for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))!=0) return V_FALSE; return V_TRUE;}
+static val_t prim_string_ci_lt(int ac, val_t *av, void *ud) {(void)ud; check_all_strings(ac, av, "string-ci<?"); for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))>=0) return V_FALSE; return V_TRUE;}
+static val_t prim_string_ci_le(int ac, val_t *av, void *ud) {(void)ud; check_all_strings(ac, av, "string-ci<=?"); for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))>0) return V_FALSE; return V_TRUE;}
+static val_t prim_string_ci_gt(int ac, val_t *av, void *ud) {(void)ud; check_all_strings(ac, av, "string-ci>?"); for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))<=0) return V_FALSE; return V_TRUE;}
+static val_t prim_string_ci_ge(int ac, val_t *av, void *ud) {(void)ud; check_all_strings(ac, av, "string-ci>=?"); for(int i=1;i<ac;i++) if(str_ci_cmp(str_data(as_str(av[i-1])),str_data(as_str(av[i])))<0) return V_FALSE; return V_TRUE;}
 
 static val_t prim_string_upcase(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
@@ -2529,6 +2546,7 @@ static val_t prim_dynamic_wind(int ac, val_t *av, void *ud) {
 
 static val_t prim_call_with_port(int ac, val_t *av, void *ud) {
     (void)ac; (void)ud;
+    if (!vis_port(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "call-with-port: not a port");
     val_t port = av[0], proc = av[1];
     val_t result = V_VOID;
     ExnHandler h;
@@ -2593,6 +2611,7 @@ static val_t prim_set_for_each(int ac, val_t *av, void *ud) {
 static val_t prim_set_map(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
     val_t proc = av[0], sv = av[1];
+    if (!vis_set(sv)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "set-map: not a set");
     val_t r = set_make(as_set(sv)->cmp);
     val_t lst = set_to_list(sv);
     while (vis_pair(lst)) {
@@ -2604,6 +2623,7 @@ static val_t prim_set_map(int ac, val_t *av, void *ud) {
 static val_t prim_set_filter(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
     val_t pred = av[0], sv = av[1];
+    if (!vis_set(sv)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "set-filter: not a set");
     val_t r = set_make(as_set(sv)->cmp);
     val_t lst = set_to_list(sv);
     while (vis_pair(lst)) {

--- a/src/port.c
+++ b/src/port.c
@@ -13,6 +13,18 @@ extern void scm_raise(val_t kind, const char *fmt, ...) __attribute__((noreturn)
 
 val_t PORT_STDIN, PORT_STDOUT, PORT_STDERR;
 
+/* Every port_* entry point below takes a caller-supplied val_t and used to
+ * cast it straight to a Port* via as_port() with no type check -- the same
+ * unchecked-as_TYPE()-cast hazard as #166/#170/#172, just at this layer
+ * instead of a builtins.c prim_* wrapper. Fixing it here once, rather than
+ * at each of the dozen-plus builtins.c call sites into this file, is what
+ * closed the gap that let call-with-port slip through even after #170
+ * fixed close-port's own builtins.c wrapper (issue #173). */
+static Port *checked_port(val_t v, const char *who) {
+    if (!vis_port(v)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%s: not a port", who);
+    return as_port(v);
+}
+
 static val_t make_port(int flags) {
     Port *p = CURRY_NEW_PINNED(Port);
     p->hdr.type  = T_PORT;
@@ -136,7 +148,7 @@ static int read_utf8_codepoint(Port *p) {
 }
 
 int port_read_char(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "read-char");
     if (p->flags & PORT_CLOSED) return -1;
     int cp;
     /* Drain the one-codepoint lookahead if present */
@@ -150,10 +162,10 @@ int port_read_char(val_t v) {
     return cp;  /* -1 (EOF) or the codepoint */
 }
 
-int port_line(val_t v) { return as_port(v)->line; }
+int port_line(val_t v) { return checked_port(v, "port-line")->line; }
 
 int port_peek_char(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "peek-char");
     if (p->flags & PORT_CLOSED) return -1;
     /* If lookahead is already filled, return it without consuming */
     if (p->peeked_cp != -2) return p->peeked_cp;
@@ -171,13 +183,13 @@ int port_peek_char(val_t v) {
 }
 
 bool port_char_ready(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "char-ready?");
     if (p->flags & PORT_STRING) return p->u.str.pos < p->u.str.len;
     return true; /* conservative */
 }
 
 void port_write_char(val_t v, int cp) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "write-char");
     if (p->flags & PORT_CLOSED) return;
     /* Encode as UTF-8 */
     char buf[5]; int len;
@@ -203,7 +215,7 @@ void port_write_char(val_t v, int cp) {
 }
 
 void port_write_string(val_t v, const char *s, uint32_t len) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "write-string");
     if (p->flags & PORT_CLOSED) return;
     if (p->flags & PORT_STRING) {
         while (p->u.str.len + len + 1 >= p->u.str.cap) {
@@ -221,7 +233,7 @@ void port_write_string(val_t v, const char *s, uint32_t len) {
 }
 
 val_t port_read_line(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "read-line");
     if (p->flags & PORT_CLOSED || p->flags & PORT_BINARY) return V_EOF;
     /* Read until newline or EOF */
     val_t out = port_open_output_string();
@@ -256,7 +268,7 @@ val_t port_read_line(val_t v) {
 }
 
 int port_read_byte(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "read-u8");
     if (p->flags & PORT_CLOSED) return -1;
     if (p->flags & PORT_STRING) {
         if (p->u.str.pos >= p->u.str.len) return -1;
@@ -267,7 +279,7 @@ int port_read_byte(val_t v) {
 }
 
 int port_peek_byte(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "peek-u8");
     if (p->flags & PORT_CLOSED) return -1;
     if (p->flags & PORT_STRING) {
         if (p->u.str.pos >= p->u.str.len) return -1;
@@ -279,7 +291,7 @@ int port_peek_byte(val_t v) {
 }
 
 void port_write_byte(val_t v, uint8_t b) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "write-u8");
     if (p->flags & PORT_CLOSED) return;
     if (p->flags & PORT_STRING) {
         /* Binary string port: append raw byte without UTF-8 encoding. */
@@ -301,7 +313,7 @@ void port_write_byte(val_t v, uint8_t b) {
 }
 
 void port_close(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "close-port");
     if (p->flags & PORT_CLOSED) return;
     if (!(p->flags & PORT_STRING) && p->u.fp &&
         p->u.fp != stdin && p->u.fp != stdout && p->u.fp != stderr) {
@@ -335,7 +347,7 @@ val_t port_open_output_bytevector(void) {
 }
 
 val_t port_get_output_string(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "get-output-string");
     if (!(p->flags & PORT_STRING))
         scm_raise(V_FALSE, "get-output-string: not a string port");
     uint32_t len = (uint32_t)p->u.str.len;
@@ -351,7 +363,7 @@ val_t port_get_output_string(val_t v) {
 }
 
 val_t port_get_output_bytevector(val_t v) {
-    Port *p = as_port(v);
+    Port *p = checked_port(v, "get-output-bytevector");
     if (!(p->flags & PORT_STRING) || !(p->flags & PORT_BINARY))
         scm_raise(V_FALSE, "get-output-bytevector: not a binary output port");
     uint32_t len = (uint32_t)p->u.str.len;

--- a/src/set.c
+++ b/src/set.c
@@ -316,6 +316,7 @@ val_t set_union(val_t a, val_t b) {
 
 val_t set_intersection(val_t a, val_t b) {
     val_t r = set_make(checked_set(a, "set-intersection")->cmp);
+    checked_set(b, "set-intersection");
     val_t la = set_to_list(a);
     while (vis_pair(la)) { if (set_member(b, vcar(la))) set_add_mut(r, vcar(la)); la = vcdr(la); }
     return r;
@@ -323,12 +324,20 @@ val_t set_intersection(val_t a, val_t b) {
 
 val_t set_difference(val_t a, val_t b) {
     val_t r = set_make(checked_set(a, "set-difference")->cmp);
+    checked_set(b, "set-difference");
     val_t la = set_to_list(a);
     while (vis_pair(la)) { if (!set_member(b, vcar(la))) set_add_mut(r, vcar(la)); la = vcdr(la); }
     return r;
 }
 
 bool set_subset(val_t a, val_t b) {
+    /* checked_set(a, ...) happens transitively via set_to_list(a) below, but
+     * b is only ever touched inside the loop via set_member(b, ...) -- if a
+     * is a valid EMPTY set, that loop body never runs, so b's type was never
+     * validated at all (confirmed: (set-subset? (make-set) 42) silently
+     * returned #t instead of raising). Check both explicitly up front. */
+    checked_set(a, "set-subset?");
+    checked_set(b, "set-subset?");
     val_t la = set_to_list(a);
     while (vis_pair(la)) { if (!set_member(b, vcar(la))) return false; la = vcdr(la); }
     return true;

--- a/src/set.c
+++ b/src/set.c
@@ -3,10 +3,22 @@
 #include "gc.h"
 #include "numeric.h"
 #include "symbolic.h"
+#include "symbol.h"
 #include "eval.h"
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+
+/* Every set_* entry point below used to cast a caller-supplied val_t
+ * straight to a Set* via as_set() with no type check -- the exact same
+ * unchecked-as_TYPE()-cast hazard #170 closed for hash-table's Hashtable*,
+ * hash-table's own sibling structure in this same file, just left
+ * unguarded (issue #173). Fixed once here rather than at every builtins.c
+ * prim_set_* call site, mirroring how #173 fixed the port.c layer. */
+static Set *checked_set(val_t v, const char *who) {
+    if (!vis_set(v)) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%s: not a set", who);
+    return as_set(v);
+}
 
 /* ---- Equality predicates ---- */
 
@@ -220,7 +232,7 @@ val_t set_make(int cmp_type) {
 }
 
 bool set_member(val_t sv, val_t elem) {
-    Set *s = as_set(sv);
+    Set *s = checked_set(sv, "set-member?");
     uint32_t mask = s->cap - 1;
     uint32_t idx  = val_hash(elem, s->cmp) & mask;
     while (1) {
@@ -232,7 +244,7 @@ bool set_member(val_t sv, val_t elem) {
 }
 
 void set_add_mut(val_t sv, val_t elem) {
-    Set *s = as_set(sv);
+    Set *s = checked_set(sv, "set-add!");
     if (set_member(sv, elem)) return;
     if (s->size * LOAD_DEN >= s->cap * LOAD_NUM) set_rehash(s);
     uint32_t mask = s->cap - 1;
@@ -244,7 +256,7 @@ void set_add_mut(val_t sv, val_t elem) {
 }
 
 void set_delete_mut(val_t sv, val_t elem) {
-    Set *s = as_set(sv);
+    Set *s = checked_set(sv, "set-delete!");
     uint32_t mask = s->cap - 1;
     uint32_t idx  = val_hash(elem, s->cmp) & mask;
     while (1) {
@@ -261,7 +273,7 @@ void set_delete_mut(val_t sv, val_t elem) {
 
 val_t set_add(val_t sv, val_t elem) {
     /* Copy and add */
-    Set *old = as_set(sv);
+    Set *old = checked_set(sv, "set-add");
     val_t nv = set_make(old->cmp);
     Set *s = as_set(nv);
     for (uint32_t i = 0; i < old->cap; i++) {
@@ -274,7 +286,7 @@ val_t set_add(val_t sv, val_t elem) {
 }
 
 val_t set_to_list(val_t sv) {
-    Set *s = as_set(sv);
+    Set *s = checked_set(sv, "set->list");
     val_t lst = V_NIL;
     for (uint32_t i = 0; i < s->cap; i++) {
         val_t e = s->buckets[i];
@@ -292,10 +304,10 @@ val_t list_to_set(val_t lst, int cmp_type) {
     return s;
 }
 
-uint32_t set_size(val_t sv) { return as_set(sv)->size; }
+uint32_t set_size(val_t sv) { return checked_set(sv, "set-size")->size; }
 
 val_t set_union(val_t a, val_t b) {
-    val_t r = set_make(as_set(a)->cmp);
+    val_t r = set_make(checked_set(a, "set-union")->cmp);
     val_t la = set_to_list(a), lb = set_to_list(b);
     while (vis_pair(la)) { set_add_mut(r, vcar(la)); la = vcdr(la); }
     while (vis_pair(lb)) { set_add_mut(r, vcar(lb)); lb = vcdr(lb); }
@@ -303,14 +315,14 @@ val_t set_union(val_t a, val_t b) {
 }
 
 val_t set_intersection(val_t a, val_t b) {
-    val_t r = set_make(as_set(a)->cmp);
+    val_t r = set_make(checked_set(a, "set-intersection")->cmp);
     val_t la = set_to_list(a);
     while (vis_pair(la)) { if (set_member(b, vcar(la))) set_add_mut(r, vcar(la)); la = vcdr(la); }
     return r;
 }
 
 val_t set_difference(val_t a, val_t b) {
-    val_t r = set_make(as_set(a)->cmp);
+    val_t r = set_make(checked_set(a, "set-difference")->cmp);
     val_t la = set_to_list(a);
     while (vis_pair(la)) { if (!set_member(b, vcar(la))) set_add_mut(r, vcar(la)); la = vcdr(la); }
     return r;
@@ -323,11 +335,11 @@ bool set_subset(val_t a, val_t b) {
 }
 
 bool set_equal(val_t a, val_t b) {
-    return as_set(a)->size == as_set(b)->size && set_subset(a, b);
+    return checked_set(a, "set=?")->size == checked_set(b, "set=?")->size && set_subset(a, b);
 }
 
 val_t set_copy(val_t sv) {
-    return list_to_set(set_to_list(sv), as_set(sv)->cmp);
+    return list_to_set(set_to_list(sv), checked_set(sv, "set-copy")->cmp);
 }
 
 val_t set_sym_diff(val_t a, val_t b) {

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -211,6 +211,13 @@
 (check "list->string" (list->string '(#\h #\i)) "hi")
 (check "string->symbol" (string->symbol "foo") 'foo)
 (check "symbol->string" (symbol->string 'bar) "bar")
+;; Issue #173: string->symbol/symbol->string had no vis_string()/vis_symbol()
+;; check -- confirmed reproducible SIGSEGV via (string->symbol 42) /
+;; (symbol->string 42) pre-fix.
+(check "string->symbol rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string->symbol 42)) 'raised)
+(check "symbol->string rejects a non-symbol argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (symbol->string 42)) 'raised)
 
 ;;; Pairs
 (check "car" (car '(1 2 3)) 1)
@@ -727,6 +734,43 @@
 (check "set-size" (set-size s) 3)
 (define s2 (list->set '(3 4 5)))
 (check "set-intersection" (set-size (set-intersection s s2)) 1)
+;; Issue #173: the entire native set-* family (hash-table's exact sibling
+;; data structure in src/set.c) had NO type check whatsoever on its set
+;; argument -- confirmed reproducible SIGSEGV for each of these pre-fix.
+(check "set-size rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-size 42)) 'raised)
+(check "set-add! rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-add! 42 1)) 'raised)
+(check "set-member? rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-member? 42 1)) 'raised)
+(check "set->list rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set->list 42)) 'raised)
+(check "set-union rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-union 42 (make-set))) 'raised)
+(check "set-copy rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-copy 42)) 'raised)
+(check "set-delete! rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-delete! 42 1)) 'raised)
+(check "set-empty? rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-empty? 42)) 'raised)
+(check "set=? rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set=? 42 (make-set))) 'raised)
+(check "set-map rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-map (lambda (x) x) 42)) 'raised)
+(check "set-filter rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-filter (lambda (x) x) 42)) 'raised)
+(check "set-intersection rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-intersection 42 (make-set))) 'raised)
+(check "set-difference rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-difference 42 (make-set))) 'raised)
+(check "set-subset? rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-subset? 42 (make-set))) 'raised)
+(check "set-for-each rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-for-each display 42)) 'raised)
+(check "set-adjoin rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-adjoin 42 1)) 'raised)
+(check "set-fold rejects a non-set argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (set-fold + 0 42)) 'raised)
 
 ;;; Records
 (define-record-type <person>
@@ -919,6 +963,35 @@
 ;;; Strings
 (check "string=?"       (string=? "abc" "abc") #t)
 (check "string<?"       (string<? "abc" "abd") #t)
+;; Issue #173: the entire string comparison family (=?/<?/<=?/>?/>=?, plus
+;; the -ci variants) and string-append/string-for-each had no vis_string()
+;; check on any argument -- confirmed reproducible SIGSEGV pre-fix.
+(check "string=? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string=? "a" 42)) 'raised)
+(check "string<? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string<? "a" 42)) 'raised)
+(check "string<=? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string<=? "a" 42)) 'raised)
+(check "string>? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string>? "a" 42)) 'raised)
+(check "string>=? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string>=? "a" 42)) 'raised)
+(check "string-ci=? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-ci=? "a" 42)) 'raised)
+(check "string-ci<? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-ci<? "a" 42)) 'raised)
+(check "string-ci<=? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-ci<=? "a" 42)) 'raised)
+(check "string-ci>? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-ci>? "a" 42)) 'raised)
+(check "string-ci>=? rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-ci>=? "a" 42)) 'raised)
+(check "string-append rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-append "a" 42)) 'raised)
+(check "string-append rejects a non-string first argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-append 42 "a")) 'raised)
+(check "string-for-each rejects a non-string argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (string-for-each display 42)) 'raised)
 (check "string-contains" (string-contains "hello world" "world") 6)
 (check "string-contains miss" (string-contains "hello" "xyz") #f)
 ;; Issue #172: string-contains had no vis_string() check on either
@@ -1006,6 +1079,48 @@
        (guard (exn (#t 'raised)) (read-bytevector -1)) 'raised)
 (check "read-bytevector basic still works"
        (bytevector-u8-ref (read-bytevector 2 (open-input-string "ab")) 0) 97)
+
+;; Issue #173: nearly the entire port I/O primitive layer (port.c's own
+;; functions, called unconditionally from most builtins.c wrappers) had no
+;; vis_port() check -- confirmed reproducible SIGSEGV for each of these
+;; pre-fix, including call-with-port, which crashed inside port_close even
+;; though its lambda body never touched the port argument at all.
+(check "read-char rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (read-char 42)) 'raised)
+(check "peek-char rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (peek-char 42)) 'raised)
+(check "read-line rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (read-line 42)) 'raised)
+(check "write-char rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (write-char #\a 42)) 'raised)
+(check "display rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (display "x" 42)) 'raised)
+(check "write rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (write "x" 42)) 'raised)
+(check "newline rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (newline 42)) 'raised)
+(check "read-u8 rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (read-u8 42)) 'raised)
+(check "peek-u8 rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (peek-u8 42)) 'raised)
+(check "write-u8 rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (write-u8 65 42)) 'raised)
+(check "char-ready? rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (char-ready? 42)) 'raised)
+(check "u8-ready? rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (u8-ready? 42)) 'raised)
+(check "read-string rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (read-string 5 42)) 'raised)
+(check "read-bytevector rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (read-bytevector 5 42)) 'raised)
+(check "write-bytevector rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (write-bytevector (bytevector 1 2) 42)) 'raised)
+(check "get-output-string rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (get-output-string 42)) 'raised)
+(check "call-with-port rejects a non-port argument (was a reproducible SIGSEGV in port_close, even though the lambda never touched the port)"
+       (guard (exn (#t 'raised)) (call-with-port 42 (lambda (p) 'ok))) 'raised)
+(check "read rejects a non-port argument (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (read 42)) 'raised)
 
 ;;; Predicates
 (check "vector?"    (vector? '#(1 2)) #t)

--- a/tests/r7rs_tests.scm
+++ b/tests/r7rs_tests.scm
@@ -771,6 +771,18 @@
        (guard (exn (#t 'raised)) (set-adjoin 42 1)) 'raised)
 (check "set-fold rejects a non-set argument (was a reproducible SIGSEGV)"
        (guard (exn (#t 'raised)) (set-fold + 0 42)) 'raised)
+;; Found during code review of #173's own fix: set-intersection/
+;; set-difference/set-subset? only validated their SECOND argument inside a
+;; loop guarded by the first (already-checked) argument's contents -- when
+;; the first argument is a valid EMPTY set, that loop body never runs, so a
+;; bad second argument silently slipped through instead of raising (e.g.
+;; (set-subset? (make-set) 42) returned #t instead of erroring).
+(check "set-intersection rejects a non-set 2nd argument even with an empty 1st set"
+       (guard (exn (#t 'raised)) (set-intersection (make-set) 42)) 'raised)
+(check "set-difference rejects a non-set 2nd argument even with an empty 1st set"
+       (guard (exn (#t 'raised)) (set-difference (make-set) 42)) 'raised)
+(check "set-subset? rejects a non-set 2nd argument even with an empty 1st set"
+       (guard (exn (#t 'raised)) (set-subset? (make-set) 42)) 'raised)
 
 ;;; Records
 (define-record-type <person>


### PR DESCRIPTION
## Summary

Closes #173.

Found during independent adversarial security review of #170's fix (and of #172, whose grep claimed `src/builtins.c` was exhaustively checked — it wasn't). Three large groups of the same unchecked-`as_TYPE()`-cast bug class, all confirmed reproducible SIGSEGV pre-fix, all reachable from plain no-import R7RS-core code:

1. **String comparison/conversion/append/for-each family** (`src/builtins.c`): `string->symbol`, `symbol->string`, `string=?`/`<?`/`<=?`/`>?`/`>=?`, the `-ci` variants, `string-append`, `string-for-each`. Fixed at each `prim_*` call site (plus the shared `scm_string_append`/`scm_string_to_symbol`/`scm_symbol_to_string` helpers), using a new `check_all_strings()` helper for the 10 variadic comparison functions rather than duplicating a loop.

2. **Nearly the entire port I/O primitive layer** (`src/port.c`): 12+ functions did an unconditional `as_port()` with no guard anywhere in the file. Given the number of call sites, fixed once via a `checked_port()` helper inside `port.c` itself, protecting all current and future callers — matching what #170's own commit message wanted for `close-port` but didn't actually implement even there. Also fixes `call-with-port`, which used to crash inside `port_close()`'s cleanup path even when its lambda never touched the port; it now also gets an explicit up-front check so a bad port fails before the proc runs at all, not just in cleanup.

3. **The entire native `set-*` family** (`src/set.c`) — hash-table's exact sibling structure that #170 fixed for hash-table but left untouched for sets. Fixed via a `checked_set()` helper. Also found and fixed two direct `as_set()` casts in `builtins.c`'s `prim_set_map`/`prim_set_filter` that bypassed `set.c`'s functions entirely.

## Review

Two independent fresh subagents (code review + security review) — the largest fix in this chain so far, reviewed accordingly:

- Both rebuilt and manually ran all ~48 originally-reported repros across the three families — all raise cleanly, zero crashes.
- Both confirmed correct-argument paths are completely unaffected.
- Security review specifically hunted for a *third* "bypasses the shared helper" bug (matching the `set_map`/`set_filter` pattern found while implementing this fix) — found none; also confirmed closed-port semantics are byte-for-byte preserved, and that `call-with-port`'s exception-handling interaction with a raising `port_close()` is safe (the up-front check means `port_close` can never itself raise during cleanup).
- Code review found one real, in-scope gap: `set_intersection`/`set_difference`/`set_subset` only validated their *second* argument inside a loop guarded by the first argument's contents — with a valid **empty** first set, that loop never ran, so a bad second argument silently slipped through (e.g. `(set-subset? (make-set) 42)` returned `#t` instead of raising). Fixed in a follow-up commit on this same branch (`995cc65`), with regression tests.
- Both noted a cosmetic tradeoff: since checks are pushed into shared helpers (`checked_port`/`checked_set`) rather than duplicated per call site, some error messages name the helper's own procedure rather than the caller's (e.g. `(set-copy 42)` raises "set->list: not a set"). Accepted as the right tradeoff for closing this bug class exhaustively rather than call-site-by-call-site.

## Test plan

- [x] `./build/curry --clear-cache tests/r7rs_tests.scm` — 538/538 pass
- [x] `ctest --test-dir build --output-on-failure` — 119/119 suites pass (fresh `--clear-cache` run)
- [x] Manual repro of all ~48 original crash sites plus the 3 empty-set edge cases, confirmed fixed
- [x] Two independent review agents (code + security) — one real finding surfaced and fixed in the same branch before push

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
