### PR TITLE
fix(modules): reject unchecked handle-argument bytevector casts across 14 C modules (#165)

### DIFF
--- a/modules/git/git.c
+++ b/modules/git/git.c
@@ -80,6 +80,13 @@ static git_repository *val_to_repo(curry_val v) {
     if (!curry_is_pair(v) || curry_car(v) != repo_tag())
         curry_error("git: not a repository handle");
     curry_val bv = curry_cdr(v);
+    /* Issue #165: the tag was checked, but the cdr -- assumed to be a
+     * pointer-holding bytevector -- was read straight via
+     * curry_bytevector_ref with no curry_is_bytevector/length check first.
+     * Confirmed reproducible SIGSEGV via
+     * (git-close! (cons 'git-repo 42)). */
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(git_repository *))
+        curry_error("git: not a repository handle");
     git_repository *r;
     for (size_t i = 0; i < sizeof(git_repository *); i++)
         ((uint8_t *)&r)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/graphql/graphql.c
+++ b/modules/graphql/graphql.c
@@ -81,7 +81,16 @@ static curry_val gql_to_val(GQLClient *c) {
 }
 
 static GQLClient *val_to_gql(curry_val v) {
+    /* Issue #165: this checked NOTHING at all -- not even a tag, let
+     * alone that the cdr was really a pointer-holding bytevector.
+     * Confirmed reproducible SIGSEGV via
+     * (graphql-query (cons 'graphql-client 42) "{x}"). */
+    if (!curry_is_pair(v) || !curry_is_symbol(curry_car(v)) ||
+        strcmp(curry_symbol(curry_car(v)), "graphql-client") != 0)
+        curry_error("graphql: not a graphql client handle");
     curry_val bv = curry_cdr(v);
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(GQLClient *))
+        curry_error("graphql: not a graphql client handle");
     GQLClient *c;
     for (size_t i = 0; i < sizeof(GQLClient *); i++)
         ((uint8_t *)&c)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/ldap/ldap.c
+++ b/modules/ldap/ldap.c
@@ -36,9 +36,16 @@ static curry_val ldap_to_val(LDAP *ld) {
 }
 
 static LDAP *val_to_ldap(curry_val v) {
-    if (!curry_is_pair(v) || !curry_is_symbol(curry_car(v)))
+    /* Issue #165: this checked that the car was *some* symbol, not which
+     * one, and never checked the cdr was actually a pointer-holding
+     * bytevector at all before curry_bytevector_ref's own unchecked
+     * as_bytes() cast dereferenced whatever was there as a pointer. */
+    if (!curry_is_pair(v) || !curry_is_symbol(curry_car(v)) ||
+        strcmp(curry_symbol(curry_car(v)), "ldap-conn") != 0)
         curry_error("ldap: not a connection handle");
     curry_val bv = curry_cdr(v);
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(LDAP *))
+        curry_error("ldap: not a connection handle");
     LDAP *ld;
     for (size_t i = 0; i < sizeof(LDAP *); i++)
         ((uint8_t *)&ld)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -158,6 +158,13 @@ static MQTTConn *val_to_conn(curry_val v) {
     if (!curry_is_pair(v) || curry_car(v) != conn_tag())
         curry_error("mqtt: not an mqtt client handle");
     curry_val bv = curry_cdr(v);
+    /* Issue #165: the tag was checked, but the cdr -- assumed to be a
+     * pointer-holding bytevector -- was read straight via
+     * curry_bytevector_ref with no curry_is_bytevector/length check first.
+     * Confirmed reproducible SIGSEGV via
+     * (mqtt-publish (cons 'mqtt-conn 42) "t" "p"). */
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(MQTTConn *))
+        curry_error("mqtt: not an mqtt client handle");
     MQTTConn *c;
     for (size_t i = 0; i < sizeof(MQTTConn *); i++)
         ((uint8_t *)&c)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/neo4j/neo4j.c
+++ b/modules/neo4j/neo4j.c
@@ -103,6 +103,13 @@ static NeoConn *conn_unbox(curry_val v, const char *ctx) {
         (curry_car(v) != conn_tag() && curry_car(v) != tx_tag()))
         curry_error("%s: not a neo4j connection or transaction", ctx);
     curry_val bv = curry_cdr(v);
+    /* Issue #165: the tag was checked, but the cdr -- assumed to be a
+     * pointer-holding bytevector -- was read straight via
+     * curry_bytevector_ref with no curry_is_bytevector/length check first.
+     * Confirmed reproducible SIGSEGV via
+     * (neo4j-disconnect (cons 'neo4j-conn 42)). */
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(NeoConn *))
+        curry_error("%s: not a neo4j connection or transaction", ctx);
     NeoConn *c;
     for (size_t i = 0; i < sizeof(NeoConn *); i++)
         ((uint8_t *)&c)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/piper/piper.c
+++ b/modules/piper/piper.c
@@ -89,6 +89,14 @@ static bool val_is_tagged(curry_val v, const char *tag) {
 
 static void *val_to_ptr(curry_val v) {
     curry_val bv = curry_cdr(v);
+    /* Issue #165: every call site checks val_is_tagged(av[0], tag) first,
+     * but that only verifies the CAR -- the cdr, assumed to be a
+     * pointer-holding bytevector, was read straight via
+     * curry_bytevector_ref with no curry_is_bytevector/length check. A
+     * forged handle like (cons 'piper-synth 42) has the right tag but a
+     * non-bytevector cdr. */
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(void *))
+        curry_error("piper: malformed handle");
     void *p;
     for (size_t i = 0; i < sizeof(void *); i++)
         ((uint8_t *)&p)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/posix/posix.c
+++ b/modules/posix/posix.c
@@ -92,6 +92,21 @@ static int has_tag(curry_val v, const char *tag) {
            strcmp(curry_symbol(curry_car(v)), tag) == 0;
 }
 
+/* Issue #165: has_tag checked the car, but fn_read_directory/
+ * fn_close_directory passed curry_cdr(av[0]) straight to unpack_ptr()
+ * with no curry_is_bytevector/length check -- a forged handle like
+ * (cons 'directory-stream 42) has the right tag but a non-bytevector
+ * cdr, and curry_bytevector_ref's own unchecked as_bytes() cast then
+ * dereferences the fixnum's raw bit pattern as a pointer. Confirmed
+ * reproducible SIGSEGV via
+ * (read-directory (cons 'directory-stream 42)). */
+static curry_val checked_ptr_cdr(curry_val v, const char *tag, const char *fn) {
+    curry_val bv = curry_cdr(v);
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(void *))
+        curry_error("posix: %s: not a %s", fn, tag);
+    return bv;
+}
+
 static void posix_error(const char *fn) {
     curry_error("posix: %s: %s", fn, strerror(errno));
 }
@@ -237,7 +252,7 @@ static curry_val fn_read_directory(int ac, curry_val *av, void *ud) {
     (void)ac; (void)ud;
     if (!has_tag(av[0], "directory-stream"))
         curry_error("posix: read-directory: not a directory stream");
-    DIR *d = (DIR *)unpack_ptr(curry_cdr(av[0]));
+    DIR *d = (DIR *)unpack_ptr(checked_ptr_cdr(av[0], "directory stream", "read-directory"));
     if (!d) curry_error("posix: read-directory: directory stream already closed");
     struct dirent *e;
     while ((e = readdir(d)) != NULL) {
@@ -251,7 +266,7 @@ static curry_val fn_close_directory(int ac, curry_val *av, void *ud) {
     (void)ac; (void)ud;
     if (!has_tag(av[0], "directory-stream"))
         curry_error("posix: close-directory: not a directory stream");
-    curry_val bv = curry_cdr(av[0]);
+    curry_val bv = checked_ptr_cdr(av[0], "directory stream", "close-directory");
     DIR *d = (DIR *)unpack_ptr(bv);
     if (!d) curry_error("posix: close-directory: directory stream already closed");
     clear_ptr(bv);

--- a/modules/qt6/qt6.cpp
+++ b/modules/qt6/qt6.cpp
@@ -231,6 +231,14 @@ static void *val_to_ptr(const char *tag, curry_val v) {
     if (strcmp(got, tag) != 0)
         curry_error("qt6: wrong handle type — expected %s, got %s", tag, got);
     curry_val bv = curry_cdr(v);
+    /* Issue #165: the tag was checked (both symbol-ness and exact match),
+     * but the cdr -- assumed to be a pointer-holding bytevector -- was
+     * read straight via curry_bytevector_ref with no
+     * curry_is_bytevector/length check first. A forged handle like
+     * (cons (string->symbol tag) 42) has the right tag but a
+     * non-bytevector cdr. */
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(void *))
+        curry_error("qt6: malformed handle (expected %s)", tag);
     void *ptr = nullptr;
     for (size_t i = 0; i < sizeof(void *); i++)
         ((uint8_t *)&ptr)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -135,6 +135,14 @@ static RedisConn *val_to_conn(curry_val v) {
     if (!curry_is_pair(v) || curry_car(v) != conn_tag())
         curry_error("redis: not a redis client handle");
     curry_val bv = curry_cdr(v);
+    /* Issue #165: the tag was checked, but the cdr -- assumed to be a
+     * pointer-holding bytevector -- was read straight via
+     * curry_bytevector_ref with no curry_is_bytevector/length check first,
+     * the same unchecked-cast hazard #158 closed for network socket
+     * handles. Confirmed reproducible SIGSEGV via
+     * (redis-close! (cons 'redis-conn 42)). */
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(RedisConn *))
+        curry_error("redis: not a redis client handle");
     RedisConn *c;
     for (size_t i = 0; i < sizeof(RedisConn *); i++)
         ((uint8_t *)&c)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/regex/regex.c
+++ b/modules/regex/regex.c
@@ -38,7 +38,18 @@ static RegexData *get_regex(curry_val v, const char *ctx) {
         !curry_is_symbol(curry_car(v)) ||
         strcmp(curry_symbol(curry_car(v)), "regex") != 0)
         curry_error("%s: expected regex handle", ctx);
-    return (RegexData *)unpack_ptr(curry_cdr(v));
+    /* Issue #165: the tag (car) was checked, but the cdr -- assumed to be
+     * a pointer-holding bytevector -- was passed straight to unpack_ptr()
+     * with no curry_is_bytevector/length check, the same unchecked-cast
+     * hazard #158 closed for network socket handles. A forged handle like
+     * (cons 'regex 42) has the right tag but a non-bytevector cdr;
+     * curry_bytevector_ref's own unchecked as_bytes() cast then
+     * dereferences the fixnum's raw bit pattern as a pointer. Confirmed
+     * reproducible SIGSEGV via (regex-free (cons 'regex 42)). */
+    curry_val bv = curry_cdr(v);
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(void *))
+        curry_error("%s: expected regex handle", ctx);
+    return (RegexData *)unpack_ptr(bv);
 }
 
 /* ---- (regex-compile pattern [flags]) → regex ---- */

--- a/modules/rpi/rpi.c
+++ b/modules/rpi/rpi.c
@@ -80,6 +80,20 @@ static int has_tag(curry_val v, const char *tag) {
            strcmp(curry_symbol(curry_car(v)), tag) == 0;
 }
 
+/* Issue #165: has_tag checked the car, but every get_gpio/get_watcher/
+ * i2c/spi/pwm/camera/uart/watchdog unwrap below passed curry_cdr(v)
+ * straight to unpack_ptr()/unpack_fd() with no curry_is_bytevector/length
+ * check -- a forged handle like (cons 'gpio 42) has the right tag but a
+ * non-bytevector cdr, and curry_bytevector_ref's own unchecked
+ * as_bytes() cast then dereferences the fixnum's raw bit pattern as a
+ * pointer. Same hazard as (cons 'redis-conn 42) in the redis module. */
+static curry_val checked_ptr_cdr(curry_val v, const char *tag, const char *ctx) {
+    curry_val bv = curry_cdr(v);
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(void *))
+        curry_error("%s: expected %s handle", ctx, tag);
+    return bv;
+}
+
 /* ---- GPIO (libgpiod) ---- */
 
 static curry_val wrap_gpio(struct gpiod_line *line) {
@@ -87,7 +101,7 @@ static curry_val wrap_gpio(struct gpiod_line *line) {
 }
 static struct gpiod_line *get_gpio(curry_val v, const char *ctx) {
     if (!has_tag(v, "gpio")) curry_error("%s: expected gpio handle", ctx);
-    return (struct gpiod_line *)unpack_ptr(curry_cdr(v));
+    return (struct gpiod_line *)unpack_ptr(checked_ptr_cdr(v, "gpio", ctx));
 }
 
 /* (gpio-open chip-num line-num direction) → gpio-handle
@@ -217,7 +231,7 @@ static curry_val wrap_watcher(GpioWatcher *w) {
 }
 static GpioWatcher *get_watcher(curry_val v, const char *ctx) {
     if (!has_tag(v, "watcher")) curry_error("%s: expected watcher handle", ctx);
-    return (GpioWatcher *)unpack_ptr(curry_cdr(v));
+    return (GpioWatcher *)unpack_ptr(checked_ptr_cdr(v, "watcher", ctx));
 }
 
 static void *watcher_thread_fn(void *arg) {
@@ -320,7 +334,7 @@ static curry_val wrap_i2c(int fd) {
 }
 static int get_i2c(curry_val v, const char *ctx) {
     if (!has_tag(v, "i2c")) curry_error("%s: expected i2c handle", ctx);
-    return unpack_fd(curry_cdr(v));
+    return unpack_fd(checked_ptr_cdr(v, "i2c", ctx));
 }
 
 /* (i2c-open bus-num) → i2c-handle  — opens /dev/i2c-N */
@@ -404,7 +418,7 @@ static curry_val wrap_spi(int fd) {
 }
 static int get_spi(curry_val v, const char *ctx) {
     if (!has_tag(v, "spi")) curry_error("%s: expected spi handle", ctx);
-    return unpack_fd(curry_cdr(v));
+    return unpack_fd(checked_ptr_cdr(v, "spi", ctx));
 }
 
 /* (spi-open bus device speed-hz mode) → spi-handle
@@ -495,7 +509,7 @@ static curry_val wrap_pwm(PwmHandle *h) {
 }
 static PwmHandle *get_pwm(curry_val v, const char *ctx) {
     if (!has_tag(v, "pwm")) curry_error("%s: expected pwm handle", ctx);
-    return (PwmHandle *)unpack_ptr(curry_cdr(v));
+    return (PwmHandle *)unpack_ptr(checked_ptr_cdr(v, "pwm", ctx));
 }
 
 static int pwm_write(const char *path, const char *val) {
@@ -638,7 +652,7 @@ static curry_val wrap_camera(Camera *c) {
 }
 static Camera *get_camera(curry_val v, const char *ctx) {
     if (!has_tag(v, "camera")) curry_error("%s: not a camera handle", ctx);
-    return (Camera *)unpack_ptr(curry_cdr(v));
+    return (Camera *)unpack_ptr(checked_ptr_cdr(v, "camera", ctx));
 }
 
 /* Map symbolic format name to V4L2 fourcc. */
@@ -843,7 +857,7 @@ static curry_val wrap_uart(int fd) {
 }
 static int get_uart(curry_val v, const char *ctx) {
     if (!has_tag(v, "uart")) curry_error("%s: not a uart handle", ctx);
-    return unpack_fd(curry_cdr(v));
+    return unpack_fd(checked_ptr_cdr(v, "uart", ctx));
 }
 
 static speed_t baud_to_speed(int baud) {
@@ -1076,7 +1090,7 @@ static curry_val wrap_watchdog(int fd) {
 }
 static int get_watchdog(curry_val v, const char *ctx) {
     if (!has_tag(v, "watchdog")) curry_error("%s: not a watchdog handle", ctx);
-    return unpack_fd(curry_cdr(v));
+    return unpack_fd(checked_ptr_cdr(v, "watchdog", ctx));
 }
 
 /* (watchdog-open [timeout-secs]) → watchdog-handle

--- a/modules/sqlite/sqlite.c
+++ b/modules/sqlite/sqlite.c
@@ -31,9 +31,24 @@ static curry_val make_opaque(void *ptr, const char *tag) {
     return curry_make_pair(curry_make_symbol(tag), bv2);
 }
 
-static void *get_opaque(curry_val v) {
+/* Issue #165: get_opaque used to check NOTHING at all -- not even that v
+ * was a pair, let alone that the tag matched or the cdr was really a
+ * pointer-holding bytevector. curry_cdr on a non-pair and
+ * curry_bytevector_ref's own unchecked as_bytes() cast on a non-bytevector
+ * cdr are both wild-pointer hazards. Confirmed reproducible SIGSEGV via
+ * (sqlite-close 42) alone -- no forged pair even needed. Now takes the
+ * expected tag and a context string (matching every other module's
+ * checked-unwrap pattern) so a wrong-handle-type mistake (e.g. passing a
+ * stmt where a db is expected) raises cleanly too, not just a raw
+ * type-confused pointer. */
+static void *get_opaque(curry_val v, const char *tag, const char *ctx) {
+    if (!curry_is_pair(v) || !curry_is_symbol(curry_car(v)) ||
+        strcmp(curry_symbol(curry_car(v)), tag) != 0)
+        curry_error("%s: expected %s handle", ctx, tag);
     curry_val bv = curry_cdr(v);
     void *ptr;
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(ptr))
+        curry_error("%s: expected %s handle", ctx, tag);
     for (size_t i = 0; i < sizeof(ptr); i++)
         ((uint8_t *)&ptr)[i] = curry_bytevector_ref(bv, (uint32_t)i);
     return ptr;
@@ -103,14 +118,14 @@ static curry_val fn_open_memory(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_close(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    ScmDB *w = (ScmDB *)get_opaque(av[0]);
+    ScmDB *w = (ScmDB *)get_opaque(av[0], "sqlite-db", "sqlite-close");
     sqlite3_close(w->db); free(w);
     return curry_void();
 }
 
 static curry_val fn_exec(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    ScmDB *db = (ScmDB *)get_opaque(av[0]);
+    ScmDB *db = (ScmDB *)get_opaque(av[0], "sqlite-db", "sqlite-exec");
     const char *sql = curry_string(av[1]);
 
     sqlite3_stmt *stmt = NULL;
@@ -150,7 +165,7 @@ static curry_val fn_exec(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_prepare(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    ScmDB *db = (ScmDB *)get_opaque(av[0]);
+    ScmDB *db = (ScmDB *)get_opaque(av[0], "sqlite-db", "sqlite-prepare");
     sqlite3_stmt *stmt = NULL;
     int rc = sqlite3_prepare_v2(db->db, curry_string(av[1]), -1, &stmt, NULL);
     if (rc != SQLITE_OK) curry_error("sqlite-prepare: %s", sqlite3_errmsg(db->db));
@@ -160,7 +175,7 @@ static curry_val fn_prepare(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_bind(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    ScmStmt *w = (ScmStmt *)get_opaque(av[0]);
+    ScmStmt *w = (ScmStmt *)get_opaque(av[0], "sqlite-stmt", "sqlite-bind");
     int idx = (int)curry_fixnum(av[1]);
     curry_val val = av[2];
     if (curry_is_bool(val) && !curry_bool(val)) sqlite3_bind_null(w->stmt, idx);
@@ -185,7 +200,7 @@ static curry_val fn_bind(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_step(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    ScmStmt *w = (ScmStmt *)get_opaque(av[0]);
+    ScmStmt *w = (ScmStmt *)get_opaque(av[0], "sqlite-stmt", "sqlite-step");
     int rc = sqlite3_step(w->stmt);
     if (rc == SQLITE_ROW) return row_to_alist(w->stmt);
     if (rc == SQLITE_DONE) return curry_make_bool(false);
@@ -194,20 +209,20 @@ static curry_val fn_step(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_finalize(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    ScmStmt *w = (ScmStmt *)get_opaque(av[0]);
+    ScmStmt *w = (ScmStmt *)get_opaque(av[0], "sqlite-stmt", "sqlite-finalize");
     sqlite3_finalize(w->stmt); free(w);
     return curry_void();
 }
 
 static curry_val fn_last_rowid(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    ScmDB *db = (ScmDB *)get_opaque(av[0]);
+    ScmDB *db = (ScmDB *)get_opaque(av[0], "sqlite-db", "sqlite-last-insert-rowid");
     return curry_make_fixnum((intptr_t)sqlite3_last_insert_rowid(db->db));
 }
 
 static curry_val fn_changes(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    ScmDB *db = (ScmDB *)get_opaque(av[0]);
+    ScmDB *db = (ScmDB *)get_opaque(av[0], "sqlite-db", "sqlite-changes");
     return curry_make_fixnum(sqlite3_changes(db->db));
 }
 

--- a/modules/storage/storage.c
+++ b/modules/storage/storage.c
@@ -88,7 +88,17 @@ static curry_val client_to_val(ClientState *cs) {
 }
 
 static ClientState *val_to_client(curry_val v) {
+    /* Issue #165: this checked NOTHING at all -- not even that v was a
+     * pair, let alone the tag or that the cdr was really a
+     * pointer-holding bytevector. curry_cdr on a non-pair and
+     * curry_bytevector_ref's own unchecked as_bytes() cast on a
+     * non-bytevector cdr are both wild-pointer hazards. */
+    if (!curry_is_pair(v) || !curry_is_symbol(curry_car(v)) ||
+        strcmp(curry_symbol(curry_car(v)), "storage-client") != 0)
+        curry_error("storage: not a storage client handle");
     curry_val bv = curry_cdr(v);
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(ClientState *))
+        curry_error("storage: not a storage client handle");
     ClientState *cs;
     for (size_t i = 0; i < sizeof(ClientState *); i++)
         ((uint8_t *)&cs)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/modules/sync/sync.c
+++ b/modules/sync/sync.c
@@ -41,13 +41,27 @@ static int has_tag(curry_val v, const char *tag) {
            strcmp(curry_symbol(curry_car(v)), tag) == 0;
 }
 
+/* Issue #165: has_tag checked the car, but every get_mutex/get_cond/
+ * get_sem below passed curry_cdr(v) straight to unpack_ptr() with no
+ * curry_is_bytevector/length check -- a forged handle like
+ * (cons 'mutex 42) has the right tag but a non-bytevector cdr, and
+ * curry_bytevector_ref's own unchecked as_bytes() cast then dereferences
+ * the fixnum's raw bit pattern as a pointer. Confirmed reproducible
+ * SIGSEGV via (mutex-lock! (cons 'mutex 42)). */
+static void *checked_unpack_ptr(curry_val v, const char *tag, const char *ctx) {
+    if (!has_tag(v, tag)) curry_error("%s: expected %s", ctx, tag);
+    curry_val bv = curry_cdr(v);
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(void *))
+        curry_error("%s: expected %s", ctx, tag);
+    return unpack_ptr(bv);
+}
+
 /* ---- Mutex ---- */
 static curry_val wrap_mutex(pthread_mutex_t *m) {
     return curry_make_pair(curry_make_symbol("mutex"), pack_ptr(m));
 }
 static pthread_mutex_t *get_mutex(curry_val v, const char *ctx) {
-    if (!has_tag(v, "mutex")) curry_error("%s: expected mutex", ctx);
-    return (pthread_mutex_t *)unpack_ptr(curry_cdr(v));
+    return (pthread_mutex_t *)checked_unpack_ptr(v, "mutex", ctx);
 }
 
 static curry_val fn_mutex_make(int ac, curry_val *av, void *ud) {
@@ -117,8 +131,7 @@ static curry_val wrap_cond(pthread_cond_t *cv) {
     return curry_make_pair(curry_make_symbol("condvar"), pack_ptr(cv));
 }
 static pthread_cond_t *get_cond(curry_val v, const char *ctx) {
-    if (!has_tag(v, "condvar")) curry_error("%s: expected condvar", ctx);
-    return (pthread_cond_t *)unpack_ptr(curry_cdr(v));
+    return (pthread_cond_t *)checked_unpack_ptr(v, "condvar", ctx);
 }
 
 static curry_val fn_cond_make(int ac, curry_val *av, void *ud) {
@@ -181,8 +194,7 @@ static curry_val wrap_sem(ScmSem *s) {
     return curry_make_pair(curry_make_symbol("semaphore"), pack_ptr(s));
 }
 static ScmSem *get_sem(curry_val v, const char *ctx) {
-    if (!has_tag(v, "semaphore")) curry_error("%s: expected semaphore", ctx);
-    return (ScmSem *)unpack_ptr(curry_cdr(v));
+    return (ScmSem *)checked_unpack_ptr(v, "semaphore", ctx);
 }
 
 static curry_val fn_sem_make(int ac, curry_val *av, void *ud) {

--- a/modules/vecdb/vecdb.cpp
+++ b/modules/vecdb/vecdb.cpp
@@ -47,7 +47,14 @@ static curry_val db_to_val(VecDB *db) {
 }
 
 static VecDB *val_to_db(curry_val v) {
+    /* Issue #165: this checked NOTHING at all -- not even a tag, let
+     * alone that the cdr was really a pointer-holding bytevector. */
+    if (!curry_is_pair(v) || !curry_is_symbol(curry_car(v)) ||
+        strcmp(curry_symbol(curry_car(v)), "vecdb") != 0)
+        curry_error("vecdb: not a vector db handle");
     curry_val bv = curry_cdr(v);
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != sizeof(VecDB *))
+        curry_error("vecdb: not a vector db handle");
     VecDB *db;
     for (size_t i = 0; i < sizeof(VecDB *); i++)
         ((uint8_t *)&db)[i] = curry_bytevector_ref(bv, (uint32_t)i);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,41 @@ if(BUILD_MODULE_GIT AND TARGET curry_git)
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
+# No dedicated suites existed for these five modules before issue #165's
+# fix (unchecked handle-argument bytevector cast across most C modules) --
+# each new file covers at least that regression; regex/sync also get full
+# basic-correctness coverage since neither needs external
+# network/server/credential state to exercise.
+if(BUILD_MODULE_REGEX AND TARGET curry_regex)
+    add_test(NAME regex COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/regex_tests.scm)
+    set_tests_properties(regex PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
+if(BUILD_MODULE_SYNC AND TARGET curry_sync)
+    add_test(NAME sync COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/sync_tests.scm)
+    set_tests_properties(sync PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
+if(BUILD_MODULE_STORAGE AND TARGET curry_storage)
+    add_test(NAME storage COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/storage_tests.scm)
+    set_tests_properties(storage PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
+if(BUILD_MODULE_GRAPHQL AND TARGET curry_graphql)
+    add_test(NAME graphql COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/graphql_tests.scm)
+    set_tests_properties(graphql PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
+if(BUILD_MODULE_NEO4J AND TARGET curry_neo4j)
+    add_test(NAME neo4j COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/neo4j_tests.scm)
+    set_tests_properties(neo4j PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
 if(TARGET curry_plplot)
     add_test(NAME plplot COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/test_plplot.scm)
     set_tests_properties(plplot PROPERTIES

--- a/tests/graphql_tests.scm
+++ b/tests/graphql_tests.scm
@@ -1,0 +1,45 @@
+;;; graphql_tests.scm — (curry graphql) issue #165 regression (unchecked
+;;; handle-argument bytevector cast).
+;;;
+;;; No dedicated test file existed for this module before. A live query
+;;; needs a real GraphQL endpoint, so this only covers the #165
+;;; regression -- a forged handle is rejected before any network access
+;;; is ever attempted.
+
+(import (scheme base) (curry graphql))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+;;; ── Issue #165: unchecked handle-argument bytevector cast ───────────
+;;;
+;;; val_to_gql checked NOTHING at all -- not even a tag, let alone that
+;;; the cdr was really a pointer-holding bytevector. Confirmed
+;;; reproducible SIGSEGV via
+;;; (graphql-query (cons 'graphql-client 42) "{x}") pre-fix.
+(check "graphql-query rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (graphql-query (cons 'graphql-client 42) "{x}"))) #t)
+(check "graphql-query rejects a non-pair argument (was a reproducible SIGSEGV)"
+  (raises? (lambda () (graphql-query 42 "{x}"))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/mqtt_tests.scm
+++ b/tests/mqtt_tests.scm
@@ -305,6 +305,18 @@
 
 
 ;;; ================================================================
+;;; Issue #165: malformed handle rejection
+;;; ================================================================
+;;; val_to_conn checked the tag but never checked the cdr was actually a
+;;; pointer-holding bytevector before curry_bytevector_ref's own unchecked
+;;; as_bytes() cast dereferenced whatever was there -- confirmed
+;;; reproducible SIGSEGV via
+;;; (mqtt-publish (cons 'mqtt-conn 42) "t" "p") pre-fix.
+(check "mqtt-publish rejects a forged handle (was a reproducible SIGSEGV)"
+  (guard (exn (#t 'raised)) (mqtt-publish (cons 'mqtt-conn 42) "t" "p"))
+  'raised)
+
+;;; ================================================================
 ;;; Summary
 ;;; ================================================================
 

--- a/tests/neo4j_tests.scm
+++ b/tests/neo4j_tests.scm
@@ -1,0 +1,46 @@
+;;; neo4j_tests.scm — (curry neo4j) issue #165 regression (unchecked
+;;; handle-argument bytevector cast).
+;;;
+;;; No dedicated test file existed for this module before. A live
+;;; connection needs a real Neo4j server, so this only covers the #165
+;;; regression -- a forged handle is rejected before any network access
+;;; is ever attempted.
+
+(import (scheme base) (curry neo4j))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+;;; ── Issue #165: unchecked handle-argument bytevector cast ───────────
+;;;
+;;; conn_unbox checked the tag but never checked the cdr was actually a
+;;; pointer-holding bytevector before curry_bytevector_ref's own
+;;; unchecked as_bytes() cast dereferenced whatever was there --
+;;; confirmed reproducible SIGSEGV via
+;;; (neo4j-disconnect (cons 'neo4j-conn 42)) pre-fix.
+(check "neo4j-disconnect rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (neo4j-disconnect (cons 'neo4j-conn 42)))) #t)
+(check "neo4j-run rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (neo4j-run (cons 'neo4j-conn 42) "RETURN 1"))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/posix_tests.scm
+++ b/tests/posix_tests.scm
@@ -256,6 +256,18 @@
 (check "machine-name is a string or #f"
        (or (string? (machine-name)) (eq? (machine-name) #f)) #t)
 
+;;; Issue #165: checked_ptr_cdr -- read-directory/close-directory checked
+;;; the tag but never checked the cdr was actually a pointer-holding
+;;; bytevector before unpack_ptr's curry_bytevector_ref dereferenced
+;;; whatever was there. Confirmed reproducible SIGSEGV via
+;;; (read-directory (cons 'directory-stream 42)) pre-fix.
+(check "read-directory rejects a forged handle (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (read-directory (cons 'directory-stream 42)))
+       'raised)
+(check "close-directory rejects a forged handle (was a reproducible SIGSEGV)"
+       (guard (exn (#t 'raised)) (close-directory (cons 'directory-stream 42)))
+       'raised)
+
 ;;; Summary
 
 (newline)

--- a/tests/redis_tests.scm
+++ b/tests/redis_tests.scm
@@ -177,6 +177,15 @@
     (redis-del! c-tls "tls:str" "tls:l" "tls:s" "tls:h")
     (redis-close! c-tls)))
 
+;;; ---- Issue #165: malformed handle rejection ----
+;;; val_to_conn checked the tag but never checked the cdr was actually a
+;;; pointer-holding bytevector before curry_bytevector_ref's own unchecked
+;;; as_bytes() cast dereferenced whatever was there -- confirmed
+;;; reproducible SIGSEGV via (redis-close! (cons 'redis-conn 42)) pre-fix.
+(check "redis-close! rejects a forged handle (was a reproducible SIGSEGV)"
+  (guard (exn (#t 'raised)) (redis-close! (cons 'redis-conn 42)))
+  'raised)
+
 ;;; ---- Summary ----
 
 (newline)

--- a/tests/regex_tests.scm
+++ b/tests/regex_tests.scm
@@ -1,0 +1,51 @@
+;;; regex_tests.scm — (curry regex) basic correctness + issue #165
+;;; regression (unchecked handle-argument bytevector cast).
+;;;
+;;; No dedicated test file existed for this module before -- added
+;;; alongside the #165 fix since that fix is specifically about
+;;; get_regex rejecting a forged handle cleanly instead of crashing.
+
+(import (scheme base) (curry regex))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+;;; ── Basic correctness ────────────────────────────────────────────────
+
+(define rx (regex-compile "^[0-9]+$"))
+(check "regex-match on matching input" (regex-match rx "12345") '((0 . 5)))
+(check "regex-match on non-matching input" (regex-match rx "abc") #f)
+(regex-free rx)
+
+;;; ── Issue #165: unchecked handle-argument bytevector cast ───────────
+;;;
+;;; get_regex checked the tag (car) but never checked the cdr was
+;;; actually a pointer-holding bytevector before unpack_ptr's
+;;; curry_bytevector_ref dereferenced whatever was there -- confirmed
+;;; reproducible SIGSEGV via (regex-free (cons 'regex 42)) pre-fix.
+(check "regex-free rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (regex-free (cons 'regex 42)))) #t)
+(check "regex-match rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (regex-match (cons 'regex 42) "x"))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/sqlite_tests.scm
+++ b/tests/sqlite_tests.scm
@@ -67,6 +67,15 @@
 
 (sqlite-close db)
 
+;;; Issue #165: get_opaque checked NOTHING at all before this fix -- not
+;;; even that its argument was a pair, let alone the tag or that the cdr
+;;; was really a pointer-holding bytevector. Confirmed reproducible
+;;; SIGSEGV via (sqlite-close 42) alone, no forged pair even needed.
+(check-error "sqlite-close-rejects-non-handle" (lambda () (sqlite-close 42)))
+(check-error "sqlite-close-rejects-forged-handle"
+  (lambda () (sqlite-close (cons 'sqlite-db 42))))
+(check-error "sqlite-exec-rejects-non-handle" (lambda () (sqlite-exec 42 "SELECT 1")))
+
 (newline)
 (display pass) (display " passed, ")
 (display fail) (display " failed")

--- a/tests/storage_tests.scm
+++ b/tests/storage_tests.scm
@@ -1,0 +1,48 @@
+;;; storage_tests.scm — (curry storage) issue #165 regression (unchecked
+;;; handle-argument bytevector cast).
+;;;
+;;; No dedicated test file existed for this module before. Live S3/GCS/
+;;; Swift/Azure round-trips need real credentials and network access, so
+;;; this only covers the #165 regression -- a forged handle is rejected
+;;; before any client/network state is ever touched.
+
+(import (scheme base) (curry storage))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+;;; ── Issue #165: unchecked handle-argument bytevector cast ───────────
+;;;
+;;; val_to_client checked NOTHING at all -- not even that its argument
+;;; was a pair, let alone the tag or that the cdr was really a
+;;; pointer-holding bytevector. Confirmed reproducible SIGSEGV via
+;;; (swift-put! (cons 'storage-client 42) "a" "b" (make-bytevector 1 0))
+;;; pre-fix.
+(check "swift-put! rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda ()
+             (swift-put! (cons 'storage-client 42) "a" "b" (make-bytevector 1 0))))
+  #t)
+(check "swift-put! rejects a non-pair argument (was a reproducible SIGSEGV)"
+  (raises? (lambda () (swift-put! 42 "a" "b" (make-bytevector 1 0)))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/sync_tests.scm
+++ b/tests/sync_tests.scm
@@ -1,0 +1,59 @@
+;;; sync_tests.scm — (curry sync) basic correctness + issue #165
+;;; regression (unchecked handle-argument bytevector cast).
+;;;
+;;; No dedicated test file existed for this module before.
+
+(import (scheme base) (curry sync))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+;;; ── Basic correctness ────────────────────────────────────────────────
+
+(define m (make-mutex))
+(mutex-lock! m)
+(mutex-unlock! m)
+(check "mutex? on a real mutex" (mutex? m) #t)
+
+(define cv (make-condvar))
+(check "condvar? on a real condvar" (condvar? cv) #t)
+
+(define sem (make-semaphore 1))
+(sem-wait! sem)
+(sem-post! sem)
+(check "semaphore-value after wait/post" (sem-value sem) 1)
+
+;;; ── Issue #165: unchecked handle-argument bytevector cast ───────────
+;;;
+;;; get_mutex/get_cond/get_sem checked the tag but never checked the cdr
+;;; was actually a pointer-holding bytevector before unpack_ptr's
+;;; curry_bytevector_ref dereferenced whatever was there -- confirmed
+;;; reproducible SIGSEGV via (mutex-lock! (cons 'mutex 42)) pre-fix.
+(check "mutex-lock! rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (mutex-lock! (cons 'mutex 42)))) #t)
+(check "condvar wait rejects a forged mutex handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (cond-wait! cv (cons 'mutex 42)))) #t)
+(check "sem-wait! rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (sem-wait! (cons 'semaphore 42)))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))

--- a/tests/test_git.scm
+++ b/tests/test_git.scm
@@ -246,6 +246,13 @@
 
 (check "git-open bad path raises" (raises? (lambda () (git-open "/nonexistent/path/xyz"))) #t)
 
+;;; Issue #165: val_to_repo checked the tag but never checked the cdr was
+;;; actually a pointer-holding bytevector before curry_bytevector_ref's own
+;;; unchecked as_bytes() cast dereferenced whatever was there -- confirmed
+;;; reproducible SIGSEGV via (git-close! (cons 'git-repo 42)) pre-fix.
+(check "git-close! rejects a forged handle (was a reproducible SIGSEGV)"
+  (raises? (lambda () (git-close! (cons 'git-repo 42)))) #t)
+
 ;;; ── Summary ──────────────────────────────────────────────────────────────
 
 (newline)


### PR DESCRIPTION
## Summary

Closes #165.

Every one of these modules represents an opaque native handle as `(tag-symbol . bytevector-of-packed-pointer)`. The unwrap helper checked the tag but never checked the cdr was actually a bytevector (or, in a few cases — `sqlite.c`, `storage.c`, `graphql.c`, `vecdb.cpp` — checked nothing at all, not even the tag). Same bug class as #158/#161: `curry_bytevector_ref`/`_length` do an unchecked `as_bytes()` cast assuming the argument already IS a bytevector, so a forged handle like `(cons 'redis-conn 42)` dereferences a fixnum's raw tagged bit pattern as a pointer.

Confirmed reproducible SIGSEGV pre-fix (now confirmed clean) in every module this environment builds by default: redis, regex, sqlite, mqtt, storage, graphql, sync, git, neo4j, posix. Also fixed by source inspection, matching the identical established pattern (not build-verified — OFF by default and not built in CI): ldap, piper, vecdb, qt6, and Linux-only rpi (8 handle types).

Fix shape varies by what each module already had:
- Sites that already checked the tag correctly (redis, mqtt, git, neo4j, qt6) just needed the missing `curry_is_bytevector` + exact-length check added.
- Sites checking nothing at all (sqlite, storage, graphql, vecdb) got both the tag and bytevector checks. `sqlite.c`'s `get_opaque` now also takes the expected tag, so a stmt/db type confusion raises cleanly too.
- Sites with an existing `has_tag()`/`unpack_ptr()` pair spread across many call sites (sync, posix, rpi) got a single shared checked-unwrap helper added once, mirroring how #173 fixed `port.c`/`set.c`.

Added `tests/regex_tests.scm`, `storage_tests.scm`, `graphql_tests.scm`, `sync_tests.scm`, `neo4j_tests.scm` (no dedicated suite existed for any of these five before) and extended `redis_tests.scm`, `mqtt_tests.scm`, `sqlite_tests.scm`, `test_git.scm`, `posix_tests.scm` with the forged-handle regression for each.

## Review

Two independent fresh subagents (code review + security review) — scaled up given the scope (14 files):

- Both rebuilt and confirmed all originally-reported repros now raise cleanly across all 10 buildable modules.
- Code review verified `sqlite.c`'s 8 `get_opaque` call sites all pass the correct tag, and did a fresh grep confirming no other module has the same handle-unwrap pattern outside the 14 already fixed.
- Security review went further than the one repro per module named in the issue — stress-tested 30+ handle-consuming functions across all 10 modules (not just `redis-close!`/`mqtt-publish`/etc., but `redis-get`/`git-log`/`neo4j-run`/every `sem-*`/`mutex-*`/`cond-*` function, and more), plus wrong-length (not just wrong-type) bytevectors, plus cross-type confusion (a tx-tagged neo4j handle where a conn is expected, a mutex-tagged handle where a condvar is expected, a db passed where a stmt is expected) — all rejected cleanly. Confirmed the shared-helper modules (sync/posix/rpi) use the correct tag string and `sizeof` at every call site, no copy-paste mixups.
- Security review also surfaced two findings — filed as #177, then closed as a duplicate once confirmed they're the same already-open #167 (`image.c` forged-vector OOB) and #169 (`qt6.cpp` data-argument casts).

## Test plan

- [x] `ctest --test-dir build --output-on-failure` — 124/124 suites pass (fresh `--clear-cache` run, 5 new suites)
- [x] Manual repro of every originally-reported crash site across all 10 buildable modules, confirmed fixed
- [x] Correct-handle usage (real mutex, real sqlite db/stmt cycle, real regex compile/match/free) confirmed unaffected
- [x] Two independent review agents (code + security) — both confirmed correct and complete; no further findings within #165's scope

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
