### PR TITLE
fix(image): forged image vector caused a real out-of-bounds heap read/write (#167)

### DIFF
--- a/modules/image/image.c
+++ b/modules/image/image.c
@@ -64,8 +64,38 @@ static curry_val make_image(uint32_t w, uint32_t h, uint32_t ch) {
     return v;
 }
 
+/* Issue #167: this used to check only that slot 0 was a fixnum -- not
+ * even that v itself was a vector (curry_vector_ref(v,0) does an
+ * unchecked as_vec() cast, so (image-width 42) SIGSEGVed before this
+ * check could even run), and never that slot 3 was really a bytevector
+ * or that its length matched the claimed width*height*channels. Since
+ * images are plain R7RS vectors, any Scheme code can forge one with
+ * (vector w h ch anything) using attacker-controlled w/h/ch alongside a
+ * too-small or wrong-typed slot 3 -- px_get/px_set then bounds-check only
+ * against the *forged* w/h/ch before reading/writing that slot 3 value,
+ * producing a real out-of-bounds heap read or write. Confirmed
+ * reproducible SIGSEGV (OOB write) via
+ * (image-set! (vector 100000 100000 4 (make-string 1 #\a)) 99999 99999 3 255).
+ * Now validates the whole shape: v is a 4-element vector, slots 0-2 are
+ * positive fixnums (with the same overflow guard make_image's own w*h*ch
+ * multiplication uses -- a forged w*h*ch that overflows back down to a
+ * small value must not be treated as valid just because it happens to
+ * match a small bytevector's length), and slot 3 is a bytevector whose
+ * length exactly equals width*height*channels. */
 static void check_image(curry_val v) {
-    if (!curry_is_fixnum(curry_vector_ref(v,0)))
+    if (!curry_is_vector(v) || curry_vector_length(v) != 4)
+        curry_error("image: not a valid image object");
+    curry_val wv = curry_vector_ref(v,0), hv = curry_vector_ref(v,1),
+              chv = curry_vector_ref(v,2), bv = curry_vector_ref(v,3);
+    if (!curry_is_fixnum(wv) || !curry_is_fixnum(hv) || !curry_is_fixnum(chv))
+        curry_error("image: not a valid image object");
+    intptr_t w = curry_fixnum(wv), h = curry_fixnum(hv), ch = curry_fixnum(chv);
+    if (w <= 0 || h <= 0 || ch <= 0 || ch > 4 || w > UINT32_MAX || h > UINT32_MAX)
+        curry_error("image: not a valid image object");
+    uint32_t uw = (uint32_t)w, uh = (uint32_t)h, uch = (uint32_t)ch;
+    if (uh > UINT32_MAX / uw || (uint64_t)uw * uh > UINT32_MAX / uch)
+        curry_error("image: not a valid image object");
+    if (!curry_is_bytevector(bv) || curry_bytevector_length(bv) != uw * uh * uch)
         curry_error("image: not a valid image object");
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -215,6 +215,14 @@ if(BUILD_MODULE_NEO4J AND TARGET curry_neo4j)
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
+# No dedicated suite existed for (curry image) before issue #167's fix
+# (forged image vector causes an OOB heap read/write).
+if(BUILD_MODULE_IMAGE AND TARGET curry_image)
+    add_test(NAME image COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/image_tests.scm)
+    set_tests_properties(image PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
 if(TARGET curry_plplot)
     add_test(NAME plplot COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/test_plplot.scm)
     set_tests_properties(plplot PROPERTIES

--- a/tests/image_tests.scm
+++ b/tests/image_tests.scm
@@ -1,0 +1,69 @@
+;;; image_tests.scm — (curry image) basic correctness + issue #167
+;;; regression (forged image vector causes an OOB heap read/write).
+;;;
+;;; No dedicated test file existed for this module before.
+
+(import (scheme base) (curry image))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+;;; ── Basic correctness ────────────────────────────────────────────────
+
+(define img (image-make 4 4 3))
+(check "image-width"    (image-width img)    4)
+(check "image-height"   (image-height img)   4)
+(check "image-channels" (image-channels img) 3)
+(image-set! img 1 2 0 200)
+(check "image-ref after image-set!" (image-ref img 1 2 0) 200)
+(check "image-ref default is 0" (image-ref img 0 0 0) 0)
+(check "image-pixels length" (bytevector-length (image-pixels img)) (* 4 4 3))
+
+;;; ── Issue #167: forged image vector causes an OOB heap read/write ───
+;;;
+;;; check_image previously only verified slot 0 was a fixnum -- not even
+;;; that the argument was a vector at all (curry_vector_ref does an
+;;; unchecked cast), and never that slot 3 was really a bytevector or
+;;; that its length matched the claimed width*height*channels. Confirmed
+;;; reproducible SIGSEGV (an out-of-bounds heap WRITE, not just a read)
+;;; pre-fix via a forged (vector 100000 100000 4 tiny-string).
+(check "image-width rejects a non-vector argument (was a reproducible SIGSEGV)"
+  (raises? (lambda () (image-width 42))) #t)
+(check "image-set! rejects a forged vector with an oversized claimed size (was a reproducible SIGSEGV -- OOB write)"
+  (raises? (lambda ()
+             (image-set! (vector 100000 100000 4 (make-string 1 #\a)) 99999 99999 3 255)))
+  #t)
+(check "image-ref rejects a forged vector with a wrong-typed slot 3 (was a reproducible SIGSEGV)"
+  (raises? (lambda () (image-ref (vector 10 10 3 42) 0 0 0))) #t)
+(check "image-set! rejects a real bytevector that's too short for the claimed dimensions"
+  (raises? (lambda ()
+             (image-set! (vector 100 100 4 (make-bytevector 4 0)) 99 99 3 255)))
+  #t)
+(check "image-ref rejects dimensions that overflow width*height*channels"
+  (raises? (lambda ()
+             (image-ref (vector 4294967295 4294967295 4 (make-bytevector 16 0)) 0 0 0)))
+  #t)
+(check "image-ref rejects a wrong-length vector (not 4 elements)"
+  (raises? (lambda () (image-ref (vector 10 10 3) 0 0 0))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

Closes #167.

Images are plain R7RS vectors `#(width height channels bytevector)`. `check_image()` previously only verified slot 0 was a fixnum — not even that the argument was a vector at all (`curry_vector_ref` does an unchecked `as_vec()` cast, so `(image-width 42)` SIGSEGVed before this check could even run), and never that slot 3 was really a bytevector or that its length matched the claimed `width*height*channels`. Since images are bare vectors, any Scheme code can forge one with `(vector w h ch anything)` using attacker-controlled `w`/`h`/`ch` alongside a too-small or wrong-typed slot-3 payload — `px_get`/`px_set` then bounds-check only against the *forged* dimensions. Confirmed reproducible SIGSEGV — a real out-of-bounds heap **write**, not just a read — via `(image-set! (vector 100000 100000 4 (make-string 1 #\a)) 99999 99999 3 255)`.

`check_image()` now validates the whole shape: `v` is a 4-element vector, slots 0-2 are positive fixnums within valid range, an overflow-safe `width*height*channels` check (mirroring `make_image`'s own existing overflow guard in the same file), and slot 3 is a bytevector whose length exactly equals `width*height*channels`. Every image-consuming primitive already routes through `check_image` first, so fixing this one function closes the gap everywhere.

Added `tests/image_tests.scm` (no dedicated suite existed for this module before) with basic correctness plus regression coverage for the forged-vector class of bug.

## Review

Two independent fresh subagents (code review + security review):

- Both rebuilt and confirmed the original repro plus every adversarial variant they could construct (3/5-element vectors, negative/zero width, channels 0/5/huge, bytevector one byte short/long, overflow boundaries at `UINT32_MAX`) all raise cleanly with no crash, and a correctly-shaped image is still legitimately accepted.
- Security review specifically checked the TOCTOU-shaped case — mutating a valid image's slot 3 via `vector-set!` *after* construction — and confirmed `check_image` catches it fresh on the next call, since validation is per-call, not cached from construction time.
- Code review traced every `img_bv`/`px_get`/`px_set` call site and confirmed all are gated by `check_image` first, including the loop-heavy ops (`crop`/`scale`/flips) which check once up front correctly.
- Both flagged adjacent, out-of-scope findings, correctly filed separately rather than folded in here: code review noted `image.c` has some unchecked `curry_fixnum` casts elsewhere (confirmed non-exploitable — downstream bounds checks catch them; optional follow-up, not filed). Security review found real, distinct issues in `qt6.cpp`/`vecdb.cpp` (data-payload argument casts) — the qt6 portion turned out to duplicate already-open #169 (cross-linked with a confirmation comment), the vecdb portion is new and filed as #179.

## Test plan

- [x] `./build/curry --clear-cache tests/image_tests.scm` — 12/12 pass
- [x] `ctest --test-dir build --output-on-failure` — 125/125 suites pass (fresh `--clear-cache` run, 1 new suite)
- [x] Manual repro of the original crash plus adversarial boundary cases, confirmed fixed
- [x] Two independent review agents (code + security) — both confirmed correct and complete; no further findings within #167's scope

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
