### PR TITLE
fix(qt6,vecdb): reject unchecked bytevector/vector casts on data-payload args (#169, #179)

### DIFF
--- a/modules/qt6/qt6.cpp
+++ b/modules/qt6/qt6.cpp
@@ -1568,6 +1568,11 @@ static curry_val fn_gl_shader_draw(int argc, curry_val *av, void *) {
  * (make-gl-texture bv w h 'rgba)    ; RGBA8 four-channel
  * (make-gl-texture bv w h 'rgba32f) ; RGBA 32-bit float (raw float bytes) */
 static curry_val fn_make_gl_texture(int argc, curry_val *av, void *) {
+    /* Issue #169: no curry_is_bytevector check on av[0] before
+     * curry_bytevector_length/_ref's unchecked as_bytes() cast -- same
+     * wild-pointer hazard #158/#161/#166 closed elsewhere. Confirmed
+     * reproducible SIGSEGV via (make-gl-texture 42 8 8). */
+    if (!curry_is_bytevector(av[0])) curry_error("make-gl-texture: not a bytevector");
     uint32_t n = curry_bytevector_length(av[0]);
     int w = (int)curry_fixnum(av[1]);
     int h = (int)curry_fixnum(av[2]);
@@ -1594,6 +1599,9 @@ static curry_val fn_make_gl_texture(int argc, curry_val *av, void *) {
 static curry_val fn_gl_texture_update(int argc, curry_val *av, void *) {
     (void)argc;
     GlTexture *tex = (GlTexture *)val_to_ptr("gl-texture", av[0]);
+    /* Issue #169: same gap as fn_make_gl_texture, on av[1]. Confirmed
+     * reproducible SIGSEGV via (gl-texture-update! tex 42). */
+    if (!curry_is_bytevector(av[1])) curry_error("gl-texture-update!: not a bytevector");
     uint32_t n = curry_bytevector_length(av[1]);
     tex->data.resize(n);
     for (uint32_t i = 0; i < n; i++)
@@ -2186,8 +2194,20 @@ static curry_val fn_gfx_draw_image(int ac, curry_val *av, void *ud) {
     double    dw = curry_float(av[3]), dh = curry_float(av[4]);
     curry_val bv = av[5];
     int       iw = (int)curry_float(av[6]), ih = (int)curry_float(av[7]);
-    QImage img(iw, ih, QImage::Format_RGBA8888);
+    /* Issue #169: bv was never checked with curry_is_bytevector before
+     * curry_bytevector_ref's unchecked as_bytes() cast, and even for a
+     * genuine bytevector, `total` was computed from separate
+     * caller-supplied iw/ih with no check that it doesn't exceed the
+     * bytevector's real backing length -- a too-short (or negative-
+     * dimensioned) argument still read/wrote out of bounds. Confirmed
+     * reproducible SIGSEGV via (gfx-draw-image! painter 0 0 10 10 42 4 4)
+     * and via a genuine but too-short bytevector. */
+    if (iw <= 0 || ih <= 0) curry_error("gfx-draw-image!: image dimensions must be positive");
     int total = iw * ih * 4;
+    if (!curry_is_bytevector(bv)) curry_error("gfx-draw-image!: not a bytevector");
+    if (curry_bytevector_length(bv) < (uint32_t)total)
+        curry_error("gfx-draw-image!: bytevector too short for %dx%d RGBA image", iw, ih);
+    QImage img(iw, ih, QImage::Format_RGBA8888);
     for (int i = 0; i < total; i++)
         img.bits()[i] = curry_bytevector_ref(bv, (uint32_t)i);
     p->drawImage(QRectF(dx,dy,dw,dh), img);

--- a/modules/vecdb/vecdb.cpp
+++ b/modules/vecdb/vecdb.cpp
@@ -90,10 +90,30 @@ static curry_val fn_make(int ac, curry_val *av, void *ud) {
     return db_to_val(db);
 }
 
+/* Issue #179: neither fn_add nor fn_search checked that the vector
+ * argument was actually a vector at all before curry_vector_length/_ref
+ * (an unchecked as_vec() cast, same class as #167's forged-image-vector
+ * bug), nor that each ELEMENT was actually numeric before curry_float --
+ * which is itself unchecked for anything but a fixnum/flonum (vfloat(v)
+ * is a raw as_flo(v)->value cast), so e.g. a vector containing a string
+ * or symbol would still wild-cast even after only checking the outer
+ * vector. Confirmed reproducible SIGSEGV via
+ * (vecdb-add db 1 42) and (vecdb-add db 1 (vector "x")). */
+static void check_numeric_vector(curry_val v, const char *who) {
+    if (!curry_is_vector(v)) curry_error("%s: not a vector", who);
+    uint32_t n = curry_vector_length(v);
+    for (uint32_t i = 0; i < n; i++) {
+        curry_val e = curry_vector_ref(v, i);
+        if (!curry_is_fixnum(e) && !curry_is_float(e))
+            curry_error("%s: vector element %u is not a real number", who, i);
+    }
+}
+
 static curry_val fn_add(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
     VecDB *db = val_to_db(av[0]);
     long id   = (long)curry_fixnum(av[1]);
+    check_numeric_vector(av[2], "vecdb-add");
     uint32_t n = curry_vector_length(av[2]);
     if ((int)n != db->dims)
         curry_error("vecdb-add: vector has %u dimensions, expected %d", n, db->dims);
@@ -106,6 +126,7 @@ static curry_val fn_add(int ac, curry_val *av, void *ud) {
 static curry_val fn_search(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
     VecDB *db  = val_to_db(av[0]);
+    check_numeric_vector(av[1], "vecdb-search");
     uint32_t n = curry_vector_length(av[1]);
     if ((int)n != db->dims)
         curry_error("vecdb-search: query vector has %u dimensions, expected %d", n, db->dims);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -388,6 +388,14 @@ if(BUILD_MODULE_TYPEDVEC AND TARGET curry_typedvec AND BUILD_MODULE_F64VECTOR AN
         ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
 endif()
 
+# No dedicated suite existed for (curry vecdb) before issue #179's fix
+# (unchecked vector/element casts on vecdb-add/vecdb-search's data args).
+if(BUILD_MODULE_VECDB AND TARGET curry_vecdb)
+    add_test(NAME vecdb COMMAND curry --clear-cache ${CMAKE_CURRENT_SOURCE_DIR}/vecdb_tests.scm)
+    set_tests_properties(vecdb PROPERTIES
+        ENVIRONMENT "CURRY_MODULE_PATH=${MOD_PATH}")
+endif()
+
 if(BUILD_MODULE_QT6 AND TARGET curry_qt6)
     # Phase 1 (widget creation) runs immediately; Phase 2 (painter / text
     # metrics) triggers an offscreen render via canvas-save-png!.

--- a/tests/test_qt6_new.scm
+++ b/tests/test_qt6_new.scm
@@ -196,6 +196,45 @@
             (lambda (v) (> v ht-12))
             ht-after-font-change)
 
+;;; ── Phase 3: issue #169 regression (unchecked bytevector data-argument
+;;; casts in make-gl-texture/gl-texture-update!/gfx-draw-image!) ─────────────
+;;;
+;;; None of these checked their bytevector data argument at all before
+;;; curry_bytevector_length/_ref's unchecked as_bytes() cast -- same class
+;;; as #158/#161/#166/#167. gfx-draw-image! additionally computed its read
+;;; loop bound from separate caller-supplied width/height arguments with no
+;;; check against the bytevector's real backing length.
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+(check "make-gl-texture rejects a non-bytevector argument (was a reproducible SIGSEGV)"
+       (raises? (lambda () (make-gl-texture 42 8 8))) #t)
+(check "make-gl-texture still works with a real bytevector"
+       (raises? (lambda () (make-gl-texture (make-bytevector 64 0) 8 8))) #f)
+
+(check "gl-texture-update! rejects a non-bytevector argument (was a reproducible SIGSEGV)"
+       (raises? (lambda ()
+                  (gl-texture-update! (make-gl-texture (make-bytevector 64 0) 8 8) 42)))
+       #t)
+
+(call-with-painter 100 100
+  (lambda (painter)
+    (check "gfx-draw-image! rejects a non-bytevector argument (was a reproducible SIGSEGV)"
+           (raises? (lambda () (gfx-draw-image! painter 0 0 10 10 42 4 4))) #t)
+    (check "gfx-draw-image! rejects a too-short bytevector (was a reproducible SIGSEGV / OOB read)"
+           (raises? (lambda ()
+                      (gfx-draw-image! painter 0 0 10 10 (make-bytevector 4 0) 4 4)))
+           #t)
+    (check "gfx-draw-image! rejects non-positive dimensions"
+           (raises? (lambda ()
+                      (gfx-draw-image! painter 0 0 10 10 (make-bytevector 64 0) -1 4)))
+           #t)
+    (check "gfx-draw-image! still works with a correctly-sized bytevector"
+           (raises? (lambda ()
+                      (gfx-draw-image! painter 0 0 10 10 (make-bytevector 64 128) 4 4)))
+           #f)))
+
 ;;; ── Summary ──────────────────────────────────────────────────────────────────
 
 (newline)

--- a/tests/vecdb_tests.scm
+++ b/tests/vecdb_tests.scm
@@ -1,0 +1,61 @@
+;;; vecdb_tests.scm — (curry vecdb) basic correctness + issue #179
+;;; regression (unchecked vector/element casts on data-payload args).
+;;;
+;;; No dedicated test file existed for this module before.
+
+(import (scheme base) (curry vecdb))
+
+(define pass 0)
+(define fail 0)
+
+(define (check label got expected)
+  (if (equal? got expected)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! pass (+ pass 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " — got ") (write got)
+             (display "  expected ") (write expected) (newline)
+             (set! fail (+ fail 1)))))
+
+(define (raises? thunk)
+  (guard (e (#t #t)) (thunk) #f))
+
+;;; ── Basic correctness ────────────────────────────────────────────────
+
+(define db (vecdb-make 3))
+(vecdb-add db 1 (vector 1.0 0.0 0.0))
+(vecdb-add db 2 (vector 0.0 1.0 0.0))
+(vecdb-add db 3 (vector 0.0 0.0 1.0))
+(check "vecdb-size after three adds" (vecdb-size db) 3)
+(check "vecdb-search finds the exact match first"
+  (caar (vecdb-search db (vector 1.0 0.0 0.0) 1)) 1)
+(vecdb-remove db 1)
+(check "vecdb-size after remove" (vecdb-size db) 2)
+
+;;; ── Issue #179: unchecked vector/element casts on data-payload args ────
+;;;
+;;; vecdb-add/vecdb-search never checked their vector argument was
+;;; actually a vector before curry_vector_length/_ref's unchecked
+;;; as_vec() cast -- same class as #167's forged-image-vector bug. Even
+;;; after checking the outer vector, each ELEMENT also needs to be
+;;; numeric before curry_float, which is itself unchecked for anything
+;;; but a fixnum/flonum. Confirmed reproducible SIGSEGV via
+;;; (vecdb-add db 1 42) and (vecdb-add db 1 (vector "x" 1 2)) pre-fix.
+(check "vecdb-add rejects a non-vector argument (was a reproducible SIGSEGV)"
+  (raises? (lambda () (vecdb-add db 4 42))) #t)
+(check "vecdb-add rejects a vector with a non-numeric element (was a reproducible SIGSEGV)"
+  (raises? (lambda () (vecdb-add db 4 (vector "x" 1 2)))) #t)
+(check "vecdb-search rejects a non-vector argument (was a reproducible SIGSEGV)"
+  (raises? (lambda () (vecdb-search db 42 1))) #t)
+(check "vecdb-search rejects a vector with a non-numeric element (was a reproducible SIGSEGV)"
+  (raises? (lambda () (vecdb-search db (vector 'a 'b 'c) 1))) #t)
+
+;;; ════════════════════════════════════════════════════════════
+;;; Summary
+;;; ════════════════════════════════════════════════════════════
+
+(newline)
+(display pass) (display " passed, ")
+(display fail) (display " failed")
+(newline)
+(if (> fail 0) (exit 1) (exit 0))


### PR DESCRIPTION
## Summary

Closes #169, closes #179.

Same recurring bug class as #158/#161/#166/#167/#165, this time in two modules OFF by default in CMake (`BUILD_MODULE_QT6`, `BUILD_MODULE_VECDB`) that were never build-verified in earlier rounds of this chain — but both are actually buildable in this environment (Qt6 via Homebrew, vecdb has no real external dependency despite its own comment claiming one), so this fix is fully build- and runtime-verified, not source-inspection-only.

**`modules/qt6/qt6.cpp` (#169)**:
- `fn_make_gl_texture`/`fn_gl_texture_update`: neither checked their bytevector data argument at all before `curry_bytevector_length`/`_ref`'s unchecked `as_bytes()` cast. Confirmed reproducible SIGSEGV via `(make-gl-texture 42 8 8)`.
- `fn_gfx_draw_image`: same gap, plus the read loop bound (`iw*ih*4`) was computed from separate caller-supplied width/height with no check against the bytevector's real backing length — a genuine bytevector that's merely too short still read out of bounds, the same "trusted size fields vs. real length" gap #167 fixed for images. Also added an `iw/ih > 0` guard (negative/zero dimensions previously produced a null `QImage` whose `->bits()` is a null pointer).

**`modules/vecdb/vecdb.cpp` (#179)**:
- `fn_add`/`fn_search`: neither checked their vector argument was actually a vector before `curry_vector_length`/`_ref`'s unchecked `as_vec()` cast. Additionally, even a genuine vector's *elements* were never checked as numeric before `curry_float`, which is itself unchecked for anything but a fixnum/flonum (`vfloat(v)` is a raw `as_flo(v)->value` cast) — so a vector containing a string would still wild-cast even with only an outer vector check. Added a shared `check_numeric_vector()` helper validating both layers.

Added `tests/vecdb_tests.scm` (no dedicated suite existed before) and extended `tests/test_qt6_new.scm` using the existing headless `call-with-painter` pattern (no display needed).

**CI note**: neither module is enabled in CI's default build, so these changes and their new tests won't actually run there — verification happened locally with both explicitly enabled (`-DBUILD_MODULE_VECDB=ON -DBUILD_MODULE_QT6=ON -DCMAKE_PREFIX_PATH="$(brew --prefix qtbase)"`, `QT_QPA_PLATFORM=offscreen` for qt6's headless tests).

## Review

Two independent fresh subagents (code review + security review), each rebuilding with both modules explicitly enabled:

- Both confirmed all three qt6 checks are correctly placed and comprehensive (tested far beyond the one repro per function — booleans, chars, pairs, symbols, vectors, hash-tables all correctly rejected).
- Both confirmed the length check in `fn_gfx_draw_image` uses `<` not `!=` (a slightly-longer bytevector is intentionally still accepted) and correctly rejects a too-short one.
- Security review specifically stress-tested the most important question — whether `check_numeric_vector`'s `curry_is_fixnum || curry_is_float` precondition correctly rejects bignums/rationals rather than silently letting them reach the unchecked `curry_float` — confirmed yes, both live under distinct type tags that never reach the unsafe path. Also confirmed the pre-existing dims-mismatch error still fires correctly alongside the new checks.
- Both reviews independently found the same five additional unguarded `curry_vector_ref`/`_length` sites elsewhere in `qt6.cpp` (`gfx-draw-points!`, `gfx-draw-lines!`, `gfx-fill-triangles!`, `project-4d`, `rotate-4d-xw`) — outside this fix's scope, correctly not folded in. Code review filed #181 (source-inspection); security review independently filed #182 with runtime-confirmed repros plus two more nuances (a length-mismatch case, and a sixth "container checked, elements not" gap in `glbuf_load_data`). #181 closed as superseded by the more complete #182.

## Test plan

- [x] `QT_QPA_PLATFORM=offscreen ctest --test-dir build --output-on-failure` (both modules enabled) — 127/127 suites pass (fresh `--clear-cache` run, 1 new suite: vecdb)
- [x] Manual repro of every originally-reported crash site plus adversarial variants (wrong types, mixed valid/invalid vector elements, length mismatches, boundary lengths), confirmed fixed
- [x] Real end-to-end usage (texture creation, `gfx-draw-image!` with a valid bytevector, vecdb add/search cycle) confirmed unaffected
- [x] Two independent review agents (code + security) — both confirmed correct and complete; adjacent findings filed as follow-ups, not folded in

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
