### PR TITLE
fix(vm): synchronize per-Chunk glob_cache entries across actor threads (#162)

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -131,6 +131,7 @@ Chunk *chunk_new(void) {
     c->name       = NULL;
     c->source_name = NULL;
     c->glob_cache = NULL;
+    c->glob_cache_lock = 0;
     c->tree_eval_cache = NULL;
     c->local_debug = NULL;
     c->local_debug_len = 0;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -57,6 +57,20 @@ typedef struct {
                                  caller-owned, must outlive the chunk     */
 
     GlobCacheEntry *glob_cache; /* parallel to constants[], filled lazily; GC-traced */
+    /* Issue #162 follow-up: a coarse spinlock (0=unlocked, 1=locked)
+     * serializing WRITES to glob_cache entries only -- reads stay fully
+     * lock-free via vm.c's gcache_load. Without this, two actor threads
+     * racing a cache-fill for the SAME entry (e.g. both miss around a
+     * concurrent GLOBAL_ENV frame_grow) could interleave their two
+     * independent field writes into a torn (slot, version) pair that
+     * neither writer produced -- gcache_load/gcache_store's acquire/
+     * release pairing only protects one writer against readers, not
+     * writer against writer. Cache fills are infrequent (a miss, or an
+     * explicit define/set!), never the hot read path, so a spinlock here
+     * costs nothing in practice. Zero-initialized like every other Chunk
+     * field (chunk_new), so unlocked by default with no explicit init
+     * needed on the .scc-load path either. */
+    int glob_cache_lock;
 
     /* Per-call-site cache for OP_TREE_EVAL_CACHED (the tree-eval
      * passthrough for import/define-library/library -- see

--- a/src/vm.c
+++ b/src/vm.c
@@ -495,6 +495,66 @@ static int vm_bind_args(BcClosure *cl, val_t *base, int argc) {
     return fixed + 1;
 }
 
+/* Issue #162: a Chunk's glob_cache is shared by every actor thread
+ * executing that compiled chunk concurrently (the normal case for N
+ * actors spawned from one shared lambda literal). root->version is
+ * already read/written with proper acquire/release (matching env.c's
+ * seqlock release store on frame_grow), but cache[ci].slot/.version
+ * themselves were plain, unsynchronized reads/writes -- so one thread's
+ * write could race another's read with no ordering between them,
+ * letting a reader observe a torn pair (a fresh version stamped next to
+ * a stale slot, or vice versa, mixed from two different writers) and
+ * wrongly take the fast path through a slot that doesn't correspond to
+ * the version it appears to match.
+ *
+ * Fixed the same way root->version already is: version is the
+ * synchronizing field (release on write, acquire on read); slot is
+ * relaxed but always written BEFORE version's release and read AFTER
+ * version's acquire, so a reader that observes a fresh version is
+ * guaranteed -- by the release/acquire pairing -- to also observe the
+ * slot write that preceded it, never a stale one from THE SAME writer.
+ * Reading version first (rather than checking slot != NULL first, as
+ * this code used to) is what makes that guarantee hold: the old order
+ * let a reader load a possibly-stale slot before even checking whether
+ * version had changed underneath it.
+ *
+ * That acquire/release pairing alone only protects one writer against
+ * concurrent readers -- it does NOT protect one writer against another
+ * concurrent writer. Two threads racing a cache-fill for the SAME entry
+ * (e.g. both miss around a concurrent GLOBAL_ENV frame_grow, so thread A
+ * computes a pre-grow (slot, ver) and thread B computes a post-grow
+ * (slot, ver) for the same index) could interleave their two independent
+ * stores into a torn pair neither of them produced: A's slot store, then
+ * B's slot store, then B's version release, then A's version release
+ * leaves (B's slot, A's version) visible -- a combination from neither
+ * writer. gcache_lock/gcache_unlock below close that by serializing
+ * WRITES only (reads stay fully lock-free through gcache_load, which is
+ * still what makes the fast path fast); see chunk.h's own comment on
+ * Chunk.glob_cache_lock for why a spinlock is cheap enough here (fills
+ * are rare, never the hot read path). */
+static inline void gcache_load(GlobCacheEntry *e, val_t **slot_out, uint32_t *ver_out) {
+    *ver_out  = atomic_load_explicit((_Atomic uint32_t *)&e->version, memory_order_acquire);
+    *slot_out = atomic_load_explicit((_Atomic(val_t *) *)&e->slot, memory_order_relaxed);
+}
+static inline void gcache_lock(Chunk *chunk) {
+    int expected = 0;
+    while (!atomic_compare_exchange_weak_explicit(
+               (_Atomic int *)&chunk->glob_cache_lock, &expected, 1,
+               memory_order_acquire, memory_order_relaxed)) {
+        expected = 0; /* CAS clobbers expected on failure; reset before retry */
+    }
+}
+static inline void gcache_unlock(Chunk *chunk) {
+    atomic_store_explicit((_Atomic int *)&chunk->glob_cache_lock, 0, memory_order_release);
+}
+static inline void gcache_store(Chunk *chunk, uint8_t ci, val_t *slot, uint32_t ver) {
+    gcache_lock(chunk);
+    GlobCacheEntry *e = &chunk->glob_cache[ci];
+    atomic_store_explicit((_Atomic(val_t *) *)&e->slot, slot, memory_order_relaxed);
+    atomic_store_explicit((_Atomic uint32_t *)&e->version, ver, memory_order_release);
+    gcache_unlock(chunk);
+}
+
 /* Shared cached global-variable lookup for OP_CALL_GLOBAL/
  * OP_TAIL_CALL_GLOBAL, which need this exact lookup fused with a call
  * rather than as a separate dispatch. Mirrors (does not replace)
@@ -510,15 +570,17 @@ static inline val_t load_global_cached(Chunk *chunk, uint8_t ci) {
     GlobCacheEntry *cache = chunk->glob_cache;
     EnvFrame *root = as_env(chunk->target_env == V_VOID ? GLOBAL_ENV : chunk->target_env);
     uint32_t root_ver = atomic_load_explicit((_Atomic uint32_t *)&root->version, memory_order_acquire);
-    if (__builtin_expect(cache != NULL && cache[ci].slot != NULL &&
-                         cache[ci].version == root_ver, 1)) {
-        return *cache[ci].slot;
+    if (cache) {
+        val_t *cslot; uint32_t cver;
+        gcache_load(&cache[ci], &cslot, &cver);
+        if (__builtin_expect(cslot != NULL && cver == root_ver, 1))
+            return *cslot;
     }
     val_t sym = chunk->constants[ci];
     uint32_t ver;
     val_t *slot = frame_lookup_versioned(root, sym, &ver);
     if (!slot) scm_raise_code(EC_UNBOUND_VARIABLE, "unbound variable: %s", sym_cstr(sym));
-    if (cache) { cache[ci].slot = slot; cache[ci].version = ver; }
+    if (cache) gcache_store(chunk, ci, slot, ver);
     return *slot;
 }
 
@@ -697,24 +759,29 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             GlobCacheEntry *cache = GCACHE;
             EnvFrame *root = as_env(TARGET_ENV);
             /* Acquire load: pairs with the release store in env.c's
-             * seq_end_write, so a match against cache[ci].version here
-             * guarantees cache[ci].slot (stamped from the same
+             * seq_end_write, so a match against the cache entry's version
+             * here guarantees its slot (stamped from the same
              * frame_lookup_versioned call that validated that version) is
              * still a slot in the CURRENT root->vals, not a stale one from
              * before a since-completed frame_grow. See env.c for why an
              * unsynchronized global-environment frame is unsafe when actor
-             * threads share it. */
+             * threads share it. gcache_load/gcache_store (see issue #162,
+             * above load_global_cached) give the cache entry ITSELF the
+             * same acquire/release treatment -- two actors executing this
+             * same compiled chunk concurrently would otherwise race on the
+             * entry's own slot/version fields. */
             uint32_t root_ver = atomic_load_explicit((_Atomic uint32_t *)&root->version, memory_order_acquire);
             val_t loaded_gval;
-            if (__builtin_expect(cache != NULL && cache[ci].slot != NULL &&
-                                 cache[ci].version == root_ver, 1)) {
-                loaded_gval = *cache[ci].slot;
+            val_t *cslot = NULL; uint32_t cver = 0;
+            if (cache) gcache_load(&cache[ci], &cslot, &cver);
+            if (__builtin_expect(cslot != NULL && cver == root_ver, 1)) {
+                loaded_gval = *cslot;
             } else {
                 val_t sym = CONSTS[ci];
                 uint32_t ver;
                 val_t *slot = frame_lookup_versioned(root, sym, &ver);
                 if (!slot) scm_raise_code(EC_UNBOUND_VARIABLE, "unbound variable: %s", sym_cstr(sym));
-                if (cache) { cache[ci].slot = slot; cache[ci].version = ver; }
+                if (cache) gcache_store(frame->closure->chunk, ci, slot, ver);
                 loaded_gval = *slot;
             }
             PUSH(loaded_gval);
@@ -737,9 +804,10 @@ val_t vm_run(BcClosure *top_closure, int argc) {
              * isn't a real global-arithmetic redefinition. */
             if (TARGET_ENV == GLOBAL_ENV)
                 jit_maybe_taint_global_arith(CONSTS[ci], val);
-            if (__builtin_expect(cache != NULL && cache[ci].slot != NULL &&
-                                 cache[ci].version == root_ver, 1)) {
-                gc_wb_slot(cache[ci].slot, val);
+            val_t *cslot = NULL; uint32_t cver = 0;
+            if (cache) gcache_load(&cache[ci], &cslot, &cver);
+            if (__builtin_expect(cslot != NULL && cver == root_ver, 1)) {
+                gc_wb_slot(cslot, val);
             } else {
                 val_t sym = CONSTS[ci];
                 uint32_t ver;
@@ -747,7 +815,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
                 if (!slot) fprintf(stderr, "vm: set! unbound variable\n");
                 else {
                     gc_wb_slot(slot, val);
-                    if (cache) { cache[ci].slot = slot; cache[ci].version = ver; }
+                    if (cache) gcache_store(frame->closure->chunk, ci, slot, ver);
                 }
             }
             NEXT;
@@ -771,7 +839,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
                 EnvFrame *root = as_env(TARGET_ENV);
                 uint32_t ver;
                 val_t *slot = frame_lookup_versioned(root, sym, &ver);
-                if (slot) { cache[ci].slot = slot; cache[ci].version = ver; }
+                if (slot) gcache_store(frame->closure->chunk, ci, slot, ver);
             }
             NEXT;
         }

--- a/tests/actors_tests.scm
+++ b/tests/actors_tests.scm
@@ -283,6 +283,84 @@
        (length (filter (lambda (a) (member a (list-actors))) la-race-actors))
        0)
 
+;;; Issue #162: vm.c's per-Chunk global-variable inline cache (glob_cache)
+;;; -- consulted by OP_LOAD_GLOBAL/OP_STORE_GLOBAL/OP_DEF_GLOBAL and the
+;;; shared load_global_cached() helper behind OP_CALL_GLOBAL/
+;;; OP_TAIL_CALL_GLOBAL -- read and wrote its cache[ci].slot/.version
+;;; fields as plain, unsynchronized memory accesses. root->version itself
+;;; was already correctly acquire/release-ordered (matching env.c's
+;;; seqlock), but nothing ordered the cache entry's own two fields
+;;; against each other, so two actor threads executing the SAME compiled
+;;; Chunk concurrently (the normal case for N actors spawned from one
+;;; shared lambda literal, exercised below) could race: one thread's
+;;; write to cache[ci].slot/.version could interleave with another's
+;;; read with no happens-before between them, letting a reader observe a
+;;; torn pair (a fresh version stamped next to a stale slot, or vice
+;;; versa) and wrongly take the fast path through a slot that doesn't
+;;; correspond to the value it appears to validate.
+;;;
+;;; Confirmed via ThreadSanitizer (not run as part of this suite -- no
+;;; TSan build target exists in this project yet): the unfixed code
+;;; reliably produced 6 data-race warnings per run at vm.c's
+;;; load_global_cached/OP_LOAD_GLOBAL/OP_CALL_GLOBAL call sites (the same
+;;; lines the issue itself reports) under 48 actors compiled from one
+;;; shared lambda, each doing 20000 iterations of global-variable
+;;; traffic; the fix (gcache_load/gcache_store, giving the cache entry's
+;;; own fields the same acquire/release treatment root->version already
+;;; had) reduced that to 0 warnings across repeated runs.
+;;;
+;;; Independent code review of that first fix then found it only
+;;; protects one writer against concurrent readers, not one writer
+;;; against another concurrent writer: two threads racing a cache-fill
+;;; for the SAME entry (e.g. both miss around a concurrent GLOBAL_ENV
+;;; frame_grow, so each computes a different (slot, version) pair for
+;;; the same index) could still interleave their two independent field
+;;; writes into a torn pair neither of them produced. Closed with a
+;;; coarse per-Chunk spinlock (Chunk.glob_cache_lock, chunk.h) that
+;;; serializes WRITES only -- reads stay lock-free through gcache_load.
+;;; Re-verified under ThreadSanitizer with actors mixing concurrent
+;;; top-level `(eval (list 'define ...))` (forcing repeated frame_grow)
+;;; against concurrent global reads: 0 glob_cache-related warnings across
+;;; 5 runs (this run does surface an unrelated, already-tracked race in
+;;; env.c's own seqlock -- see issue #153 -- which is why this test
+;;; doesn't attempt to force a frame_grow itself, to keep this a clean
+;;; signal specifically for glob_cache).
+;;;
+;;; This test can't reproduce a TSan report itself, but it does exercise
+;;; the exact shared-chunk-under-concurrent-global-lookup shape the race
+;;; depends on and asserts every actor still computes the mathematically
+;;; correct result despite the contention -- a torn cache read
+;;; manifesting as a wrong-value result (rather than a crash) would fail
+;;; this.
+(define n-gcache-workers 24)
+(define gcache-results (make-vector n-gcache-workers #f))
+(define (gcache-worker id)
+  (lambda ()
+    (let loop ((i 0) (acc 0))
+      (if (< i 2000)
+          (loop (+ i 1) (+ acc (modulo (+ id i) 97)))
+          (vector-set! gcache-results id acc)))))
+(define (gcache-expected id)
+  (let loop ((i 0) (acc 0))
+    (if (< i 2000) (loop (+ i 1) (+ acc (modulo (+ id i) 97))) acc)))
+(define gcache-actors
+  (let loop ((i 0) (acc '()))
+    (if (>= i n-gcache-workers) acc
+        (loop (+ i 1) (cons (spawn (gcache-worker i)) acc)))))
+(define (gcache-all-done? actors)
+  (or (null? actors)
+      (and (not (actor-alive? (car actors))) (gcache-all-done? (cdr actors)))))
+(let loop ((tries 0))
+  (when (and (< tries 2000) (not (gcache-all-done? gcache-actors)))
+    (la-busy-wait-a-bit)
+    (loop (+ tries 1))))
+(check "glob_cache: every actor computed the correct result under concurrent shared-chunk global lookups"
+       (let loop ((id 0))
+         (cond ((>= id n-gcache-workers) #t)
+               ((not (equal? (vector-ref gcache-results id) (gcache-expected id))) #f)
+               (else (loop (+ id 1)))))
+       #t)
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")


### PR DESCRIPTION
## Summary
- `vm.c`'s per-Chunk global-variable inline cache (`glob_cache`) is shared by every actor thread executing that compiled chunk concurrently (the normal case for N actors spawned from one shared lambda literal). `root->version` was already correctly acquire/release-ordered (matching env.c's seqlock), but each cache entry's own two fields (`GlobCacheEntry.slot`/`.version`) were read and written as plain, unsynchronized memory accesses.
- Confirmed via ThreadSanitizer: the unfixed code reliably produces 6 data-race warnings per run, at exactly the `load_global_cached`/`OP_LOAD_GLOBAL`/`OP_CALL_GLOBAL` lines the issue cites.
- Adds `gcache_load`/`gcache_store` (`src/vm.c`), giving the cache entry the same acquire-on-read/release-on-write treatment `root->version` already had, at all 4 call sites: `load_global_cached`, `OP_LOAD_GLOBAL`, `OP_STORE_GLOBAL`, `OP_DEF_GLOBAL`.
- Independent code review of that first pass found it only protects one writer against concurrent readers, not one writer against another concurrent writer — two threads racing a cache-fill for the same entry around a concurrent `GLOBAL_ENV` `frame_grow` could still interleave their two independent field writes into a torn pair neither of them produced. Closed with a coarse per-Chunk spinlock (`Chunk.glob_cache_lock`) serializing writes only; reads stay fully lock-free.
- That second-pass verification incidentally reproduced an unrelated, already-tracked race in `env.c`'s own seqlock protocol — documented as a comment on #153 with the concrete repro, not fixed here (out of scope for this PR).

## Test plan
- [x] `cmake --build build` clean
- [x] `ctest --test-dir build` — 127/127 passing
- [x] ThreadSanitizer build, original issue repro: 6 warnings/run before the fix → 0 warnings across 4 repeated runs after
- [x] ThreadSanitizer build, heavier stress repro (mixing concurrent top-level `define` forcing `frame_grow` against concurrent reads, targeting the writer-vs-writer scenario code review flagged): 0 `glob_cache`-related warnings across 5 runs
- [x] Added a functional regression test to `tests/actors_tests.scm` exercising the shared-chunk-under-concurrent-global-lookup shape
- [x] Independent code-review and security-review passes: both clean

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151dxuF9rGDxCxMt1BArPph
