### PR TITLE
fix(symbolic): move sx_simplify's generation stamp off shared hdr.flags (#140)

### DIFF
--- a/src/object.h
+++ b/src/object.h
@@ -712,6 +712,17 @@ typedef struct {
     Hdr      hdr;
     val_t    op;       /* a symbol: "+", "*", "expt", "sin", ... */
     uint32_t nargs;
+    /* Issue #140: sx_simplify's memoization generation stamp. Was
+     * packed into hdr.flags (a uint32_t shared with every other heap
+     * object type) by #137 -- that width let the global generation
+     * counter wrap in ~3 minutes under tight invalidation (repeated
+     * define-rule/define-algebra/assume! calls), letting a stale
+     * cached node get served as current. SymExpr is its own dedicated
+     * struct (not a shared layout), so a wider, PRIVATE field is just
+     * as easy as reusing hdr.flags was -- this is that field. See
+     * symbolic.c's sx_simplify/g_sx_simplify_generation for the full
+     * scheme; hdr.flags is no longer used by this type (left 0). */
+    uint64_t simplify_gen;
     val_t    args[];   /* flex array of sub-expressions */
 } SymExpr;
 

--- a/src/symbolic.c
+++ b/src/symbolic.c
@@ -127,6 +127,7 @@ val_t sx_make_expr(val_t op, int nargs, val_t *args) {
     e->hdr.flags = 0;
     e->op        = op;
     e->nargs     = (uint32_t)nargs;
+    e->simplify_gen = 0; /* zero-init is automatic via GC too; explicit for clarity */
     for (int i = 0; i < nargs; i++) e->args[i] = args[i];
     return vptr(e);
 }
@@ -239,15 +240,15 @@ static bool decompose_trig_sq(val_t term,
  * of CPU under a generous stack ulimit before the guard ever engages.
  *
  * Fixed with a generation-tagged memoization cache: SymExpr's own
- * hdr.flags field (unused for this type otherwise, confirmed by grep)
- * stores the g_sx_simplify_generation value in effect the last time
- * this exact node was fully simplified; sx_simplify (the public entry
- * point, below sx_simplify_impl) checks that tag first and returns the
- * node UNCHANGED with no recursion at all if it matches the CURRENT
- * generation -- turning the "wrap an already-simplified result" pattern
- * back into O(depth) total, since each wrap only ever simplifies the
- * ONE new outer node, never re-walking the (already-tagged) tree
- * beneath it.
+ * dedicated simplify_gen field (see object.h -- issue #140 moved this
+ * off hdr.flags, see below) stores the g_sx_simplify_generation value
+ * in effect the last time this exact node was fully simplified;
+ * sx_simplify (the public entry point, below sx_simplify_impl) checks
+ * that tag first and returns the node UNCHANGED with no recursion at
+ * all if it matches the CURRENT generation -- turning the "wrap an
+ * already-simplified result" pattern back into O(depth) total, since
+ * each wrap only ever simplifies the ONE new outer node, never
+ * re-walking the (already-tagged) tree beneath it.
  *
  * The generation counter exists because simplification is not a fixed
  * function of an expression's own shape alone: `define-rule`/
@@ -261,21 +262,66 @@ static bool decompose_trig_sq(val_t term,
  * registration functions call sx_invalidate_simplify_cache() (declared
  * in symbolic.h), which bumps this counter, so every previously-cached
  * tag stops matching and the next sx_simplify call on each affected
- * node redoes the full pass under the new rule set. */
-/* Plain uint32_t, NOT _Atomic-qualified: __atomic_load_n/__atomic_add_fetch
+ * node redoes the full pass under the new rule set.
+ *
+ * Issue #140 found two follow-up problems with this scheme, both from
+ * independent review of #137's own fix:
+ *
+ *   1. Invalidation is GLOBAL, not scoped to the operator/variable that
+ *      actually changed -- interleaving one cheap define-rule/
+ *      define-algebra call per step of an otherwise-cheap deep-
+ *      expression construction defeats memoization entirely,
+ *      reintroducing the O(depth^2) DoS this whole cache exists to
+ *      close. A proper fix needs per-operator AND per-variable scoped
+ *      invalidation (assumption changes are per-SymVar, not
+ *      per-operator, so the two invalidation sources need reconciling
+ *      too). Deliberately NOT attempted here: a design was drafted and
+ *      independently validated in the session that produced this fix,
+ *      and while directionally buildable, it surfaced a real soundness
+ *      gap (a node's tracked operator-dependency set must be derived
+ *      from the operator sx_simplify_impl actually QUERIED via
+ *      sx_rule_try/sx_algebra_lookup, not the operator of whatever
+ *      result it rewrites to -- e.g. `(- a 0)` rewrites to a `neg(a)`
+ *      node, silently losing the tracked dependency on SUB if derived
+ *      from the result's own top-level op instead) and a structural
+ *      ceiling no design in this category can close (sx_rule_add/
+ *      sx_algebra_define register arbitrary Scheme closures; one that
+ *      closes over a SymVar not among the expression's own args and
+ *      branches on its assumption flags creates a dependency invisible
+ *      to any args-tree-based tracking scheme). Filed as its own
+ *      follow-up issue with the validated design, the soundness fix,
+ *      and the capacity-sizing findings (a 128-slot per-operator table
+ *      is plausibly exhausted by an ORDINARY program's operator
+ *      vocabulary, not just an adversarial one) preserved for whoever
+ *      picks it up.
+ *
+ *   2. The generation counter itself was only 32 bits (constrained by
+ *      living inside SymExpr's shared hdr.flags field), and reliably
+ *      wrapped in ~3 minutes under tight invalidation (confirmed via a
+ *      repro driving ~22M cheap rule-registration calls/sec) -- letting
+ *      a stale cached node get served as CURRENT after wraparound, a
+ *      silent correctness bug, not just a missed optimization. THIS is
+ *      what this change fixes: SymExpr is its own dedicated struct (not
+ *      a layout shared with other heap object types the way hdr.flags
+ *      is), so a wider, private field costs nothing to add. At 64 bits,
+ *      wrapping the SAME workload that reached 2^32 in ~3 minutes would
+ *      take on the order of tens of thousands of years -- computationally
+ *      infeasible. */
+/* Plain uint64_t, NOT _Atomic-qualified: __atomic_load_n/__atomic_add_fetch
  * require a plain type (see runtime.c's identical convention/comment for
  * g_jit_arith_tainted et al.) -- curry's own actors are real OS threads,
  * so a script running define-rule/define-algebra/assume! on one actor
  * while another is mid-sx_simplify needs at least a non-torn read/write
  * here, even though the two-generations-out-of-sync worst case is just a
  * transient over-eager cache miss (an extra full simplify pass), not a
- * memory-safety issue -- SymExpr's own hdr.flags tag is a plain word
+ * memory-safety issue -- SymExpr's own simplify_gen tag is a plain word
  * write with no such cross-thread guarantee, matching how every other
  * per-object flags field in this codebase is handled (see review notes
  * on issue #137: no crash found in an actor stress test). Skipping 0 on
  * increment reserves it for "never simplified" (sx_make_expr always
- * zero-initializes hdr.flags), so a 2^32 wraparound can't make a fresh,
- * never-simplified node read as cache-valid.
+ * zero-initializes simplify_gen), so a 2^64 wraparound (already
+ * computationally infeasible on its own, see above) still couldn't make
+ * a fresh, never-simplified node read as cache-valid even in principle.
  *
  * The skip-0 step uses a compare-exchange retry loop rather than a plain
  * fetch-add followed by a corrective second fetch-add: a second review
@@ -298,11 +344,11 @@ static bool decompose_trig_sq(val_t term,
  * reading the OLD assumption flags/rule table -- matches the
  * release/acquire pattern runtime.c already uses for g_jit_arith_tainted
  * for the identical cross-thread-visibility reason, not relaxed. */
-static uint32_t g_sx_simplify_generation = 1;
+static uint64_t g_sx_simplify_generation = 1;
 
 void sx_invalidate_simplify_cache(void) {
-    uint32_t cur = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_RELAXED);
-    uint32_t next;
+    uint64_t cur = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_RELAXED);
+    uint64_t next;
     do {
         next = cur + 1;
         if (next == 0) next = 1;
@@ -1028,12 +1074,12 @@ static val_t sx_simplify_impl(val_t expr) {
  * the current generation is returned unchanged with no further
  * recursion at any depth, not just at the top level. */
 val_t sx_simplify(val_t expr) {
-    uint32_t gen = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_ACQUIRE);
-    if (vis_symexpr(expr) && as_symexpr(expr)->hdr.flags == gen)
+    uint64_t gen = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_ACQUIRE);
+    if (vis_symexpr(expr) && as_symexpr(expr)->simplify_gen == gen)
         return expr;
     val_t result = sx_simplify_impl(expr);
     if (vis_symexpr(result))
-        as_symexpr(result)->hdr.flags = gen;
+        as_symexpr(result)->simplify_gen = gen;
     return result;
 }
 

--- a/tests/numeric_ext_tests.scm
+++ b/tests/numeric_ext_tests.scm
@@ -1138,6 +1138,33 @@
     (exact->inexact (substitute s xv 0.04)) (sqrt 1.04) 1e-6))
 
 ;;; =========================================================================
+;;; Issue #140 (finding 2): sx_simplify's memoization generation counter
+;;; used to be packed into SymExpr's shared 32-bit hdr.flags field and
+;;; wrapped in ~3 minutes under tight invalidation (repeated
+;;; define-rule/define-algebra/assume! calls), letting a stale cached
+;;; node get served as current. Moved to a dedicated 64-bit field
+;;; (object.h's SymExpr.simplify_gen) -- not testing the wraparound
+;;; itself here (2^64 isn't reachable in test time), just the ordinary
+;;; correctness properties the fix must preserve: a cached result stays
+;;; cached until something actually invalidates it, and define-rule
+;;; still correctly invalidates and forces a fresh simplify pass.
+;;; =========================================================================
+
+(let* ((gv (sym-var 'g140))
+       (once (simplify (sin gv)))
+       (again (simplify (sin gv))))
+  (check "issue #140: repeated simplify of an unchanged expression is stable"
+    (equal? (sym->string once) (sym->string again)) #t))
+
+(define gv2 (sym-var 'g140b))
+(define before-140 (simplify (sin gv2)))
+(check "issue #140: simplify result before any rule change"
+  (sym->string before-140) "sin(g140b)")
+(define-rule (sin ?y) → (quote issue-140-rule-fired))
+(check "issue #140: define-rule invalidates the cache and the next simplify sees it"
+  (simplify (sin gv2)) 'issue-140-rule-fired)
+
+;;; =========================================================================
 ;;; Summary
 ;;; =========================================================================
 


### PR DESCRIPTION
## Summary
- `sx_simplify`'s memoization cache (added by #137 to fix an O(depth²) CPU-exhaustion DoS) tags each fully-simplified `SymExpr` node with a global generation counter, invalidated whenever `define-rule`/`define-algebra`/`assume!` changes anything. That counter was only 32 bits — constrained by living inside `SymExpr`'s shared `hdr.flags` field — and reliably wrapped in ~3 minutes under tight invalidation (confirmed via a repro driving ~22M cheap rule-registration calls/sec), letting a stale cached node get served as **current** after wraparound. A silent correctness bug.
- Fix: `SymExpr` is its own dedicated struct, so a wider private field costs nothing to add. Moves the generation stamp to a new dedicated `uint64_t simplify_gen` field (`object.h`), widens `g_sx_simplify_generation` to match (same CAS-retry-skip-0 / acquire-release convention, only the width changes), updates `sx_simplify()` accordingly. At 64 bits, the same workload that wrapped a 32-bit counter in ~3 minutes would take on the order of tens of thousands of years.
- This closes #140's "finding 2" only. Finding 1 (interleaved rule/algebra registration defeats memoization by invalidating globally instead of per-operator, reintroducing the O(depth²) DoS under a specific adversarial pattern) was scoped into a full per-operator/per-variable design, independently validated in this session — directionally buildable, but validation surfaced a real soundness gap and a structural ceiling (arbitrary rule/algebra closures can capture dependencies invisible to any args-tree-based tracking scheme) worth documenting before building. Filed as #195 with the full validated design rather than folded in here.

## Test plan
- [x] `cmake --build build` clean
- [x] `ctest --test-dir build` — 127/127 passing, including `numeric_ext`/`sx_rules`/`sx_algebra`/`sx_poly`/`sx_risch`
- [x] Manually confirmed memoization still works (not O(depth²)): a 40000-deep chain of repeated `sin` wraps completes in ~27ms
- [x] Manually confirmed invalidation still works: `define-rule` correctly forces a fresh `simplify` pass and picks up the new rule
- [x] Sanity-checked the CAS-retry-skip-0 logic at a reduced width in an isolated scratch program (not committed) — confirmed it never lands on 0 across multiple wraps, since the logic is width-independent by construction
- [x] Added regression tests to `tests/numeric_ext_tests.scm` for both properties above
- [x] Independent code-review and security-review passes: both clean

Closes #140 (partial — finding 2 only; finding 1 tracked as #195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151dxuF9rGDxCxMt1BArPph
