### PR TITLE
fix(env): synchronize GLOBAL_ENV's seqlock-protected fields (#153)

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -238,8 +238,10 @@ static val_t prim_untrace(int ac, val_t *av, void *ud) {
  * bug class in this codebase's own SRFI shims) is always a global macro. */
 static bool lookup_global_syntax(val_t sym, val_t *out_transformer) {
     val_t *slot = env_lookup_slot(GLOBAL_ENV, sym);
-    if (!slot || !vis_syntax(*slot)) return false;
-    *out_transformer = as_syntax(*slot)->transformer;
+    if (!slot) return false;
+    val_t v = env_slot_load(slot); /* issue #153: GLOBAL_ENV slot, concurrently writable */
+    if (!vis_syntax(v)) return false;
+    *out_transformer = as_syntax(v)->transformer;
     return true;
 }
 static val_t prim_macro_p(int ac, val_t *av, void *ud) {

--- a/src/env.c
+++ b/src/env.c
@@ -107,6 +107,65 @@ static inline void seq_end_write(EnvFrame *f, uint32_t v) {
     atomic_store_explicit((_Atomic uint32_t *)&f->version, v + 2, memory_order_release);
 }
 
+/*
+ * Issue #153: seq_begin_write/seq_end_write's own release/acquire pairing
+ * on `version` is C11-sound on its own terms -- a reader whose acquire
+ * load of `version` observes a given even value synchronizes-with
+ * whichever seq_end_write produced it, establishing happens-before over
+ * everything that writer did before that release store. The bug is a
+ * layer down: syms/vals/hidx/cap/hcap/size themselves are PLAIN fields,
+ * and a plain read racing a plain write to the SAME memory is a data
+ * race by the letter of the C11 standard the instant it happens in real
+ * time -- regardless of whether the reader's later version check (v2==v1)
+ * discards the result afterward. Confirmed via a real TSan run (see the
+ * comment on issue #153): frame_grow's plain `f->syms = ns` write racing
+ * frame_lookup_unlocked's plain `f->syms[idx]` read, reliably, under
+ * concurrent actors mixing `(define ...)` (forcing frame_grow) against
+ * plain global reads.
+ *
+ * Fix: make the fields themselves properly atomic (relaxed suffices --
+ * the ordering guarantee readers need still comes entirely from the
+ * separate version-counter's acquire/release above; these just need to
+ * stop being non-atomic so a racing access is well-defined instead of
+ * UB). Gated on frame_is_global(f): these accessor functions are shared
+ * between the global root frame (genuinely read/written by more than one
+ * actor thread) and every other frame (function-call locals, let bodies,
+ * ...), which is exclusively owned by whichever single call stack
+ * created it and never has this problem at all -- see this file's own
+ * top-of-file comment. Unconditionally atomic-ifying local-frame access
+ * would tax the hottest path in the tree-walking interpreter (every
+ * function-call frame's parameter binding) for zero benefit, so every
+ * field touch below is gated on a single frame_is_global(f) check per
+ * call, not applied blindly. */
+static inline uint32_t g_load_u32(uint32_t *p, bool atomic) {
+    return atomic ? atomic_load_explicit((_Atomic uint32_t *)p, memory_order_relaxed) : *p;
+}
+static inline void g_store_u32(uint32_t *p, uint32_t v, bool atomic) {
+    if (atomic) atomic_store_explicit((_Atomic uint32_t *)p, v, memory_order_relaxed);
+    else *p = v;
+}
+static inline val_t g_load_val(val_t *p, bool atomic) {
+    return atomic ? atomic_load_explicit((_Atomic val_t *)p, memory_order_relaxed) : *p;
+}
+static inline void g_store_val(val_t *p, val_t v, bool atomic) {
+    if (atomic) atomic_store_explicit((_Atomic val_t *)p, v, memory_order_relaxed);
+    else *p = v;
+}
+static inline val_t *g_load_valptr(val_t **p, bool atomic) {
+    return atomic ? (val_t *)atomic_load_explicit((_Atomic(val_t *) *)p, memory_order_relaxed) : *p;
+}
+static inline void g_store_valptr(val_t **p, val_t *v, bool atomic) {
+    if (atomic) atomic_store_explicit((_Atomic(val_t *) *)p, v, memory_order_relaxed);
+    else *p = v;
+}
+static inline uint32_t *g_load_u32ptr(uint32_t **p, bool atomic) {
+    return atomic ? (uint32_t *)atomic_load_explicit((_Atomic(uint32_t *) *)p, memory_order_relaxed) : *p;
+}
+static inline void g_store_u32ptr(uint32_t **p, uint32_t *v, bool atomic) {
+    if (atomic) atomic_store_explicit((_Atomic(uint32_t *) *)p, v, memory_order_relaxed);
+    else *p = v;
+}
+
 /* ---- Pair construction (needed for rest-arg list building) ---- */
 
 static val_t env_cons(val_t car, val_t cdr) {
@@ -123,10 +182,18 @@ static uint32_t sym_hash(val_t sym, uint32_t hcap) {
     return (uint32_t)((sym >> 3) * 2654435761u) & (hcap - 1);
 }
 
-static void hash_insert(uint32_t *hidx, uint32_t hcap, val_t *syms, uint32_t idx) {
+/* `atomic`: true when writing into a hidx array a lock-free reader can
+ * already see (the global frame's LIVE f->hidx, rehash's "just reinsert"
+ * fast path) -- false when building a fresh array not yet published via
+ * f->hidx (safe to touch plainly, no reader can reach it yet). syms is
+ * read-only here and only ever touched by the thread already holding
+ * g_global_frame_lock (hash_insert is only called from frame_build_hash/
+ * frame_hash_rehash, both invoked from within frame_define_unlocked while
+ * the writer lock is held), so no atomics are needed for that read. */
+static void hash_insert(uint32_t *hidx, uint32_t hcap, val_t *syms, uint32_t idx, bool atomic) {
     uint32_t h = sym_hash(syms[idx], hcap);
-    while (hidx[h] != UINT32_MAX) h = (h + 1) & (hcap - 1);
-    hidx[h] = idx;
+    while (g_load_u32(&hidx[h], atomic) != UINT32_MAX) h = (h + 1) & (hcap - 1);
+    g_store_u32(&hidx[h], idx, atomic);
 }
 
 static void frame_build_hash(EnvFrame *f) {
@@ -136,26 +203,29 @@ static void frame_build_hash(EnvFrame *f) {
     uint32_t *hidx = (uint32_t *)gc_alloc_raw_pinned_atomic(hcap * sizeof(uint32_t));
     memset(hidx, 0xFF, hcap * sizeof(uint32_t)); /* UINT32_MAX = empty */
     for (uint32_t i = 0; i < f->size; i++)
-        hash_insert(hidx, hcap, f->syms, i);
-    f->hidx = hidx;
-    f->hcap = hcap;
+        hash_insert(hidx, hcap, f->syms, i, false); /* fresh array, not yet published */
+    bool g = frame_is_global(f);
+    g_store_u32ptr(&f->hidx, hidx, g);
+    g_store_u32(&f->hcap, hcap, g);
 }
 
 static void frame_hash_rehash(EnvFrame *f) {
+    bool g = frame_is_global(f);
     uint32_t hcap = f->hcap;
     while (hcap < f->size * 2) hcap <<= 1;
     if (hcap == f->hcap) {
-        /* Just re-insert the newest entry */
-        hash_insert(f->hidx, f->hcap, f->syms, f->size - 1);
+        /* Just re-insert the newest entry -- into the LIVE f->hidx a
+         * lock-free reader can already be probing. */
+        hash_insert(f->hidx, f->hcap, f->syms, f->size - 1, g);
         return;
     }
     /* Need larger table */
     uint32_t *hidx = (uint32_t *)gc_alloc_raw_pinned_atomic(hcap * sizeof(uint32_t));
     memset(hidx, 0xFF, hcap * sizeof(uint32_t));
     for (uint32_t i = 0; i < f->size; i++)
-        hash_insert(hidx, hcap, f->syms, i);
-    f->hidx = hidx;
-    f->hcap = hcap;
+        hash_insert(hidx, hcap, f->syms, i, false); /* fresh array, not yet published */
+    g_store_u32ptr(&f->hidx, hidx, g);
+    g_store_u32(&f->hcap, hcap, g);
 }
 
 /* ---- Frame ---- */
@@ -183,31 +253,53 @@ EnvFrame *frame_new(uint32_t cap, EnvFrame *parent) {
  * hidx afterward, letting a concurrent lock-free reader through to observe
  * a torn intermediate state. */
 static void frame_grow(EnvFrame *f) {
+    bool g = frame_is_global(f);
     uint32_t new_cap = f->cap * 2;
     val_t *ns = (val_t *)gc_alloc_raw_pinned(new_cap * sizeof(val_t));
     val_t *nv = (val_t *)gc_alloc_raw_pinned(new_cap * sizeof(val_t));
     memcpy(ns, f->syms, f->size * sizeof(val_t));
     memcpy(nv, f->vals, f->size * sizeof(val_t));
-    f->syms = ns; f->vals = nv; f->cap = new_cap;
+    g_store_valptr(&f->syms, ns, g);
+    g_store_valptr(&f->vals, nv, g);
+    g_store_u32(&f->cap, new_cap, g);
 }
 
+/* Issue #153: the redefine-search reads below (hcap/hidx/syms/size) are
+ * safe as plain reads regardless of frame_is_global -- this function only
+ * ever runs while g_global_frame_lock is held (via frame_define), so no
+ * OTHER writer can be concurrently mutating them, and a lock-free
+ * reader's OWN concurrent read of the same fields is a benign read-read,
+ * never a race. What DOES need gating: every WRITE a lock-free reader
+ * could observe -- the redefine value-write, and the insert path's
+ * syms/vals/size writes (matching gc_wb_slot_atomic_relaxed's own doc
+ * comment: relaxed suffices, ordering comes from the seqlock). */
 static bool frame_define_unlocked(EnvFrame *f, val_t sym, val_t val) {
+    bool g = frame_is_global(f);
     /* Check if already in this frame (redefine) */
     if (f->hcap) {
         uint32_t h = sym_hash(sym, f->hcap);
         while (f->hidx[h] != UINT32_MAX) {
             uint32_t idx = f->hidx[h];
-            if (f->syms[idx] == sym) { gc_wb_slot(&f->vals[idx], val); return true; }
+            if (f->syms[idx] == sym) {
+                if (g) gc_wb_slot_atomic_relaxed(&f->vals[idx], val);
+                else   gc_wb_slot(&f->vals[idx], val);
+                return true;
+            }
             h = (h + 1) & (f->hcap - 1);
         }
     } else {
         for (uint32_t i = 0; i < f->size; i++)
-            if (f->syms[i] == sym) { gc_wb_slot(&f->vals[i], val); return true; }
+            if (f->syms[i] == sym) {
+                if (g) gc_wb_slot_atomic_relaxed(&f->vals[i], val);
+                else   gc_wb_slot(&f->vals[i], val);
+                return true;
+            }
     }
     if (f->size >= f->cap) frame_grow(f);
-    f->syms[f->size] = sym;
-    gc_wb_slot(&f->vals[f->size], val);
-    f->size++;
+    g_store_val(&f->syms[f->size], sym, g);
+    if (g) gc_wb_slot_atomic_relaxed(&f->vals[f->size], val);
+    else   gc_wb_slot(&f->vals[f->size], val);
+    g_store_u32(&f->size, f->size + 1, g);
     /* Build or update hash index */
     if (f->hcap) {
         frame_hash_rehash(f);
@@ -233,13 +325,29 @@ static bool frame_set_unlocked(EnvFrame *f, val_t sym, val_t val) {
         uint32_t h = sym_hash(sym, f->hcap);
         while (f->hidx[h] != UINT32_MAX) {
             uint32_t idx = f->hidx[h];
-            if (f->syms[idx] == sym) { gc_wb_slot(&f->vals[idx], val); return true; }
+            if (f->syms[idx] == sym) {
+                /* Reads above are safe plain reads regardless of global-
+                 * ness: frame_set_unlocked only ever runs while
+                 * g_global_frame_lock is held for the global case (via
+                 * frame_set), ruling out a concurrent structural writer;
+                 * a lock-free reader's own concurrent read of the same
+                 * fields is a benign read-read. Only this value WRITE
+                 * needs gating -- see gc_wb_slot_atomic_relaxed's doc
+                 * comment. */
+                if (frame_is_global(f)) gc_wb_slot_atomic_relaxed(&f->vals[idx], val);
+                else                    gc_wb_slot(&f->vals[idx], val);
+                return true;
+            }
             h = (h + 1) & (f->hcap - 1);
         }
         return false;
     }
     for (uint32_t i = 0; i < f->size; i++)
-        if (f->syms[i] == sym) { gc_wb_slot(&f->vals[i], val); return true; }
+        if (f->syms[i] == sym) {
+            if (frame_is_global(f)) gc_wb_slot_atomic_relaxed(&f->vals[i], val);
+            else                    gc_wb_slot(&f->vals[i], val);
+            return true;
+        }
     return false;
 }
 
@@ -253,38 +361,79 @@ bool frame_set(EnvFrame *f, val_t sym, val_t val) {
      * does. Taking g_global_frame_lock here (the same lock frame_define
      * holds for its whole critical section) rules that out directly: no
      * frame_define can be reallocating syms/vals/hidx while we hold it, so
-     * the traversal below is safe without a separate retry loop. This also
-     * serializes two actors calling (set! shared-global ...) at the same
-     * time against EACH OTHER, matching frame_define's writer-vs-writer
-     * guarantee — without it, two concurrent gc_wb_slot stores to the same
-     * slot are a plain, unsynchronized write/write race. */
+     * the traversal below is safe without a separate retry loop.
+     *
+     * This only serializes writer-vs-writer for callers that go through
+     * frame_set itself (env_set, i.e. tree-walked `(set! ...)`) — issue
+     * #153's independent review flagged that a PRE-EXISTING, separate
+     * overclaim here previously said this serializes "two actors calling
+     * (set! shared-global ...) against EACH OTHER" unconditionally, which
+     * is not true: VM-compiled `(set! ...)` (vm.c's OP_STORE_GLOBAL) writes
+     * the value slot directly via gslot_store and has never taken this
+     * lock, tree-walked or compiled, before or after #153's fix. Two
+     * concurrent writes to the SAME global from mixed tree-walked/compiled
+     * call sites are therefore each individually well-defined (gslot_store/
+     * gc_wb_slot_atomic_relaxed rule out torn reads/writes, per #153) but
+     * NOT ordered relative to each other -- an ordinary unsynchronized
+     * last-write-wins race, same as `set!`'s memory model gives you in any
+     * language without the caller adding their own synchronization. */
     pthread_mutex_lock(&g_global_frame_lock);
     bool result = frame_set_unlocked(f, sym, val);
     pthread_mutex_unlock(&g_global_frame_lock);
     return result;
 }
 
+/* Issue #153: the lock-free (global) read path -- every field touch below
+ * is gated on frame_is_global(f), snapshotted ONCE at entry rather than
+ * re-derived per access, so one lookup attempt is internally consistent
+ * even under a concurrent writer (the outer seqlock retry in
+ * frame_lookup_versioned discards the whole attempt if version changed
+ * meanwhile; this function's job is only to make sure that discarding is
+ * the WORST outcome -- never UB or an out-of-bounds access -- which
+ * requires every one of these to be a proper atomic load when g is
+ * true). Local (non-global) frames keep the exact original plain-access
+ * behavior. */
 static val_t *frame_lookup_unlocked(EnvFrame *f, val_t sym) {
-    if (f->hcap) {
-        uint32_t h = sym_hash(sym, f->hcap);
-        while (f->hidx[h] != UINT32_MAX) {
-            uint32_t idx = f->hidx[h];
-            if (f->syms[idx] == sym) return &f->vals[idx];
-            h = (h + 1) & (f->hcap - 1);
+    bool g = frame_is_global(f);
+    uint32_t hcap = g_load_u32(&f->hcap, g);
+    if (hcap) {
+        uint32_t *hidx = g_load_u32ptr(&f->hidx, g);
+        val_t    *syms = g_load_valptr(&f->syms, g);
+        val_t    *vals = g_load_valptr(&f->vals, g);
+        uint32_t h = sym_hash(sym, hcap);
+        for (;;) {
+            uint32_t idx = g_load_u32(&hidx[h], g);
+            if (idx == UINT32_MAX) return NULL;
+            if (g_load_val(&syms[idx], g) == sym) return &vals[idx];
+            h = (h + 1) & (hcap - 1);
         }
-        return NULL;
     }
-    for (uint32_t i = 0; i < f->size; i++)
-        if (f->syms[i] == sym) return &f->vals[i];
+    uint32_t size = g_load_u32(&f->size, g);
+    val_t   *syms = g_load_valptr(&f->syms, g);
+    val_t   *vals = g_load_valptr(&f->vals, g);
+    for (uint32_t i = 0; i < size; i++)
+        if (g_load_val(&syms[i], g) == sym) return &vals[i];
     return NULL;
 }
+
+/* Issue #153 item 2: an uncapped seqlock retry loop is a theoretical
+ * livelock under sustained contention (no backoff, restarts on ANY
+ * concurrent writer starting or completing mid-read). After this many
+ * failed attempts, fall back to taking g_global_frame_lock outright --
+ * serializing with writers instead of racing them -- which guarantees
+ * forward progress regardless of how hot the contention gets. Picked
+ * generously: normal contention resolves in a handful of retries at
+ * most (structural global-frame writes are load-time-rare, see this
+ * file's own top-of-file comment), so this only ever engages under
+ * genuinely pathological, sustained writer pressure. */
+#define FRAME_SEQLOCK_RETRY_CAP 1000
 
 val_t *frame_lookup_versioned(EnvFrame *f, val_t sym, uint32_t *out_ver) {
     if (!frame_is_global(f)) {
         if (out_ver) *out_ver = 0;
         return frame_lookup_unlocked(f, sym);
     }
-    for (;;) {
+    for (int tries = 0; tries < FRAME_SEQLOCK_RETRY_CAP; tries++) {
         uint32_t v1 = atomic_load_explicit((_Atomic uint32_t *)&f->version, memory_order_acquire);
         if (v1 & 1) continue;
         val_t *result = frame_lookup_unlocked(f, sym);
@@ -293,10 +442,25 @@ val_t *frame_lookup_versioned(EnvFrame *f, val_t sym, uint32_t *out_ver) {
         if (out_ver) *out_ver = v1;
         return result;
     }
+    pthread_mutex_lock(&g_global_frame_lock);
+    val_t *result = frame_lookup_unlocked(f, sym);
+    if (out_ver) *out_ver = atomic_load_explicit((_Atomic uint32_t *)&f->version, memory_order_acquire);
+    pthread_mutex_unlock(&g_global_frame_lock);
+    return result;
 }
 
 val_t *frame_lookup(EnvFrame *f, val_t sym) {
     return frame_lookup_versioned(f, sym, NULL);
+}
+
+/* Copies syms[0..n) / vals[0..n) element-by-element via atomic-relaxed
+ * loads instead of memcpy -- issue #153: memcpy has no notion of
+ * atomicity, so it can't safely read an array a concurrent writer might
+ * be touching (the same UB-by-definition concern gc_wb_slot_atomic_relaxed's
+ * doc comment explains for single-slot writes, just for a bulk read). */
+static void frame_copy_global(val_t *dst, val_t *src, uint32_t n) {
+    for (uint32_t i = 0; i < n; i++)
+        dst[i] = atomic_load_explicit((_Atomic val_t *)&src[i], memory_order_relaxed);
 }
 
 uint32_t frame_snapshot_bindings(EnvFrame *f, val_t **out_syms, val_t **out_vals) {
@@ -309,19 +473,30 @@ uint32_t frame_snapshot_bindings(EnvFrame *f, val_t **out_syms, val_t **out_vals
         *out_syms = syms; *out_vals = vals;
         return n;
     }
-    for (;;) {
+    for (int tries = 0; tries < FRAME_SEQLOCK_RETRY_CAP; tries++) {
         uint32_t v1 = atomic_load_explicit((_Atomic uint32_t *)&f->version, memory_order_acquire);
         if (v1 & 1) continue;
-        uint32_t n = f->size;
+        uint32_t n = g_load_u32(&f->size, true);
+        val_t *fsyms = g_load_valptr(&f->syms, true);
+        val_t *fvals = g_load_valptr(&f->vals, true);
         val_t *syms = (val_t *)gc_alloc_raw_pinned(n * sizeof(val_t));
         val_t *vals = (val_t *)gc_alloc_raw_pinned(n * sizeof(val_t));
-        memcpy(syms, f->syms, n * sizeof(val_t));
-        memcpy(vals, f->vals, n * sizeof(val_t));
+        frame_copy_global(syms, fsyms, n);
+        frame_copy_global(vals, fvals, n);
         uint32_t v2 = atomic_load_explicit((_Atomic uint32_t *)&f->version, memory_order_acquire);
         if (v2 != v1) continue;
         *out_syms = syms; *out_vals = vals;
         return n;
     }
+    pthread_mutex_lock(&g_global_frame_lock);
+    uint32_t n = f->size;
+    val_t *syms = (val_t *)gc_alloc_raw_pinned(n * sizeof(val_t));
+    val_t *vals = (val_t *)gc_alloc_raw_pinned(n * sizeof(val_t));
+    memcpy(syms, f->syms, n * sizeof(val_t));
+    memcpy(vals, f->vals, n * sizeof(val_t));
+    pthread_mutex_unlock(&g_global_frame_lock);
+    *out_syms = syms; *out_vals = vals;
+    return n;
 }
 
 /* ---- Environment ---- */
@@ -384,14 +559,26 @@ bool env_set(val_t env, val_t sym, val_t val) {
     return false;
 }
 
+/* Issue #153: env.c's own internal helper -- a caller outside this file
+ * should use env_slot_load (env.h) instead, which doesn't need a frame
+ * argument since all its callers pass a root environment. */
+static inline val_t frame_slot_load(EnvFrame *f, val_t *slot) {
+    return frame_is_global(f) ? atomic_load_explicit((_Atomic val_t *)slot, memory_order_relaxed) : *slot;
+}
+
+val_t env_slot_load(val_t *slot) {
+    return atomic_load_explicit((_Atomic val_t *)slot, memory_order_relaxed);
+}
+
 val_t env_lookup(val_t env, val_t sym) {
     EnvFrame *f = as_env(env);
     while (f) {
         val_t *slot = frame_lookup(f, sym);
         if (slot) {
-            if (*slot == V_UNDEF)
+            val_t v = frame_slot_load(f, slot);
+            if (v == V_UNDEF)
                 scm_raise(V_FALSE, "variable used before initialization: %s", sym_cstr(sym));
-            return *slot;
+            return v;
         }
         f = f->parent;
     }
@@ -402,7 +589,10 @@ val_t env_lookup_or_false(val_t env, val_t sym) {
     EnvFrame *f = as_env(env);
     while (f) {
         val_t *slot = frame_lookup(f, sym);
-        if (slot && *slot != V_UNDEF) return *slot;
+        if (slot) {
+            val_t v = frame_slot_load(f, slot);
+            if (v != V_UNDEF) return v;
+        }
         f = f->parent;
     }
     return V_FALSE;
@@ -412,7 +602,7 @@ val_t *env_lookup_slot(val_t env, val_t sym) {
     EnvFrame *f = as_env(env);
     while (f) {
         val_t *slot = frame_lookup(f, sym);
-        if (slot && *slot != V_UNDEF) return slot;
+        if (slot && frame_slot_load(f, slot) != V_UNDEF) return slot;
         f = f->parent;
     }
     return NULL;

--- a/src/env.h
+++ b/src/env.h
@@ -20,8 +20,30 @@
 struct EnvFrame;
 struct EnvFrame *frame_new(uint32_t capacity, struct EnvFrame *parent);
 bool             frame_define(struct EnvFrame *f, val_t sym, val_t val);
-bool             frame_set(struct EnvFrame *f, val_t sym, val_t val);  /* local only */
+bool             frame_set(struct EnvFrame *f, val_t sym, val_t val);  /* handles both
+                                                                            local frames and
+                                                                            the (possibly
+                                                                            shared) global
+                                                                            root frame */
 val_t           *frame_lookup(struct EnvFrame *f, val_t sym);          /* NULL if not found */
+
+/* Issue #153: a pointer returned by env_lookup_slot into a ROOT
+ * environment's vals[] (GLOBAL_ENV, or a define-library body's own
+ * env_new_root() frame -- both reachable from more than one actor
+ * thread, see env.c's own big seqlock comment) is a slot a DIFFERENT
+ * actor thread's frame_set/OP_STORE_GLOBAL can write concurrently,
+ * lock-free -- dereferencing it with a plain `*slot` is a data race by
+ * the letter of C11, the same class gc_wb_slot_atomic_relaxed's doc
+ * comment (env.c) explains for the write side. env_lookup_slot(root_env,
+ * sym)'s match, if any, is ALWAYS root_env's own frame (a root frame's
+ * chain walk terminates after one step, parent == NULL) -- so any
+ * caller that calls env_lookup_slot with a root environment (GLOBAL_ENV,
+ * or a module's own env) and then dereferences the result itself should
+ * read through this helper instead of `*slot` directly, rather than
+ * re-deriving "is this global" itself. Safe to call unconditionally --
+ * an atomic-relaxed load of a val_t is well-defined and correct
+ * regardless of whether the memory happens to be contended. */
+val_t            env_slot_load(val_t *slot);
 
 /* Like frame_lookup, but for the (possibly shared) GLOBAL_ENV frame also
  * hands back the frame->version the lookup was validated against, in the

--- a/src/gc.h
+++ b/src/gc.h
@@ -40,6 +40,13 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#ifndef __cplusplus
+#include <stdatomic.h> /* C++ TUs (qt6.cpp) that include this header never
+                         * call gc_wb_slot_atomic_relaxed below -- stdatomic.h
+                         * is C11-only and its atomic_* macros collide with
+                         * <atomic>/libc++ when pulled into a C++ TU, so it's
+                         * guarded out entirely rather than risk that clash. */
+#endif
 #include "value.h" /* val_t, and CURRY_THREAD_LOCAL used by gc_nursery etc. below --
                      * moved here from further down in this file (it used to be
                      * included lazily right before its first use) because
@@ -497,5 +504,45 @@ static inline void gc_wb_slot(val_t *slot, val_t newval) {
 
 #define GC_WB(obj, field, newval) \
     do { val_t _gc_v = (newval); gc_wb_slot((val_t *)&(obj)->field, _gc_v); } while(0)
+
+/*
+ * gc_wb_slot_atomic_relaxed — issue #153: same write-barrier bookkeeping
+ * as gc_wb_slot, but the actual store is an atomic-relaxed store instead
+ * of a plain `*slot = newval`. Use ONLY for a slot that a lock-free
+ * reader on another thread can observe without holding any lock -- today
+ * that means exactly one thing: GLOBAL_ENV (or another root EnvFrame)'s
+ * vals[] array, written from env.c's frame_set_unlocked/
+ * frame_define_unlocked (the global-frame branch) and vm.c's
+ * OP_STORE_GLOBAL. Every other gc_wb_slot call site (pairs, vectors,
+ * local-frame fields, ...) stays on the plain version: those objects are
+ * single-thread-owned (see env.c's own top-of-file comment on why local
+ * frames never need this), so there is no concurrent reader to protect
+ * against and no reason to pay for an atomic store.
+ *
+ * Relaxed suffices (not acquire/release) because the ordering readers
+ * actually need comes from the SEPARATE seqlock version counter
+ * (env.c's seq_begin_write/seq_end_write, unchanged by this fix) for the
+ * structural (grow/rehash) case, or is simply "read old or new value,
+ * both are live, never torn" for the direct value-update case (frame_set/
+ * OP_STORE_GLOBAL never bump version at all -- this store's only job is
+ * to stop the write from being UB-by-definition against a concurrent
+ * plain read, not to add ordering the seqlock doesn't already provide).
+ *
+ * C-only (see the stdatomic.h include guard above): no C++ TU in this
+ * codebase touches GLOBAL_ENV's seqlock-protected slots directly. */
+#ifndef __cplusplus
+static inline void gc_wb_slot_atomic_relaxed(val_t *slot, val_t newval) {
+    atomic_store_explicit((_Atomic val_t *)slot, newval, memory_order_relaxed);
+    if (gc_dirty_slots && vis_ptr(newval)) {
+        const uint8_t *p = (const uint8_t *)(uintptr_t)newval;
+        if (p >= gc_main_nursery_base && p < gc_main_nursery_limit) {
+            if (gc_dirty_count < GC_DIRTY_CAP)
+                gc_dirty_slots[gc_dirty_count++] = slot;
+            else
+                gc_dirty_overflow = true;
+        }
+    }
+}
+#endif /* __cplusplus */
 
 #endif /* CURRY_GC_H */

--- a/src/llvm/codegen.cpp
+++ b/src/llvm/codegen.cpp
@@ -1505,7 +1505,9 @@ static Value *emit_expr(CompileCtx &cc, val_t expr) {
          * chunk before curry_llvm_jit_compile is ever called -- this
          * function never sees a let-syntax-local macro call at all. */
         val_t *slot = env_lookup_slot(GLOBAL_ENV, S(name));
-        if (slot && vis_syntax(*slot))
+        /* Issue #153: GLOBAL_ENV slot, concurrently writable -- see
+         * jit.cpp's curry_jit_global_lookup for the identical fix. */
+        if (slot && vis_syntax(env_slot_load(slot)))
             throw std::runtime_error(
                 std::string("JIT: macro invocation '") + name + "' not supported");
     }

--- a/src/llvm/jit.cpp
+++ b/src/llvm/jit.cpp
@@ -91,7 +91,12 @@ static uint64_t curry_jit_global_lookup(uint64_t sym_val) {
     val_t *slot = env_lookup_slot(GLOBAL_ENV, (val_t)sym_val);
     if (!slot)
         scm_raise(V_FALSE, "unbound variable");
-    return (uint64_t)*slot;
+    /* Issue #153: GLOBAL_ENV slot, concurrently writable by another
+     * actor's frame_set/OP_STORE_GLOBAL -- env_slot_load (not a plain
+     * *slot) matches how vm.c's own OP_LOAD_GLOBAL reads the same
+     * slots (gslot_load), just via env.h's C-linkage wrapper since this
+     * is a C++ TU and gc_wb_slot_atomic_relaxed itself is C-only. */
+    return (uint64_t)env_slot_load(slot);
 }
 
 /* Define or redefine a global variable. */

--- a/src/main.c
+++ b/src/main.c
@@ -464,10 +464,13 @@ static void eval_port_exprs(val_t port, bool print) {
                     val_t *slot = env_lookup_slot(GLOBAL_ENV, sym_intern_cstr(fn_name));
                     if (!slot) {
                         fprintf(stderr, "unbound variable: %s\n", fn_name);
-                    } else if (!vis_bcclosure(*slot)) {
-                        fprintf(stderr, "%s: not a compiled procedure (no bytecode)\n", fn_name);
                     } else {
-                        chunk_disasm(as_bcclosure(*slot)->chunk, fn_name, stdout);
+                        /* issue #153: GLOBAL_ENV slot, concurrently writable */
+                        val_t v = env_slot_load(slot);
+                        if (!vis_bcclosure(v))
+                            fprintf(stderr, "%s: not a compiled procedure (no bytecode)\n", fn_name);
+                        else
+                            chunk_disasm(as_bcclosure(v)->chunk, fn_name, stdout);
                     }
                     continue;
                 }

--- a/src/modules.c
+++ b/src/modules.c
@@ -564,7 +564,10 @@ val_t modules_import(val_t spec, val_t env) {
             val_t sym = vcar(es);
             val_t *slot = env_lookup_slot(mod_env_val, sym);
             if (!slot) continue; /* declared exported but never defined */
-            import_binding(sym, *slot, spec, filter, env);
+            /* issue #153: mod->env is a root frame (env_new_root()),
+             * concurrently writable by another actor still loading/
+             * defining into this module. */
+            import_binding(sym, env_slot_load(slot), spec, filter, env);
         }
     } else {
         /* No export list: every binding in the module's own environment is

--- a/src/vm.c
+++ b/src/vm.c
@@ -555,6 +555,26 @@ static inline void gcache_store(Chunk *chunk, uint8_t ci, val_t *slot, uint32_t 
     gcache_unlock(chunk);
 }
 
+/* Issue #153: every slot dereferenced here (whether freshly looked up via
+ * frame_lookup_versioned or fetched from a warm glob_cache entry) always
+ * points into a ROOT EnvFrame's vals[] -- that's what OP_LOAD_GLOBAL/
+ * OP_STORE_GLOBAL/OP_CALL_GLOBAL/load_global_cached mean by "global" --
+ * which a DIFFERENT actor thread's frame_set/frame_define can write
+ * concurrently, lock-free. A plain `*slot` read or write here is a data
+ * race by the letter of C11 (see env.c's own doc comment on this same
+ * class of bug); load_global_cached/OP_LOAD_GLOBAL's own root->version
+ * check only validates the SLOT POINTER is still current, it says
+ * nothing about the VALUE stored there being torn-read-safe against a
+ * concurrent frame_set (frame_set never bumps version at all -- see
+ * env.c). Relaxed suffices: ordering comes from the version check above
+ * these calls, not from the value load/store itself. */
+static inline val_t gslot_load(val_t *slot) {
+    return atomic_load_explicit((_Atomic val_t *)slot, memory_order_relaxed);
+}
+static inline void gslot_store(val_t *slot, val_t v) {
+    gc_wb_slot_atomic_relaxed(slot, v);
+}
+
 /* Shared cached global-variable lookup for OP_CALL_GLOBAL/
  * OP_TAIL_CALL_GLOBAL, which need this exact lookup fused with a call
  * rather than as a separate dispatch. Mirrors (does not replace)
@@ -574,14 +594,14 @@ static inline val_t load_global_cached(Chunk *chunk, uint8_t ci) {
         val_t *cslot; uint32_t cver;
         gcache_load(&cache[ci], &cslot, &cver);
         if (__builtin_expect(cslot != NULL && cver == root_ver, 1))
-            return *cslot;
+            return gslot_load(cslot);
     }
     val_t sym = chunk->constants[ci];
     uint32_t ver;
     val_t *slot = frame_lookup_versioned(root, sym, &ver);
     if (!slot) scm_raise_code(EC_UNBOUND_VARIABLE, "unbound variable: %s", sym_cstr(sym));
     if (cache) gcache_store(chunk, ci, slot, ver);
-    return *slot;
+    return gslot_load(slot);
 }
 
 /* Tier 2.5 step 1: shared fast path for every open-coded 1-argument
@@ -775,14 +795,14 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             val_t *cslot = NULL; uint32_t cver = 0;
             if (cache) gcache_load(&cache[ci], &cslot, &cver);
             if (__builtin_expect(cslot != NULL && cver == root_ver, 1)) {
-                loaded_gval = *cslot;
+                loaded_gval = gslot_load(cslot);
             } else {
                 val_t sym = CONSTS[ci];
                 uint32_t ver;
                 val_t *slot = frame_lookup_versioned(root, sym, &ver);
                 if (!slot) scm_raise_code(EC_UNBOUND_VARIABLE, "unbound variable: %s", sym_cstr(sym));
                 if (cache) gcache_store(frame->closure->chunk, ci, slot, ver);
-                loaded_gval = *slot;
+                loaded_gval = gslot_load(slot);
             }
             PUSH(loaded_gval);
             NEXT;
@@ -807,14 +827,14 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             val_t *cslot = NULL; uint32_t cver = 0;
             if (cache) gcache_load(&cache[ci], &cslot, &cver);
             if (__builtin_expect(cslot != NULL && cver == root_ver, 1)) {
-                gc_wb_slot(cslot, val);
+                gslot_store(cslot, val);
             } else {
                 val_t sym = CONSTS[ci];
                 uint32_t ver;
                 val_t *slot = frame_lookup_versioned(root, sym, &ver);
                 if (!slot) fprintf(stderr, "vm: set! unbound variable\n");
                 else {
-                    gc_wb_slot(slot, val);
+                    gslot_store(slot, val);
                     if (cache) gcache_store(frame->closure->chunk, ci, slot, ver);
                 }
             }

--- a/tests/actors_tests.scm
+++ b/tests/actors_tests.scm
@@ -361,6 +361,62 @@
                (else (loop (+ id 1)))))
        #t)
 
+;;; Issue #153: GLOBAL_ENV's seqlock (env.c) protects frame_grow/
+;;; frame_hash_rehash's structural writes with a version counter whose OWN
+;;; release/acquire ordering is C11-sound, but the PLAIN fields it guards
+;;; (syms/vals/hidx/cap/hcap/size) were read/written non-atomically -- a
+;;; data race by the letter of the C11 standard the instant a lock-free
+;;; reader's optimistic read overlaps a writer's plain write in real time,
+;;; regardless of whether the reader's later version check discards the
+;;; result. A separate, more direct gap: frame_set (tree-walked `set!`)
+;;; and vm.c's compiled OP_STORE_GLOBAL both wrote an existing global
+;;; slot's VALUE with zero seqlock coverage at all (frame_set never bumps
+;;; version, by design, since it's "no structural change").
+;;;
+;;; Confirmed via ThreadSanitizer (not run as part of this suite -- no
+;;; TSan build target exists in this project yet): the unfixed code
+;;; reliably produced 3-7 data-race warnings per run at exactly
+;;; frame_grow/frame_hash_rehash/frame_lookup_unlocked (env.c) under 32
+;;; actors mixing `(eval (list 'define ...))` (forcing frame_grow)
+;;; against plain global reads; the fix (atomic-relaxed accessors on the
+;;; global-frame path, gated on frame_is_global so local frames are
+;;; untouched, plus gc_wb_slot_atomic_relaxed for the value-write path)
+;;; reduced that to 0 warnings at this class across 5 repeated runs.
+;;;
+;;; This test can't reproduce a TSan report itself, but it exercises the
+;;; same shape (concurrent define-forced frame_grow against concurrent
+;;; reads AND writes of the SAME global) and asserts every actor still
+;;; observes internally-consistent results despite the contention -- a
+;;; torn read manifesting as a wrong value (rather than a crash) would
+;;; fail this.
+(define n153-workers 24)
+(define g153-counter 0) ; shared global -- exercises frame_set's value race too
+(define (worker153 id)
+  (lambda ()
+    (eval (list 'define (string->symbol (string-append "g153-" (number->string id))) id))
+    (let loop ((i 0))
+      (if (< i 500)
+          (begin (set! g153-counter (+ g153-counter 0)) ; touches the shared slot's value
+                 (loop (+ i 1)))))
+    (eval (list 'set! 'g153-counter '(+ g153-counter 0)))))
+(define actors153
+  (let loop ((i 0) (acc '()))
+    (if (>= i n153-workers) acc
+        (loop (+ i 1) (cons (spawn (worker153 i)) acc)))))
+(define (all-done153? actors)
+  (or (null? actors)
+      (and (not (actor-alive? (car actors))) (all-done153? (cdr actors)))))
+(let loop ((tries 0))
+  (when (and (< tries 2000) (not (all-done153? actors153)))
+    (la-busy-wait-a-bit)
+    (loop (+ tries 1))))
+(check "env.c seqlock: every actor's own top-level define is visible and correctly valued after concurrent frame_grow"
+       (let loop ((id 0))
+         (cond ((>= id n153-workers) #t)
+               ((not (equal? (eval (string->symbol (string-append "g153-" (number->string id)))) id)) #f)
+               (else (loop (+ id 1)))))
+       #t)
+
 ;;; Summary
 (newline)
 (display pass) (display " passed, ")


### PR DESCRIPTION
## Summary
- GLOBAL_ENV's seqlock lets lock-free readers race the mutex-protected writer path. The version counter's own release/acquire ordering is C11-sound, but the plain fields it guards (`syms`/`vals`/`hidx`/`cap`/`hcap`/`size`) were read/written non-atomically — a data race by the letter of C11 the instant a reader's optimistic read overlaps a writer's plain write, regardless of whether the reader's later version check discards the result.
- A separate, more direct gap: `frame_set` (tree-walked `set!`) and `vm.c`'s compiled `OP_STORE_GLOBAL` both wrote an existing global slot's *value* via a plain `gc_wb_slot` with **zero** seqlock coverage — `frame_set` never bumps `version` at all (by design, since it's "no structural change").
- Confirmed via ThreadSanitizer: unfixed code reliably produces 3-7 data-race warnings/run at exactly `frame_grow`/`frame_hash_rehash`/`frame_lookup_unlocked`, under 32 actors mixing `(eval (list 'define ...))` against plain global reads.
- Fix (gated on `frame_is_global(f)`, local frames untouched): atomic-relaxed field access throughout `env.c`'s global-frame path, `vm.c`'s direct slot dereferences, a new `gc_wb_slot_atomic_relaxed` write-barrier helper, bounded seqlock retry with a lock fallback (closes #153's item 2), and `env_slot_load()` for the handful of external callers that dereference an `env_lookup_slot` result themselves.
- Independent security review caught two more sites doing the same plain dereference in the LLVM JIT tier (`jit.cpp`, `codegen.cpp`) — fixed with the same helper.
- Independent code review caught a stale, overclaiming comment on `frame_set` (pre-existing, not introduced by this fix) — corrected to describe the actual guarantee.
- A fourth gap found during design validation — the moving GC backends' own evacuation of `f->vals` — is confined entirely to the experimental, opt-in `--gc generational`/semispace backends (Boehm, the default, never executes that code). Filed as #198 rather than folded in here.

## Test plan
- [x] `cmake --build build` clean
- [x] `ctest --test-dir build` — 127/127 passing
- [x] ThreadSanitizer: pre-fix baseline reliably races (3-7 warnings/run at `frame_grow`/`frame_hash_rehash`/`frame_lookup_unlocked`); post-fix is clean (0 warnings at this class across 5 repeated runs, including after the security-review fixes)
- [x] Confirmed both LLVM-JIT security-review fixes compile cleanly with `-DBUILD_LLVM=ON`
- [x] New functional regression test in `tests/actors_tests.scm`
- [x] Independent code-review and security-review passes, findings from both addressed

Closes #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151dxuF9rGDxCxMt1BArPph
