### PR TITLE
fix(gc_gen): synchronize T_ENV evacuation against env.c's own seqlock (#198)

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -570,6 +570,9 @@ val_t env_slot_load(val_t *slot) {
     return atomic_load_explicit((_Atomic val_t *)slot, memory_order_relaxed);
 }
 
+void env_global_frame_lock_for_gc(void)   { pthread_mutex_lock(&g_global_frame_lock); }
+void env_global_frame_unlock_for_gc(void) { pthread_mutex_unlock(&g_global_frame_lock); }
+
 val_t env_lookup(val_t env, val_t sym) {
     EnvFrame *f = as_env(env);
     while (f) {

--- a/src/env.h
+++ b/src/env.h
@@ -45,6 +45,28 @@ val_t           *frame_lookup(struct EnvFrame *f, val_t sym);          /* NULL i
  * regardless of whether the memory happens to be contended. */
 val_t            env_slot_load(val_t *slot);
 
+/* Issue #198: thin wrappers around g_global_frame_lock (env.c, private)
+ * for the moving-GC backend's (gc_gen.c) OWN evacuation of a root
+ * EnvFrame's vals[] -- the SAME mutex frame_define/frame_set already take
+ * for their own critical sections, so evacuation gets the same writer-
+ * exclusion guarantee without needing to replicate env.c's seqlock retry
+ * protocol in a GC backend file.
+ *
+ * Safe against self-deadlock, but for a NARROWER reason than "minor GC
+ * never fires synchronously mid-allocation" (that's not true in general --
+ * gc_nursery_refill CAN fire minor GC synchronously off an ordinary
+ * gc_alloc call, e.g. from the VM dispatch loop): every allocation INSIDE
+ * frame_define/frame_set/frame_grow/frame_build_hash/frame_hash_rehash
+ * (i.e. everywhere this lock is already held) goes through
+ * gc_alloc_raw_pinned[_atomic], which resolves straight to Boehm's
+ * GC_MALLOC/GC_MALLOC_ATOMIC (gen_alloc_raw_pinned, gc_gen.c) -- never
+ * gc_nursery_alloc/gc_nursery_refill. So THIS lock's own critical
+ * sections specifically never take the one path that could trigger a
+ * synchronous minor GC on the same thread, regardless of the general
+ * safepoint-deferral behavior elsewhere in the codebase. */
+void             env_global_frame_lock_for_gc(void);
+void             env_global_frame_unlock_for_gc(void);
+
 /* Like frame_lookup, but for the (possibly shared) GLOBAL_ENV frame also
  * hands back the frame->version the lookup was validated against, in the
  * same lock-free read as the slot fetch itself — see vm.c's OP_LOAD_GLOBAL/

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -20,6 +20,7 @@
 #include "gc_gen.h"
 #include "gc.h"
 #include "object.h"
+#include "env.h"         /* env_global_frame_lock_for_gc/unlock_for_gc, issue #198 */
 #include "vm.h"          /* VM struct, vm TLS pointer */
 #include <gc/gc.h>
 #include <gc/gc_mark.h>
@@ -554,9 +555,62 @@ static void scan_pinned_object(void *obj) {
     }
 
     case T_ENV: {
+        /* Issue #198: a root (GLOBAL_ENV, or a define-library body's own
+         * env_new_root() frame) is genuinely shared across actor threads
+         * (see env.c's own seqlock, issue #153) -- this evacuation loop
+         * used to read f->size and read/write f->vals[i] as plain fields
+         * with no synchronization at all, racing a concurrent
+         * frame_grow/frame_define/frame_set on whichever thread actually
+         * OWNS/mutates this frame. This runs once per frame (the pinned-
+         * object scan that fires on the NEXT minor GC after a frame is
+         * created, per this file's own pinned_add/compact design) --
+         * for a long-lived, actively-shared frame like GLOBAL_ENV, that
+         * one scan can easily land well after actors are already running
+         * and mutating it concurrently.
+         *
+         * Fixed by taking the SAME g_global_frame_lock frame_define/
+         * frame_set already use (env_global_frame_lock_for_gc, env.h) --
+         * safe against self-deadlock since minor GC only ever fires at an
+         * explicit safepoint, never synchronously from inside a call
+         * already holding that lock (see env.h's own doc comment on
+         * these wrappers) -- which rules out any OTHER writer racing
+         * size/vals for the loop's duration. A lock-free READER
+         * (frame_lookup_versioned) can still be running concurrently
+         * though, so each element is still read/written via atomic-
+         * relaxed (not plain) to keep that side well-defined too, exactly
+         * matching env.c's own gcache/vals-slot convention (relaxed
+         * suffices: correctness against evacuation moving an object is
+         * "reader sees the pre- or post-move pointer, either is a live,
+         * valid reference to the same logical value," not something that
+         * needs its own ordering -- from-space stays readable until the
+         * whole collection cycle completes). Skip the store when nothing
+         * moved, same as chunk.h's tree_eval_cache evacuation just above,
+         * to avoid a redundant atomic write racing a concurrent reader
+         * for no reason.
+         *
+         * LOCAL (non-root) frames are deliberately left on the original
+         * plain, lock-free loop -- matching #153's own local-frame
+         * exemption (single-owner, never raced by another MUTATOR
+         * thread) -- see issue #198's follow-up note for why a local
+         * frame's OWN one-time pinned-scan window is a separate, much
+         * narrower/lower-probability concern not fixed here. */
         EnvFrame *f = (EnvFrame *)obj;
-        for (uint32_t i = 0; i < f->size; i++)
-            f->vals[i] = evacuate(f->vals[i]);
+        if (f->parent == NULL) {
+            env_global_frame_lock_for_gc();
+            uint32_t n = f->size;
+            val_t *vals = f->vals;
+            for (uint32_t i = 0; i < n; i++) {
+                _Atomic val_t *slot = (_Atomic val_t *)&vals[i];
+                val_t old = atomic_load_explicit(slot, memory_order_relaxed);
+                val_t moved = evacuate(old);
+                if (moved != old)
+                    atomic_store_explicit(slot, moved, memory_order_relaxed);
+            }
+            env_global_frame_unlock_for_gc();
+        } else {
+            for (uint32_t i = 0; i < f->size; i++)
+                f->vals[i] = evacuate(f->vals[i]);
+        }
         break;
     }
     case T_CLOSURE: {


### PR DESCRIPTION
## Summary
- `gc_gen.c` (the only compiled generational-GC backend — `gc_generational.c`/`gc_semispace.c` exist but aren't in the build) evacuates a root `EnvFrame`'s `vals[]` via plain, unsynchronized reads of `f->size` and reads/writes of `f->vals[i]` during its per-object pinned-scan — racing a concurrent `frame_grow`/`frame_define`/`frame_set` on whichever actor thread owns/mutates that frame (`GLOBAL_ENV`, or a define-library body's own root frame — both genuinely shared across actors, per #153 earlier this session).
- This scan happens once per frame lifetime (scan-once-then-compact, relying on `gc_dirty_slots` for later updates). For a long-lived, actively-shared frame like `GLOBAL_ENV`, that one scan can land well after actors are already running and mutating it concurrently.
- Confirmed via ThreadSanitizer: reliably fires under a stress test spawning actors immediately with heavy `(eval (list 'define ...))` load and a tiny nursery to force frequent minor GCs.
- Fix: gate on `f->parent == NULL` (root frame). For root frames, take the same `g_global_frame_lock` `frame_define`/`frame_set` already use, ruling out concurrent writers; each element still reads/writes via atomic-relaxed since a lock-free reader can still be running concurrently. Local frames are untouched (matching #153's own exemption).
- Verified deadlock-safe (independently confirmed by both reviews): every allocation inside `g_global_frame_lock`'s critical sections goes straight to Boehm's `GC_MALLOC`, never the nursery path that could trigger a synchronous minor GC on the same thread; no code path acquires `pinned_lock` while holding `g_global_frame_lock`.
- The same TSan stress test surfaced a genuinely separate, broader pre-existing pattern in other `scan_pinned_object` cases (`T_UPVALUE`/`T_BCCLOSURE`/`T_ACTOR`/`T_MAILBOX`) — confirmed present with or without this fix, filed as #200 (likely the same root cause as #144) rather than folded in here.

## Test plan
- [x] `cmake --build build` clean
- [x] `ctest --test-dir build` — 127/127 passing (default Boehm backend)
- [x] Manual `--gc generational` runs of `r7rs_tests`/`numeric_ext_tests`/`actors_tests`/`dynamic_wind_tests`/`sx_rules_tests` — all pass (`sx_algebra_tests` fails under that flag, confirmed pre-existing and unrelated)
- [x] ThreadSanitizer: 0 races within the `T_ENV` case across 5 repeated runs post-fix, vs. reliably reproducing pre-fix
- [x] No automated regression test added — `--gc generational` has no CI/ctest coverage in this project at all (confirmed via `tests/CMakeLists.txt`), so a test here wouldn't be exercised by anything; same situation already noted for TSan coverage in #153
- [x] Independent code-review and security-review, including explicit verification of the lock-ordering safety argument: both clean

Closes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151dxuF9rGDxCxMt1BArPph
