### PR TITLE
fix(network): reject socket handles naming a fd curry never opened (#160)

### DIFF
--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -46,12 +46,54 @@
  * helpers (net_sock_to_val/net_val_to_sock/net_is_raw_socket_handle/
  * net_extract_fd) now live in network_internal.h, shared with srfi106.c
  * (the SRFI-106 socket interface, added alongside it) -- see that
- * header's own comment. Local aliases kept here (rather than rewriting
- * every call site below) purely to minimize this diff; srfi106.c uses
- * the net_-prefixed names directly. */
+ * header's own comment. */
 #include "network_internal.h"
-#define sock_to_val net_sock_to_val
-#define val_to_sock net_val_to_sock
+
+#include <pthread.h>
+
+/* Issue #160: storage for the fd registry declared in network_internal.h
+ * -- defined once here (network.c is always compiled whenever the network
+ * module is built, unlike srfi106.c/tls.c which are conditionally added
+ * sources; see CMakeLists.txt) so both TUs share one table instead of
+ * each getting its own via a `static` definition in the shared header. */
+static pthread_mutex_t g_fd_registry_lock = PTHREAD_MUTEX_INITIALIZER;
+static sock_t *g_fd_registry = NULL;
+static size_t g_fd_registry_len = 0, g_fd_registry_cap = 0;
+
+bool net_fd_registry_add(sock_t fd) {
+    pthread_mutex_lock(&g_fd_registry_lock);
+    bool ok = true;
+    if (g_fd_registry_len == g_fd_registry_cap) {
+        size_t newcap = g_fd_registry_cap ? g_fd_registry_cap * 2 : 16;
+        sock_t *grown = realloc(g_fd_registry, newcap * sizeof(sock_t));
+        if (grown) { g_fd_registry = grown; g_fd_registry_cap = newcap; }
+        else ok = false;
+    }
+    if (ok) g_fd_registry[g_fd_registry_len++] = fd;
+    pthread_mutex_unlock(&g_fd_registry_lock);
+    return ok;
+}
+
+void net_fd_registry_remove(sock_t fd) {
+    pthread_mutex_lock(&g_fd_registry_lock);
+    for (size_t i = 0; i < g_fd_registry_len; i++) {
+        if (g_fd_registry[i] == fd) {
+            g_fd_registry[i] = g_fd_registry[--g_fd_registry_len];
+            break;
+        }
+    }
+    pthread_mutex_unlock(&g_fd_registry_lock);
+}
+
+bool net_fd_registry_contains(sock_t fd) {
+    pthread_mutex_lock(&g_fd_registry_lock);
+    bool found = false;
+    for (size_t i = 0; i < g_fd_registry_len; i++) {
+        if (g_fd_registry[i] == fd) { found = true; break; }
+    }
+    pthread_mutex_unlock(&g_fd_registry_lock);
+    return found;
+}
 
 static curry_val fn_tcp_connect(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
@@ -127,7 +169,7 @@ static curry_val fn_tcp_listen(int ac, curry_val *av, void *ud) {
     if (listen(fd, backlog) != 0) {
         sock_close(fd); curry_error("tcp-listen: listen failed");
     }
-    return sock_to_val(fd);
+    return net_sock_to_val_registered(fd, "tcp-listen");
 }
 
 static curry_val fn_tcp_accept(int ac, curry_val *av, void *ud) {
@@ -157,7 +199,9 @@ static curry_val fn_tcp_accept(int ac, curry_val *av, void *ud) {
 
 static curry_val fn_tcp_close(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
-    sock_close(net_checked_val_to_sock(av[0], "tcp-close"));
+    sock_t fd = net_checked_val_to_sock(av[0], "tcp-close");
+    net_fd_registry_remove(fd);
+    sock_close(fd);
     return curry_void();
 }
 
@@ -170,7 +214,7 @@ static curry_val fn_udp_socket(int ac, curry_val *av, void *ud) {
      * there, unlike Linux) even before any udp-bind call. */
     int off = 0;
     setsockopt((int)fd, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
-    return sock_to_val(fd);
+    return net_sock_to_val_registered(fd, "udp-socket");
 }
 
 static curry_val fn_udp_bind(int ac, curry_val *av, void *ud) {

--- a/modules/network/network_internal.h
+++ b/modules/network/network_internal.h
@@ -21,6 +21,7 @@
 
 #include <curry.h>
 #include <string.h>
+#include <stdbool.h>
 
 #ifdef _WIN32
 #  include <winsock2.h>
@@ -34,11 +35,59 @@ typedef int sock_t;
 #  define sock_close close
 #endif
 
+/* Issue #160: process-wide registry of fds curry's own socket-opening
+ * primitives actually created (every call site that calls
+ * net_sock_to_val_registered below: tcp-listen, udp-socket,
+ * make-client-socket, make-server-socket, socket-accept). A raw socket
+ * handle's PAIR SHAPE is trivially forgeable from Scheme --
+ * net_is_raw_socket_handle (below) only checks shape, not provenance (see
+ * #158) -- so `(cons 'socket packed-fd-bytes)` names whatever fd number
+ * happens to be encoded, including fds this process has open for
+ * something entirely unrelated to a socket the curry script was ever
+ * actually handed: another open file, stdin/stdout/stderr, a DIFFERENT
+ * actor's own socket, or a fd number simply recycled by the OS after an
+ * earlier close. net_checked_val_to_sock and net_extract_fd's handle
+ * branch (below) both cross-check membership here before returning a fd
+ * to any caller, so a forged/foreign fd number is rejected the same way a
+ * malformed pair shape already is, instead of silently letting a curry
+ * script operate on whatever that fd currently happens to be.
+ *
+ * Defined once in network.c (always compiled whenever this module is
+ * built -- see CMakeLists.txt's BUILD_MODULE_NETWORK block), declared
+ * here with ordinary extern linkage so srfi106.c shares the exact same
+ * table instead of each translation unit getting its own (which a
+ * `static` definition in this header would have silently produced, since
+ * network.c and srfi106.c are separate TUs compiled into the same .so
+ * target). Mutex-protected growable array rather than a fixed-size table
+ * sized against sysconf(_SC_OPEN_MAX) (a soft limit a program can raise
+ * at runtime) or a full hash set: the number of concurrently open sockets
+ * in a real program is expected to stay small, so linear scan/insert/
+ * remove is plenty fast for this table's actual size. */
+bool net_fd_registry_add(sock_t fd);       /* false = registration failed (OOM) */
+void net_fd_registry_remove(sock_t fd);
+bool net_fd_registry_contains(sock_t fd);
+
 static inline curry_val net_sock_to_val(sock_t fd) {
     curry_val bv = curry_make_bytevector(sizeof(sock_t), 0);
     for (size_t i = 0; i < sizeof(sock_t); i++)
         curry_bytevector_set(bv, (uint32_t)i, ((uint8_t *)&fd)[i]);
     return curry_make_pair(curry_make_symbol("socket"), bv);
+}
+
+/* Every primitive that hands a freshly-created fd back to Scheme as a raw
+ * socket handle must register it first -- this is the one choke point
+ * that does both, so no call site can pack a handle without also
+ * registering it. On registration failure (OOM in the registry's own
+ * growable array), the fd is closed rather than handed to Scheme
+ * unregistered, which would have made it permanently unusable anyway
+ * (every future net_checked_val_to_sock/net_extract_fd call would reject
+ * it as unregistered) while also silently leaking it. */
+static inline curry_val net_sock_to_val_registered(sock_t fd, const char *who) {
+    if (!net_fd_registry_add(fd)) {
+        sock_close(fd);
+        curry_error("%s: out of memory (socket registry)", who);
+    }
+    return net_sock_to_val(fd);
 }
 
 static inline sock_t net_val_to_sock(curry_val v) {
@@ -78,7 +127,14 @@ static inline bool net_is_raw_socket_handle(curry_val v) {
  * port (tcp-connect's/tcp-accept's in-port or out-port) -- extract_fd
  * dispatches on which it got. */
 static inline int net_extract_fd(curry_val v, const char *who) {
-    if (net_is_raw_socket_handle(v)) return (int)net_val_to_sock(v);
+    if (net_is_raw_socket_handle(v)) {
+        sock_t fd = net_val_to_sock(v);
+        /* Issue #160: shape alone doesn't prove this fd is one curry's
+         * own socket primitives ever actually opened -- see the registry
+         * comment above. */
+        if (!net_fd_registry_contains(fd)) curry_error("%s: not a socket handle", who);
+        return (int)fd;
+    }
     int fd = curry_port_fd(v);
     if (fd < 0) curry_error("%s: not a socket handle or file-backed port", who);
     return fd;
@@ -102,7 +158,11 @@ static inline int net_extract_fd(curry_val v, const char *who) {
  * duplicate it. */
 static inline sock_t net_checked_val_to_sock(curry_val v, const char *who) {
     if (!net_is_raw_socket_handle(v)) curry_error("%s: not a socket handle", who);
-    return net_val_to_sock(v);
+    sock_t fd = net_val_to_sock(v);
+    /* Issue #160: see the registry comment above -- shape alone doesn't
+     * prove provenance. */
+    if (!net_fd_registry_contains(fd)) curry_error("%s: not a socket handle", who);
+    return fd;
 }
 
 #endif /* CURRY_NETWORK_INTERNAL_H */

--- a/modules/network/srfi106.c
+++ b/modules/network/srfi106.c
@@ -125,7 +125,7 @@ static curry_val fn_make_client_socket(int ac, curry_val *av, void *ud) {
         curry_error("make-client-socket: connect failed");
     }
     freeaddrinfo(res);
-    return net_sock_to_val(fd);
+    return net_sock_to_val_registered(fd, "make-client-socket");
 }
 
 static curry_val fn_make_server_socket(int ac, curry_val *av, void *ud) {
@@ -163,7 +163,7 @@ static curry_val fn_make_server_socket(int ac, curry_val *av, void *ud) {
         curry_error("make-server-socket: listen failed");
     }
     freeaddrinfo(res);
-    return net_sock_to_val(fd);
+    return net_sock_to_val_registered(fd, "make-server-socket");
 }
 
 static curry_val fn_socket_p(int ac, curry_val *av, void *ud) {
@@ -177,7 +177,7 @@ static curry_val fn_socket_accept(int ac, curry_val *av, void *ud) {
     struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
     sock_t client = accept(server, (struct sockaddr *)&addr, &addrlen);
     if (client == SOCK_INVALID) curry_error("socket-accept: accept failed");
-    return net_sock_to_val(client);
+    return net_sock_to_val_registered(client, "socket-accept");
 }
 
 /* (socket-local-port socket) -> fixnum
@@ -292,7 +292,9 @@ static curry_val fn_socket_close(int ac, curry_val *av, void *ud) {
      * accept a port, only a raw handle. */
     if (!net_is_raw_socket_handle(av[0]))
         curry_error("socket-close: not a socket (did you mean close-port, for a socket-input-port/socket-output-port result?)");
-    sock_close(net_val_to_sock(av[0]));
+    sock_t fd = net_checked_val_to_sock(av[0], "socket-close");
+    net_fd_registry_remove(fd);
+    sock_close(fd);
     return curry_void();
 }
 


### PR DESCRIPTION
## Summary

- Closes #160: a raw socket handle `(socket . bytevector-packed-fd)` is a shape any curry script can forge; every socket primitive previously validated only that shape, never whether curry's own socket primitives actually opened the named fd. A forged handle naming an arbitrary fd the process happens to have open (stdin/stdout/stderr, a fd belonging to something unrelated, a recycled fd number from an already-closed socket) was silently operated on as a real socket.
- Adds a process-wide mutex-protected fd registry in `network.c`, shared with `srfi106.c` via `network_internal.h`. Every primitive that hands a raw handle back to Scheme (`tcp-listen`, `udp-socket`, `make-client-socket`, `make-server-socket`, `socket-accept`) registers its fd via a new `net_sock_to_val_registered()` wrapper before returning; `net_checked_val_to_sock`/`net_extract_fd`'s raw-handle branch reject any fd not present in the registry; `tcp-close`/`socket-close` deregister before closing.

## Test plan

- [x] `cmake --build build` — clean, no new warnings
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` — 127/127 passing
- [x] Manual repro: a handle forged to name fd 1 (a real, live fd) is rejected with "not a socket handle"; a genuine `udp-socket` handle still works and closes normally
- [x] Independent code-review pass (fresh subagent) — no correctness bugs found
- [x] Independent security-review pass (fresh subagent) — confirmed the fix closes the confused-deputy gap, no bypass or new race found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151dxuF9rGDxCxMt1BArPph
