### PR TITLE
fix(gc_gen,sx_rules,sx_algebra): synchronize T_MODULE evacuation and skip no-op rtab/atab scans (#150, #146)

### DIFF
--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -21,6 +21,7 @@
 #include "gc.h"
 #include "object.h"
 #include "env.h"         /* env_global_frame_lock_for_gc/unlock_for_gc, issue #198 */
+#include "modules.h"      /* modules_registry_*lock_for_gc, issue #150 */
 #include "vm.h"          /* VM struct, vm TLS pointer */
 #include <gc/gc.h>
 #include <gc/gc_mark.h>
@@ -665,9 +666,17 @@ static void scan_pinned_object(void *obj) {
         break;
     }
     case T_MODULE: {
+        /* Issue #150: modules.c's modules_import reads mod->exports
+         * outside module_registry_lock's normal critical sections
+         * (registry_lookup/registry_insert/scan_module_registry) -- take
+         * the same lock here (its write side, since this mutates) so
+         * that read has something to synchronize against, mirroring
+         * #198's identical fix for GLOBAL_ENV's frame_set/env_slot_load. */
         Module *m = (Module *)obj;
+        modules_registry_wrlock_for_gc();
         m->name    = evacuate(m->name);
         m->exports = evacuate(m->exports);
+        modules_registry_unlock_for_gc();
         break;
     }
     case T_ACTOR: {

--- a/src/modules.c
+++ b/src/modules.c
@@ -59,6 +59,21 @@ static ModuleEntry *registry = NULL;
  * sx_rule_try's guard_fn/action_fn callbacks did. */
 static pthread_rwlock_t module_registry_lock = PTHREAD_RWLOCK_INITIALIZER;
 
+/* Issue #150: thin wrappers around module_registry_lock so callers outside
+ * this file can synchronize against gc_gen.c's scan_pinned_object T_MODULE
+ * case, which mutates a live Module's name/exports fields (evacuating any
+ * that point into the nursery) during another actor's minor GC -- same
+ * "reuse the existing lock instead of inventing a new protocol" approach
+ * #198 used for GLOBAL_ENV (env_global_frame_lock_for_gc). modules_import
+ * (below) takes the read lock around its own read of mod->exports before
+ * that pointer can be raced by a concurrent T_MODULE scan on another
+ * thread; gc_gen.c's T_MODULE case takes the write lock (it mutates)
+ * around its evacuation, mirroring registry_insert's/scan_module_registry's
+ * own existing write-lock use of this exact mutex above. */
+void modules_registry_rdlock_for_gc(void) { pthread_rwlock_rdlock(&module_registry_lock); }
+void modules_registry_wrlock_for_gc(void) { pthread_rwlock_wrlock(&module_registry_lock); }
+void modules_registry_unlock_for_gc(void) { pthread_rwlock_unlock(&module_registry_lock); }
+
 static bool names_equal(val_t a, val_t b) {
     while (vis_pair(a) && vis_pair(b)) {
         if (vcar(a) != vcar(b)) return false;
@@ -560,7 +575,14 @@ val_t modules_import(val_t spec, val_t env) {
          * each exported name up directly instead of scanning every binding
          * the module happens to define. */
         val_t mod_env_val = vptr(mod->env);
-        for (val_t es = mod->exports; vis_pair(es); es = vcdr(es)) {
+        /* Issue #150: mod->exports is a field gc_gen.c's scan_pinned_object
+         * (T_MODULE case) can concurrently evacuate on another actor's
+         * minor GC -- snapshot it under the same lock that scan takes,
+         * rather than dereferencing it directly here. */
+        modules_registry_rdlock_for_gc();
+        val_t exports = mod->exports;
+        modules_registry_unlock_for_gc();
+        for (val_t es = exports; vis_pair(es); es = vcdr(es)) {
             val_t sym = vcar(es);
             val_t *slot = env_lookup_slot(mod_env_val, sym);
             if (!slot) continue; /* declared exported but never defined */

--- a/src/modules.h
+++ b/src/modules.h
@@ -39,6 +39,15 @@ bool modules_available(val_t name_list);
 /* Import a module spec into env */
 val_t modules_import(val_t spec, val_t env);
 
+/* Issue #150: thin wrappers around modules.c's own (private)
+ * module_registry_lock, for the moving-GC backend's (gc_gen.c) scan of a
+ * pinned Module object's name/exports fields -- see modules.c's own
+ * comment on these for why a caller reading mod->exports outside this
+ * file (modules_import) needs the read-lock side of this same mutex. */
+void modules_registry_rdlock_for_gc(void);
+void modules_registry_wrlock_for_gc(void);
+void modules_registry_unlock_for_gc(void);
+
 /* Register a built-in module */
 void modules_register_builtin(val_t name_list, val_t env);
 

--- a/src/sx_algebra.c
+++ b/src/sx_algebra.c
@@ -28,6 +28,13 @@ static int atab_initialised = 0;
  * consistent copy, not a live, potentially-mid-write table slot. */
 static pthread_rwlock_t atab_lock = PTHREAD_RWLOCK_INITIALIZER;
 
+/* Issue #146: same reasoning and pattern as sx_rules.c's identical
+ * rtab_generation/rtab_last_scanned_gen fix -- see that file's comment
+ * for the full explanation of why a per-thread "nothing added since my
+ * last scan" check is correctness-preserving, not just a heuristic. */
+static _Atomic uint64_t atab_generation = 0;
+static CURRY_THREAD_LOCAL uint64_t atab_last_scanned_gen = (uint64_t)-1;
+
 void sx_algebra_init(void) {
     memset(atab, 0, sizeof(atab));
     for (int i = 0; i < ATAB_SIZE; i++) atab[i].op = V_VOID;
@@ -67,6 +74,9 @@ void sx_algebra_define(val_t op, bool commutative, bool associative,
             atab[idx].identity     = identity;
             atab[idx].absorbing    = absorbing;
             atab[idx].relations_fn = relations_fn;
+            atomic_store_explicit(&atab_generation,
+                atomic_load_explicit(&atab_generation, memory_order_relaxed) + 1,
+                memory_order_relaxed);
             pthread_rwlock_unlock(&atab_lock);
             /* Issue #137: same reasoning as sx_rule_add's identical
              * call -- a node cached as "fully simplified" before this
@@ -89,7 +99,13 @@ void sx_algebra_gc_scan(void) {
      * sx_algebra_define uses; safe against self-deadlock for the same
      * reason sx_rules_gc_scan's identical fix is -- gc_ss_evac/gc_ss_fwd
      * don't allocate, and neither sx_algebra_define nor
-     * sx_algebra_lookup ever allocates while holding atab_lock. */
+     * sx_algebra_lookup ever allocates while holding atab_lock.
+     *
+     * Issue #146: skip the walk when nothing has been added to atab (by
+     * any thread) since this thread's own last scan -- see
+     * atab_generation's/rtab_generation's declaration comments. */
+    uint64_t gen = atomic_load_explicit(&atab_generation, memory_order_relaxed);
+    if (gen == atab_last_scanned_gen) return;
     pthread_rwlock_wrlock(&atab_lock);
     for (int i = 0; i < ATAB_SIZE; i++) {
         if (atab[i].op == V_VOID) continue;
@@ -99,6 +115,7 @@ void sx_algebra_gc_scan(void) {
         atab[i].relations_fn = (val_t)gc_ss_evac((uintptr_t)atab[i].relations_fn);
     }
     pthread_rwlock_unlock(&atab_lock);
+    atab_last_scanned_gen = gen;
 }
 
 /* ---- Assumption keyword → flag ---- */

--- a/src/sx_rules.c
+++ b/src/sx_rules.c
@@ -50,6 +50,33 @@ static int rtab_initialised = 0;
  * implementations' writer-preference. */
 static pthread_rwlock_t rtab_lock = PTHREAD_RWLOCK_INITIALIZER;
 
+/* Issue #146: sx_rules_gc_scan used to walk every accumulated rule on
+ * every single minor GC, from every actor, unconditionally -- an O(total
+ * rule count) cost paid repeatedly (once per actor's own minor GC) even
+ * when nothing in rtab could possibly need re-scanning. It can't: each
+ * actor's minor GC only evacuates pointers into THAT actor's own
+ * thread-local nursery (gc_nursery, gc.h, is CURRY_THREAD_LOCAL; evacuate/
+ * gc_ss_evac's in_nursery check is against the calling thread's own
+ * bounds) -- so a scan is only ever useful if some rule holding a
+ * still-unpromoted nursery pointer was added since this exact thread's
+ * own last scan. rtab_generation is bumped (under rtab_lock, so no extra
+ * atomicity is needed for the increment itself) on every successful
+ * sx_rule_add; rtab_last_scanned_gen is a plain thread-local snapshot of
+ * the generation this thread scanned as of its last sx_rules_gc_scan
+ * call. If nothing was added anywhere since then, this thread's next
+ * minor GC needs no work here at all -- any rule added by ANOTHER thread
+ * still gets a correctly-scoped (if now slightly delayed) scan the first
+ * time that OTHER thread's own minor GC runs, since generation is shared
+ * across all threads. The comparison is a relaxed atomic load/store, not
+ * because of any ordering requirement here (the real synchronization for
+ * the scan itself is still rtab_lock, unchanged), just because the
+ * generation counter is written under a different thread's rtab_lock
+ * critical section than the one reading it here -- a plain read/write
+ * pair split across threads is a data race by the letter of C11
+ * regardless of what a mutex elsewhere in the program guarantees. */
+static _Atomic uint64_t rtab_generation = 0;
+static CURRY_THREAD_LOCAL uint64_t rtab_last_scanned_gen = (uint64_t)-1;
+
 void sx_rules_init(void) {
     for (int i = 0; i < RTAB_SIZE; i++) rtab[i].op = V_VOID;
     rtab_initialised = 1;
@@ -109,6 +136,17 @@ void sx_rule_add(val_t pattern, val_t pvars,
         while (tail->next) tail = tail->next;
         tail->next = r;
     }
+    /* Issue #146: a fresh rule may hold nursery pointers (pattern/pvars/
+     * guard_fn/action_fn/ruleset) that a scan needs to evacuate -- bump
+     * the generation counter so any thread's "nothing changed, skip"
+     * check in sx_rules_gc_scan sees it. Still inside rtab_lock: no
+     * separate atomicity concern for the increment itself, just needs to
+     * use an atomic store since the counter is read via a plain relaxed
+     * load from other threads without rtab_lock (see the counter's own
+     * declaration comment). */
+    atomic_store_explicit(&rtab_generation,
+        atomic_load_explicit(&rtab_generation, memory_order_relaxed) + 1,
+        memory_order_relaxed);
     pthread_rwlock_unlock(&rtab_lock);
 
     /* Issue #137: a node sx_simplify already cached as "fully
@@ -332,7 +370,15 @@ void sx_rules_gc_scan(void) {
      * sx_rule_add's pre-lock GC_NEW and sx_rules_list's snapshot-then-
      * release pattern) -- so no thread can already be holding rtab_lock
      * at the moment its own allocation triggers the minor collection
-     * that calls this scanner. */
+     * that calls this scanner.
+     *
+     * Issue #146: skip the whole O(total rule count) walk below when
+     * nothing has been added to rtab (by ANY thread) since this thread's
+     * own last scan -- see rtab_generation's declaration comment for why
+     * that's a sufficient, correctness-preserving check, not just a
+     * heuristic. */
+    uint64_t gen = atomic_load_explicit(&rtab_generation, memory_order_relaxed);
+    if (gen == rtab_last_scanned_gen) return;
     pthread_rwlock_wrlock(&rtab_lock);
     for (int i = 0; i < RTAB_SIZE; i++) {
         if (rtab[i].op == V_VOID) continue;
@@ -348,4 +394,5 @@ void sx_rules_gc_scan(void) {
         }
     }
     pthread_rwlock_unlock(&rtab_lock);
+    rtab_last_scanned_gen = gen;
 }


### PR DESCRIPTION
## Summary

- Closes #150: `gc_gen.c`'s T_MODULE evacuation of a live Module's `name`/`exports` fields raced `modules_import`'s unlocked read of `mod->exports` under `--gc generational`. Exposes `modules.c`'s existing `module_registry_lock` via three wrapper functions and takes it on both sides, mirroring #198's identical fix for GLOBAL_ENV.
- Closes #146: `sx_rules_gc_scan`/`sx_algebra_gc_scan` walked their entire table on every minor GC from every actor, holding a write lock for the whole O(table-size) duration -- a real throughput regression. Adds a shared generation counter + per-thread last-scanned marker to skip the walk when nothing changed since this thread's own last scan.
- Both scoped to the experimental, opt-in `--gc generational` backend; the default Boehm backend is unaffected.
- Filed #203 as a follow-up: code review surfaced a deeper, pre-existing gap one level past #150's scope (list-cell traversal after the lock is released) -- real, but needs a different fix shape (snapshot-under-lock, like `sx_rule_try` already does for rtab), so it's tracked separately rather than expanding this PR.

## Test plan

- [x] `cmake --build build` -- clean
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` -- 127/127 passing
- [x] Smoke-tested under `--gc generational` (module import works correctly)
- [x] Manual A/B via `git stash`: #146's fix measured ~6x faster on a 5000-rule/8-actor repro (0.435s -> 0.074s)
- [x] Independent code-review pass (fresh subagent) -- confirmed both fixes correct; found and I filed the #203 follow-up
- [x] Independent security-review pass (fresh subagent) -- no findings; confirmed the #146 skip-check is sound and can't cause missed evacuation, no new attack surface from the #150 lock wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151dxuF9rGDxCxMt1BArPph
