### PR TITLE
feat(gc_gen): stop-the-world safepoint plumbing, Phase A (#200)

### DIFF
--- a/include/curry.h
+++ b/include/curry.h
@@ -219,6 +219,23 @@ void curry_port_write_byte(curry_val port, uint8_t byte);
  * an output port. No-op on a closed port or a non-port value. */
 void curry_port_write_string(curry_val port, const char *s);
 
+/* Issue #200 Phase A: bracket a C module primitive's own genuinely long
+ * or unbounded blocking OS call (a blocking accept()/recv()/connect()
+ * with no timeout, or anything else that can block for an unpredictable
+ * duration) with curry_gc_thread_park() immediately before the call and
+ * curry_gc_thread_unpark() immediately after it returns. Without this, a
+ * future stop-the-world GC safepoint request (--gc generational; a
+ * cheap no-op under the default Boehm backend) would wait for this
+ * thread to return to its next safepoint poll, which may not happen
+ * until the blocking call itself completes -- e.g. until a connection
+ * arrives, which may be never. Safe to park across any call that
+ * doesn't touch Curry heap values while blocked, which every plain OS
+ * networking/IO syscall qualifies as. Calls must be paired 1:1, with no
+ * Curry API calls in between (the whole point is that nothing Curry-
+ * visible happens while parked). */
+void curry_gc_thread_park(void);
+void curry_gc_thread_unpark(void);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/modules/mcp/mcp.c
+++ b/modules/mcp/mcp.c
@@ -819,6 +819,12 @@ static void handle_sse_get(int fd) {
      * concurrent write failure on the POST side.
      * Use nanosleep with EINTR retry so Boehm GC signals (stop-the-world)
      * don't truncate the 15-second interval and fire a premature keepalive. */
+    /* Issue #200 Phase A: this loop blocks (in nanosleep, then whatever
+     * time the client takes to keep the socket alive) for the life of
+     * the SSE connection, which is meant to last indefinitely -- park
+     * for the whole loop, not per iteration, since nothing here touches
+     * Curry heap state either way. */
+    curry_gc_thread_park();
     while (true) {
         struct timespec ts = {15, 0}, rem;
         while (nanosleep(&ts, &rem) < 0 && errno == EINTR) ts = rem;
@@ -833,6 +839,7 @@ static void handle_sse_get(int fd) {
         pthread_mutex_unlock(&sess->wlock);
         if (!alive) break;
     }
+    curry_gc_thread_unpark();
 
 done:
     pthread_mutex_lock(&sess->wlock);
@@ -907,14 +914,22 @@ static void *conn_thread(void *arg) {
     vm_init();
 
     HttpReq req;
-    if (!http_recv(fd, &req)) { close(fd); return NULL; }
+    /* Issue #200 Phase A: http_recv can block indefinitely waiting for a
+     * slow/idle client -- park across the whole read, not each individual
+     * recv() inside it (fd_read_line reads one byte at a time; bracketing
+     * every syscall would mean a park/unpark pair, and the global
+     * gc_stw_mutex they take, per byte). */
+    curry_gc_thread_park();
+    bool got_req = http_recv(fd, &req);
+    curry_gc_thread_unpark();
+    if (!got_req) { close(fd); goto out; }
 
     /* OPTIONS preflight carries no credentials — bypass auth for CORS. */
     if (strcmp(req.method, "OPTIONS") == 0) {
         send(fd, CORS_PREFLIGHT, strlen(CORS_PREFLIGHT), MSG_NOSIGNAL);
         close(fd);
         free(req.body);
-        return NULL;
+        goto out;
     }
 
     /* POST /token is the unauthenticated token-issuance endpoint (mode A). */
@@ -924,18 +939,20 @@ static void *conn_thread(void *arg) {
         mcp_auth_handle_token_endpoint(fd, req.body ? req.body : "", req.body_len);
         close(fd);
         free(req.body);
-        return NULL;
+        goto out;
     }
 
     /* All other endpoints require a valid Bearer token. */
-    const char *bearer = extract_bearer(req.auth);
-    if (!mcp_auth_validate(bearer)) {
-        send_unauthorized(fd,
-            bearer[0] ? "invalid_token" : NULL,
-            bearer[0] ? "The access token is invalid or has expired" : NULL);
-        close(fd);
-        free(req.body);
-        return NULL;
+    {
+        const char *bearer = extract_bearer(req.auth);
+        if (!mcp_auth_validate(bearer)) {
+            send_unauthorized(fd,
+                bearer[0] ? "invalid_token" : NULL,
+                bearer[0] ? "The access token is invalid or has expired" : NULL);
+            close(fd);
+            free(req.body);
+            goto out;
+        }
     }
 
     if (strcmp(req.method, "GET") == 0 && strcmp(req.path, "/sse") == 0) {
@@ -948,6 +965,13 @@ static void *conn_thread(void *arg) {
     }
 
     free(req.body);
+out:
+    /* Issue #200 Phase A: symmetric with gc_register_thread() above --
+     * every exit path funnels through here so gc_gen_thread_count stays
+     * accurate (a leaked count per connection would eventually make a
+     * future stop-the-world request wait forever on threads that no
+     * longer exist). */
+    gc_unregister_thread();
     return NULL;
 }
 
@@ -1005,6 +1029,10 @@ static curry_val fn_mcp_serve_sse(int ac, curry_val *av, void *ud) {
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
+    /* Issue #200 Phase A: accept() blocks indefinitely between incoming
+     * connections -- park across the whole loop, not per-iteration
+     * (matches the doc comment above: "blocks forever"). */
+    curry_gc_thread_park();
     while (true) {
         int fd = accept(srv, NULL, NULL);
         if (fd < 0) continue;
@@ -1013,6 +1041,7 @@ static curry_val fn_mcp_serve_sse(int ac, curry_val *av, void *ud) {
         pthread_t tid;
         pthread_create(&tid, &attr, conn_thread, ca);
     }
+    curry_gc_thread_unpark();
 
     pthread_attr_destroy(&attr);
     close(srv);

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -450,7 +450,12 @@ static curry_val fn_receive(int ac, curry_val *av, void *ud) {
         ts.tv_sec  +=  timeout_ms / 1000;
         ts.tv_nsec += (long)(timeout_ms % 1000) * 1000000L;
         if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
+        /* Issue #200 Phase A: bounded by timeout_ms, but a caller can pass
+         * an arbitrarily large one -- park so a future GC safepoint
+         * doesn't wait on this thread for as long as that takes. */
+        curry_gc_thread_park();
         pthread_cond_timedwait(&c->qcv, &c->qmtx, &ts);
+        curry_gc_thread_unpark();
     }
 
     if (c->qhead == c->qtail) {

--- a/modules/network/network.c
+++ b/modules/network/network.c
@@ -104,12 +104,21 @@ static curry_val fn_tcp_connect(int ac, curry_val *av, void *ud) {
     struct addrinfo hints = {0}, *res;
     hints.ai_family   = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
-    if (getaddrinfo(host, port_str, &hints, &res) != 0)
+    /* Issue #200 Phase A: DNS resolution and connect() can both block for
+     * a while (resolver timeout, TCP connect timeout) -- park across both
+     * so a future GC safepoint doesn't wait on this thread meanwhile. */
+    curry_gc_thread_park();
+    int gai_rc = getaddrinfo(host, port_str, &hints, &res);
+    curry_gc_thread_unpark();
+    if (gai_rc != 0)
         curry_error("tcp-connect: could not resolve %s", host);
 
     sock_t fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (fd == SOCK_INVALID) { freeaddrinfo(res); curry_error("tcp-connect: socket failed"); }
-    if (connect(fd, res->ai_addr, (socklen_t)res->ai_addrlen) != 0) {
+    curry_gc_thread_park();
+    int connect_rc = connect(fd, res->ai_addr, (socklen_t)res->ai_addrlen);
+    curry_gc_thread_unpark();
+    if (connect_rc != 0) {
         sock_close(fd); freeaddrinfo(res);
         curry_error("tcp-connect: connect failed");
     }
@@ -176,7 +185,12 @@ static curry_val fn_tcp_accept(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
     sock_t server = net_checked_val_to_sock(av[0], "tcp-accept");
     struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
+    /* Issue #200 Phase A: accept() can block indefinitely waiting for an
+     * incoming connection -- park so a future GC safepoint doesn't wait
+     * on this thread for as long as that takes (see curry.h's comment). */
+    curry_gc_thread_park();
     sock_t client = accept((int)server, (struct sockaddr *)&addr, &addrlen);
+    curry_gc_thread_unpark();
     if (client == SOCK_INVALID) curry_error("tcp-accept: accept failed");
 
     /* Port pair, same rationale (and same fd-leak-on-fdopen-failure fix)
@@ -267,8 +281,11 @@ static curry_val fn_udp_recv(int ac, curry_val *av, void *ud) {
     uint8_t *buf = malloc((size_t)maxbytes);
     if (!buf) curry_error("udp-recv: out of memory");
     struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
+    /* Issue #200 Phase A: can block indefinitely with nothing incoming. */
+    curry_gc_thread_park();
     ssize_t n = recvfrom((int)fd, buf, (size_t)maxbytes, 0,
                           (struct sockaddr *)&addr, &addrlen);
+    curry_gc_thread_unpark();
     if (n < 0) { free(buf); curry_error("udp-recv: recvfrom failed"); }
     curry_val bv = curry_make_bytevector((uint32_t)n, 0);
     for (ssize_t i = 0; i < n; i++) curry_bytevector_set(bv, (uint32_t)i, buf[i]);

--- a/modules/network/srfi106.c
+++ b/modules/network/srfi106.c
@@ -111,7 +111,12 @@ static curry_val fn_make_client_socket(int ac, curry_val *av, void *ud) {
     hints.ai_flags    = ac > 4 ? (int)checked_fixnum(av[4], 5, "make-client-socket") : 0;
     hints.ai_protocol = ac > 5 ? (int)checked_fixnum(av[5], 6, "make-client-socket") : 0;
 
-    if (getaddrinfo(node, service, &hints, &res) != 0)
+    /* Issue #200 Phase A: DNS resolution and connect() can both block for
+     * a while -- park across both (see curry.h's own comment). */
+    curry_gc_thread_park();
+    int gai_rc = getaddrinfo(node, service, &hints, &res);
+    curry_gc_thread_unpark();
+    if (gai_rc != 0)
         curry_error("make-client-socket: could not resolve %s", node);
 
     sock_t fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
@@ -119,7 +124,10 @@ static curry_val fn_make_client_socket(int ac, curry_val *av, void *ud) {
         freeaddrinfo(res);
         curry_error("make-client-socket: socket failed");
     }
-    if (connect((int)fd, res->ai_addr, (socklen_t)res->ai_addrlen) != 0) {
+    curry_gc_thread_park();
+    int connect_rc = connect((int)fd, res->ai_addr, (socklen_t)res->ai_addrlen);
+    curry_gc_thread_unpark();
+    if (connect_rc != 0) {
         sock_close(fd);
         freeaddrinfo(res);
         curry_error("make-client-socket: connect failed");
@@ -139,7 +147,11 @@ static curry_val fn_make_server_socket(int ac, curry_val *av, void *ud) {
     hints.ai_flags    = AI_PASSIVE;
     hints.ai_protocol = ac > 3 ? (int)checked_fixnum(av[3], 4, "make-server-socket") : 0;
 
-    if (getaddrinfo(NULL, service, &hints, &res) != 0)
+    /* Issue #200 Phase A: see fn_make_client_socket's identical comment. */
+    curry_gc_thread_park();
+    int gai_rc = getaddrinfo(NULL, service, &hints, &res);
+    curry_gc_thread_unpark();
+    if (gai_rc != 0)
         curry_error("make-server-socket: could not resolve service %s", service);
 
     sock_t fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
@@ -175,7 +187,10 @@ static curry_val fn_socket_accept(int ac, curry_val *av, void *ud) {
     (void)ud; (void)ac;
     int server = net_extract_fd(av[0], "socket-accept");
     struct sockaddr_storage addr; socklen_t addrlen = sizeof(addr);
+    /* Issue #200 Phase A: see network.c's fn_tcp_accept's identical comment. */
+    curry_gc_thread_park();
     sock_t client = accept(server, (struct sockaddr *)&addr, &addrlen);
+    curry_gc_thread_unpark();
     if (client == SOCK_INVALID) curry_error("socket-accept: accept failed");
     return net_sock_to_val_registered(client, "socket-accept");
 }
@@ -238,7 +253,10 @@ static curry_val fn_socket_recv(int ac, curry_val *av, void *ud) {
 
     uint8_t *buf = malloc((size_t)size);
     if (!buf) curry_error("socket-recv: out of memory");
+    /* Issue #200 Phase A: can block indefinitely with nothing incoming. */
+    curry_gc_thread_park();
     ssize_t n = recv(fd, buf, (size_t)size, flags);
+    curry_gc_thread_unpark();
     if (n < 0) { free(buf); curry_error("socket-recv: recv failed: %s", strerror(errno)); }
 
     curry_val bv = curry_make_bytevector((uint32_t)n, 0);

--- a/modules/network/tls.c
+++ b/modules/network/tls.c
@@ -155,12 +155,20 @@ static curry_val fn_tcp_connect_tls(int ac, curry_val *av, void *ud) {
     struct addrinfo hints = {0}, *res;
     hints.ai_family   = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
-    if (getaddrinfo(host, port_str, &hints, &res) != 0)
+    /* Issue #200 Phase A: DNS resolution and connect() can both block for
+     * a while -- park across both (see curry.h's own comment). */
+    curry_gc_thread_park();
+    int gai_rc = getaddrinfo(host, port_str, &hints, &res);
+    curry_gc_thread_unpark();
+    if (gai_rc != 0)
         curry_error("tcp-connect-tls: could not resolve %s", host);
 
     int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (fd < 0) { freeaddrinfo(res); curry_error("tcp-connect-tls: socket failed"); }
-    if (connect(fd, res->ai_addr, (socklen_t)res->ai_addrlen) != 0) {
+    curry_gc_thread_park();
+    int connect_rc = connect(fd, res->ai_addr, (socklen_t)res->ai_addrlen);
+    curry_gc_thread_unpark();
+    if (connect_rc != 0) {
         close(fd); freeaddrinfo(res);
         curry_error("tcp-connect-tls: connect failed");
     }
@@ -184,7 +192,12 @@ static curry_val fn_tcp_connect_tls(int ac, curry_val *av, void *ud) {
         curry_error("tcp-connect-tls: SSL_set1_host failed");
     }
 
-    if (SSL_connect(ssl) != 1) {
+    /* Issue #200 Phase A: the TLS handshake itself is a blocking network
+     * round-trip, same rationale as the plain connect() above. */
+    curry_gc_thread_park();
+    int ssl_connect_rc = SSL_connect(ssl);
+    curry_gc_thread_unpark();
+    if (ssl_connect_rc != 1) {
         unsigned long e = ERR_get_error();
         char errbuf[256];
         ERR_error_string_n(e, errbuf, sizeof(errbuf));

--- a/modules/piper/piper.c
+++ b/modules/piper/piper.c
@@ -621,8 +621,15 @@ static curry_val fn_piper_wait(int ac, curry_val *av, void *ud) {
     PiperPlayback *pb = (PiperPlayback *)val_to_ptr(av[0]);
 
     pthread_mutex_lock(&pb->lock);
-    while (!pb->done)
-        pthread_cond_wait(&pb->cond, &pb->lock);
+    if (!pb->done) {
+        /* Issue #200 Phase A: audio playback duration is unbounded from
+         * the GC's perspective -- park so a future safepoint doesn't wait
+         * on this thread for as long as that takes. */
+        curry_gc_thread_park();
+        while (!pb->done)
+            pthread_cond_wait(&pb->cond, &pb->lock);
+        curry_gc_thread_unpark();
+    }
     bool had_error = pb->had_error;
     char msg[256];
     if (had_error) memcpy(msg, pb->error_msg, sizeof(msg));

--- a/modules/sync/sync.c
+++ b/modules/sync/sync.c
@@ -154,7 +154,11 @@ static curry_val fn_cond_wait(int ac, curry_val *av, void *ud) {
     (void)ac; (void)ud;
     pthread_cond_t  *cv = get_cond(av[0], "cond-wait!");
     pthread_mutex_t *m  = get_mutex(av[1], "cond-wait!");
+    /* Issue #200 Phase A: an untimed wait can block indefinitely -- park
+     * so a future GC safepoint doesn't wait on this thread meanwhile. */
+    curry_gc_thread_park();
     pthread_cond_wait(cv, m);
+    curry_gc_thread_unpark();
     return curry_void();
 }
 /* (cond-wait-timeout! cv mutex seconds) → #t signalled, #f timed out */
@@ -169,7 +173,11 @@ static curry_val fn_cond_wait_timeout(int ac, curry_val *av, void *ud) {
     ts.tv_sec  += (time_t)secs;
     ts.tv_nsec += (long)((secs - (long)secs) * 1e9);
     if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
+    /* Issue #200 Phase A: bounded by the timeout, but that can still be
+     * arbitrarily long -- see fn_cond_wait's identical comment. */
+    curry_gc_thread_park();
     int rc = pthread_cond_timedwait(cv, m, &ts);
+    curry_gc_thread_unpark();
     return curry_make_bool(rc != ETIMEDOUT);
 }
 static curry_val fn_cond_signal(int ac, curry_val *av, void *ud) {
@@ -220,7 +228,13 @@ static curry_val fn_sem_wait(int ac, curry_val *av, void *ud) {
     (void)ac; (void)ud;
     ScmSem *s = get_sem(av[0], "sem-wait!");
     pthread_mutex_lock(&s->mtx);
-    while (s->count == 0) pthread_cond_wait(&s->cnd, &s->mtx);
+    if (s->count == 0) {
+        /* Issue #200 Phase A: can block indefinitely -- see fn_cond_wait's
+         * identical comment. */
+        curry_gc_thread_park();
+        while (s->count == 0) pthread_cond_wait(&s->cnd, &s->mtx);
+        curry_gc_thread_unpark();
+    }
     s->count--;
     pthread_mutex_unlock(&s->mtx);
     return curry_void();

--- a/src/actors.c
+++ b/src/actors.c
@@ -125,9 +125,24 @@ static void mailbox_push(Mailbox *m, val_t msg, Actor *target) {
 static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
     pthread_mutex_lock(&m->mutex);
     if (timeout_ms < 0) {
-        while (m->q.head == m->q.tail)
-            pthread_cond_wait(&m->cond, &m->mutex);
-    } else {
+        if (m->q.head == m->q.tail) {
+            /* Issue #200 Phase A: this can block for an unbounded time
+             * (no message ever arrives) -- park so a future
+             * gc_gen_stop_the_world() doesn't wait on this thread for as
+             * long as that takes. Safe: this thread touches no Curry
+             * heap pointers while blocked here beyond what the pinned
+             * Mailbox object itself already exposes. */
+            gc_gen_thread_park();
+            while (m->q.head == m->q.tail)
+                pthread_cond_wait(&m->cond, &m->mutex);
+            gc_gen_thread_unpark();
+        }
+    } else if (m->q.head == m->q.tail) {
+        /* Bounded by timeout_ms, but still park -- the timeout can be
+         * arbitrarily long, and there's no reason to make a
+         * stop-the-world request wait out someone else's receive
+         * timeout when this thread isn't touching Curry objects. */
+        gc_gen_thread_park();
         while (m->q.head == m->q.tail) {
             struct timespec ts;
             clock_gettime(CLOCK_REALTIME, &ts);
@@ -136,10 +151,12 @@ static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
             if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
             int rc = pthread_cond_timedwait(&m->cond, &m->mutex, &ts);
             if (rc != 0 && m->q.head == m->q.tail) {
+                gc_gen_thread_unpark();
                 pthread_mutex_unlock(&m->mutex);
                 return V_FALSE;  /* timeout */
             }
         }
+        gc_gen_thread_unpark();
     }
     val_t msg = m->q.msgs[m->q.head];
     m->q.head = (m->q.head + 1) % m->q.cap;
@@ -217,6 +234,12 @@ static void *actor_thread(void *arg) {
      * to leak one allocation per actor spawned from an active load
      * context (i.e. nearly every actor in practice). */
     load_dir_release(0);
+
+    /* Issue #200 Phase A: symmetric with gc_register_thread() at this
+     * thread's entry (top of actor_thread) -- keeps gc_gen_thread_count
+     * accurate now that a thread count actually exists to keep accurate.
+     * See gc.h's own comment on this function. */
+    gc_unregister_thread();
 
     vm_free();
     pthread_cleanup_pop(1);

--- a/src/api.c
+++ b/src/api.c
@@ -248,6 +248,9 @@ void curry_port_write_string(curry_val port, const char *s) {
     port_write_string((val_t)port, s, (uint32_t)strlen(s));
 }
 
+void curry_gc_thread_park(void)   { gc_gen_thread_park(); }
+void curry_gc_thread_unpark(void) { gc_gen_thread_unpark(); }
+
 /* ---- List helpers ---- */
 
 curry_val curry_list(int n, ...) {

--- a/src/builtins_curry.c
+++ b/src/builtins_curry.c
@@ -1134,12 +1134,19 @@ static val_t prim_tree_eval(int ac, val_t *av, void *ud) {
 
 static int map_par_threshold = 8;
 
-/* Shared wait pattern: submit, wait, check errors. */
+/* Shared wait pattern: submit, wait, check errors.
+ * Issue #200 Phase A: the submitting thread's wait here is unbounded from
+ * the GC's perspective (worker completion time isn't known in advance) --
+ * park so a future GC safepoint doesn't wait on this thread meanwhile. */
 #define POOL_WAIT(n_done_var, nchunks_var, done_mutex_var, done_cond_var) \
     do { \
         pthread_mutex_lock(&(done_mutex_var)); \
-        while (atomic_load(&(n_done_var)) < (nchunks_var)) \
-            pthread_cond_wait(&(done_cond_var), &(done_mutex_var)); \
+        if (atomic_load(&(n_done_var)) < (nchunks_var)) { \
+            gc_gen_thread_park(); \
+            while (atomic_load(&(n_done_var)) < (nchunks_var)) \
+                pthread_cond_wait(&(done_cond_var), &(done_mutex_var)); \
+            gc_gen_thread_unpark(); \
+        } \
         pthread_mutex_unlock(&(done_mutex_var)); \
         pthread_mutex_destroy(&(done_mutex_var)); \
         pthread_cond_destroy(&(done_cond_var)); \

--- a/src/channel.c
+++ b/src/channel.c
@@ -66,11 +66,17 @@ void channel_send(val_t v, val_t val) {
         gc_wb_slot(&ch->buf[0], val);
         ch->hdr.flags |= CH_SYNC_WAITING_SEND;
         pthread_cond_signal(&ch->not_empty);
+        /* Issue #200 Phase A: can block indefinitely with no receiver --
+         * park so a future GC safepoint doesn't wait on this thread. */
+        gc_gen_thread_park();
         while ((ch->hdr.flags & CH_SYNC_WAITING_SEND) && !ch->closed)
             pthread_cond_wait(&ch->not_full, &ch->lock);
+        gc_gen_thread_unpark();
     } else {
+        gc_gen_thread_park();
         while (ch->count == ch->cap && !ch->closed)
             pthread_cond_wait(&ch->not_full, &ch->lock);
+        gc_gen_thread_unpark();
 
         if (ch->closed) {
             pthread_mutex_unlock(&ch->lock);
@@ -98,8 +104,11 @@ val_t channel_recv(val_t v) {
     if (ch->cap == 0) {
         ch->hdr.flags |= CH_SYNC_WAITING_RECV;
         pthread_cond_signal(&ch->not_full);
+        /* Issue #200 Phase A: see channel_send's identical comment. */
+        gc_gen_thread_park();
         while (!(ch->hdr.flags & CH_SYNC_WAITING_SEND) && !ch->closed)
             pthread_cond_wait(&ch->not_empty, &ch->lock);
+        gc_gen_thread_unpark();
 
         if (ch->closed && !(ch->hdr.flags & CH_SYNC_WAITING_SEND)) {
             ch->hdr.flags &= ~(uint32_t)CH_SYNC_WAITING_RECV;
@@ -114,8 +123,10 @@ val_t channel_recv(val_t v) {
         return val;
 
     } else {
+        gc_gen_thread_park();
         while (ch->count == 0 && !ch->closed)
             pthread_cond_wait(&ch->not_empty, &ch->lock);
+        gc_gen_thread_unpark();
 
         if (ch->count == 0) {
             pthread_mutex_unlock(&ch->lock);

--- a/src/eval.c
+++ b/src/eval.c
@@ -218,6 +218,15 @@ tail:
         extern void gc_gen_minor_collect(void);
         gc_gen_minor_collect();
     }
+    /* Issue #200 Phase A: cross-thread safepoint poll, eval()'s analog to
+     * vm.c's L_DISPATCH check just above -- see that comment for the full
+     * rationale (same gc_inhibit_count == 0 gate; cheap no-op under the
+     * default Boehm backend). expr/env are the only live roots needed here,
+     * both already tracked by the GC_AUTOFRAME above. */
+    if (__builtin_expect(gc_inhibit_count == 0, 1)) {
+        extern void gc_gen_safepoint(void);
+        gc_gen_safepoint();
+    }
     /* Non-pointer immediates: fixnum (tag=01), char (tag=10), bool/nil/void/eof (tag=11) */
     if (expr & 3) return expr;
     /* Heap object: dispatch on type */

--- a/src/gc.c
+++ b/src/gc.c
@@ -43,6 +43,17 @@ static void  boehm_register_thread(void) {
     GC_get_stack_base(&sb);
     GC_register_my_thread(&sb);
 }
+/* Issue #200 Phase A: no-op counterpart to gen_unregister_thread's real
+ * live-thread-count decrement (src/gc_gen.c) -- Boehm has no such count to
+ * keep accurate. Needed as its own vtable slot (not just a direct call to
+ * the generational-only decrement from every register_thread() call site)
+ * because register_thread() is itself already backend-dispatched: a
+ * direct, ungated call to the generational decrement from a caller like
+ * actors.c/workpool.c would run under EVERY backend including this one,
+ * silently driving gc_gen_thread_count negative on every actor/worker
+ * exit under the (default) Boehm backend, where nothing ever incremented
+ * it in the first place. */
+static void  boehm_unregister_thread(void) {}
 /* Boehm is conservative — pin/unpin and root registration are no-ops. */
 static void  boehm_pin(void *obj)              { (void)obj; }
 static void  boehm_unpin(void *obj)            { (void)obj; }
@@ -61,6 +72,7 @@ static gc_ops_t gc_boehm_ops = {
     .alloc_raw_pinned  = boehm_alloc_raw_pinned,
     .collect           = boehm_collect,
     .register_thread   = boehm_register_thread,
+    .unregister_thread = boehm_unregister_thread,
     .pin               = boehm_pin,
     .unpin             = boehm_unpin,
     .register_root     = boehm_register_root,
@@ -399,6 +411,10 @@ void gc_init(void) {
 
 void gc_register_thread(void) {
     gc_ops->register_thread();
+}
+
+void gc_unregister_thread(void) {
+    gc_ops->unregister_thread();
 }
 
 void gc_finalizer(void *obj, void (*fn)(void *, void *), void *cd) {

--- a/src/gc.h
+++ b/src/gc.h
@@ -85,6 +85,12 @@ typedef struct gc_ops {
     /* Called once per new pthread before any allocation on that thread. */
     void  (*register_thread)(void);
 
+    /* Issue #200 Phase A: called once, symmetrically, from that same
+     * thread's exit path. No-op under Boehm; decrements the generational
+     * backend's live-thread count (gc_gen_thread_count, gc_gen.c) that a
+     * future stop-the-world safepoint's wait target depends on. */
+    void  (*unregister_thread)(void);
+
     /*
      * Pin/unpin: prevent the collector from moving `obj`.
      * Required when a C extension stores a raw Scheme pointer in a struct or
@@ -184,6 +190,12 @@ static inline void *gc_nursery_alloc(size_t n, bool has_ptrs) {
 
 void gc_init(void);              /* call once at startup, before any allocation */
 void gc_register_thread(void);   /* call once per new pthread                   */
+void gc_unregister_thread(void); /* call once from that same pthread's exit path
+                                   * (issue #200 Phase A) -- backend-dispatched via
+                                   * gc_ops, unlike a direct call to the
+                                   * generational-only gc_gen_unregister_thread(),
+                                   * so it's correctly a no-op under Boehm instead
+                                   * of corrupting a counter Boehm never touches */
 void gc_finalizer(void *obj, void (*fn)(void *, void *), void *cd);
 
 /* GC tuning — safe to call after gc_init() */
@@ -413,6 +425,43 @@ void gc_inhibit_restore(int saved);
     GcFrame _gc_frame = {_gc_frame_roots, (n), gc_shadow_stack}; \
     gc_shadow_stack = &_gc_frame; \
     __attribute__((cleanup(gc_pop_frame))) GcFrame *_gc_frame_sentinel = &_gc_frame
+
+/*
+ * Issue #200 Phase A — stop-the-world safepoint plumbing for the
+ * generational backend (defined unconditionally in gc_gen.c, same as
+ * gc_gen_minor_collect itself; harmless/near-free under the default
+ * Boehm backend since nothing sets gc_stop_world to 1 outside the
+ * generational backend's own code). See gc_gen.c's own declaration
+ * comments for the full rationale.
+ *
+ * gc_gen_safepoint() is already wired into the two existing poll points
+ * (vm.c's L_DISPATCH, eval.c's tail: label) as of this issue; declared
+ * here (rather than only inline-extern'd at those two sites, matching
+ * gc_gen_minor_collect's convention) because the remaining functions
+ * below have several call sites across different files.
+ *
+ * gc_gen_thread_park()/gc_gen_thread_unpark() bracket a genuinely long or
+ * unbounded blocking call (mailbox receive, a blocking accept()/recv(), a
+ * work-queue park) — without this, a thread parked in such a call would
+ * never return to a poll point on its own, so a future
+ * gc_gen_stop_the_world() request would wait for it indefinitely. Pair
+ * every blocking call reachable from actor code with these, park()
+ * immediately before the blocking call and unpark() immediately after.
+ *
+ * gc_gen_unregister_thread() is gc_gen.c's own vtable implementation of
+ * gc_unregister_thread() (above, near gc_register_thread's own
+ * declaration) -- call sites should use gc_unregister_thread(), NOT this
+ * directly: a direct call would run unconditionally regardless of active
+ * backend, decrementing gc_gen_thread_count even under Boehm (which never
+ * incremented it in the first place, since gen_register_thread is only
+ * reached when the generational backend is active). Declared here only
+ * so gc.c's vtable wiring can see it. */
+void gc_gen_safepoint(void);
+void gc_gen_stop_the_world(void);
+void gc_gen_start_the_world(void);
+void gc_gen_thread_park(void);
+void gc_gen_thread_unpark(void);
+void gc_gen_unregister_thread(void);  /* vtable impl only -- see comment above */
 
 /* ── GC statistics (available under both Boehm and generational backends) ── */
 

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -729,6 +729,139 @@ static void scan_pinned_object(void *obj) {
 static uintptr_t gen_evac_fn(uintptr_t v) { return (uintptr_t)evacuate((val_t)v); }
 static void     *gen_fwd_fn(void *p)      { return evacuate_raw(p); }
 
+/* ── Safepoint: live thread count and stop-the-world handshake ───────────── */
+/*
+ * Issue #200 Phase A. Ported from gc_generational.c's safepoint core
+ * (gc_generational.c:181-242) -- that file is an orphaned, never-built
+ * earlier GC rewrite attempt (CMakeLists.txt only compiles gc.c and THIS
+ * file), but its stop-the-world mechanism itself is architecture-agnostic
+ * (it doesn't depend on that file's shared-nursery design) and is a clean
+ * fit here, adapted to this file's actually-live per-thread-nursery model
+ * and its own gc_inhibit_count (gc.c)/gc_minor_pending conventions rather
+ * than duplicating them.
+ *
+ * This section is PLUMBING ONLY -- gc_stop_world is never set to 1 by
+ * anything in this phase (that's Phase B, wiring it into
+ * gc_gen_minor_collect()'s pinned-object-scan window so a scan of any
+ * object reachable from more than one actor thread runs with every other
+ * actor genuinely paused, closing the whole class of race #198/#150/#200
+ * found piecemeal). Landing the plumbing on its own first: it's pure
+ * addition with no behavior change (gc_gen_safepoint() is an always-false
+ * fast-path check until Phase B), independently testable, and keeps this
+ * change reviewable at the size the rest of this session's core-touching
+ * work has been kept at.
+ *
+ * gc_gen_thread_count is the piece that didn't exist at all before this:
+ * gen_register_thread (below) sets up a thread's nursery but never
+ * tracked a live-thread count anywhere, and no actor-exit path called
+ * anything symmetric to unregister one (see gc_gen_unregister_thread's
+ * own comment). A safepoint's "has everyone else paused" wait needs an
+ * accurate count to wait against.
+ *
+ * gc_stop_world/gc_gen_parked_count/gc_gen_thread_count are _Atomic
+ * rather than plain, even though every real synchronization decision
+ * still happens under gc_stw_mutex/the condvars -- gc_gen_safepoint()'s
+ * fast path deliberately reads gc_stop_world OUTSIDE the mutex before
+ * falling back to the locked slow path (the whole point of a cheap
+ * poll), and a plain read racing a plain write from another thread is a
+ * data race by the letter of C11 regardless of what the mutex elsewhere
+ * guarantees -- the same class of issue #153/#198's fixes closed for
+ * GLOBAL_ENV's seqlock-protected fields, so the same fix applies here.
+ */
+static _Atomic int gc_gen_thread_count = 0;
+static _Atomic int gc_gen_parked_count = 0;
+static _Atomic int gc_stop_world       = 0;
+
+static pthread_mutex_t gc_stw_mutex  = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  gc_stw_resume = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t  gc_stw_parked = PTHREAD_COND_INITIALIZER;
+
+/* Called from the same poll points gc_minor_pending's self-collection
+ * check already uses (vm.c's L_DISPATCH, eval.c's tail: label), under
+ * the same gc_inhibit_count == 0 gate -- see those call sites' own
+ * comments for why that gate is what makes this correct: a thread
+ * mid-primitive-call (which may transiently hold a subsystem lock this
+ * scan needs, e.g. rtab_lock/pinned_lock) is never asked to park until
+ * it returns here with the inhibit count back at zero, so
+ * gc_gen_stop_the_world()'s wait naturally waits out any in-flight
+ * critical section instead of racing it. */
+void gc_gen_safepoint(void) {
+    if (!atomic_load_explicit(&gc_stop_world, memory_order_relaxed)) return;
+    pthread_mutex_lock(&gc_stw_mutex);
+    if (atomic_load_explicit(&gc_stop_world, memory_order_relaxed)) {
+        atomic_fetch_add_explicit(&gc_gen_parked_count, 1, memory_order_relaxed);
+        pthread_cond_signal(&gc_stw_parked);
+        while (atomic_load_explicit(&gc_stop_world, memory_order_relaxed))
+            pthread_cond_wait(&gc_stw_resume, &gc_stw_mutex);
+        atomic_fetch_sub_explicit(&gc_gen_parked_count, 1, memory_order_relaxed);
+    }
+    pthread_mutex_unlock(&gc_stw_mutex);
+}
+
+/* Requester side: block until every OTHER live registered thread has
+ * reached gc_gen_safepoint() and parked (thread_count - 1, excluding the
+ * calling/requesting thread itself). Not yet called from anywhere in
+ * Phase A -- Phase B calls this around gc_gen_minor_collect()'s
+ * pinned-object-scan window. */
+void gc_gen_stop_the_world(void) {
+    pthread_mutex_lock(&gc_stw_mutex);
+    atomic_store_explicit(&gc_stop_world, 1, memory_order_relaxed);
+    /* Recompute the target each iteration: gc_gen_thread_park() can
+     * decrement gc_gen_thread_count while we wait (a thread that's about
+     * to block on a non-GC condvar doesn't need to reach a safepoint at
+     * all -- see its own comment), which signals gc_stw_parked so we
+     * re-check here rather than waiting on a target that's gone stale. */
+    while (atomic_load_explicit(&gc_gen_parked_count, memory_order_relaxed) <
+           atomic_load_explicit(&gc_gen_thread_count, memory_order_relaxed) - 1)
+        pthread_cond_wait(&gc_stw_parked, &gc_stw_mutex);
+}
+
+void gc_gen_start_the_world(void) {
+    atomic_store_explicit(&gc_stop_world, 0, memory_order_relaxed);
+    pthread_cond_broadcast(&gc_stw_resume);
+    pthread_mutex_unlock(&gc_stw_mutex);
+}
+
+/* Bracket a genuinely long/unbounded blocking call (mailbox receive, a
+ * blocking accept()/recv(), a work-queue park) with thread_park()/
+ * thread_unpark(): a thread parked in a real blocking OS wait never
+ * returns to a poll point on its own, so without this a
+ * gc_gen_stop_the_world() request would wait for it indefinitely (e.g.
+ * until a message arrives or a connection comes in, which may be never).
+ * Safe to exclude such a thread from the count entirely while it's
+ * blocked: it holds no Curry heap pointers that need protecting from a
+ * concurrent scan beyond what's already reachable through the pinned
+ * mailbox/socket object itself, since it isn't touching Curry objects at
+ * all while parked in the syscall/condvar wait. */
+void gc_gen_thread_park(void) {
+    pthread_mutex_lock(&gc_stw_mutex);
+    atomic_fetch_sub_explicit(&gc_gen_thread_count, 1, memory_order_relaxed);
+    pthread_cond_signal(&gc_stw_parked);
+    pthread_mutex_unlock(&gc_stw_mutex);
+}
+
+/* Re-register BEFORE calling gc_gen_safepoint(): if the safepoint call
+ * came first, a stop_the_world() that starts in the window between it
+ * returning and the count increment below would proceed without waiting
+ * for this (now-running-again) thread. Incrementing first means any such
+ * request either starts before the increment (and this thread's park()
+ * call already excluded it, correctly) or starts after (and now correctly
+ * waits for it via gc_gen_safepoint() below). */
+void gc_gen_thread_unpark(void) {
+    atomic_fetch_add_explicit(&gc_gen_thread_count, 1, memory_order_relaxed);
+    gc_gen_safepoint();
+}
+
+/* Actor exit has no symmetric call to gen_register_thread's nursery setup
+ * today (src/actors.c's cleanup path never called anything to undo it) --
+ * this doesn't reclaim the nursery slab (out of scope for Phase A, and
+ * Boehm already owns that memory via GC_MALLOC_UNCOLLECTABLE regardless),
+ * just keeps gc_gen_thread_count accurate so a future stop_the_world()'s
+ * wait target reflects threads that are actually still live. */
+void gc_gen_unregister_thread(void) {
+    atomic_fetch_sub_explicit(&gc_gen_thread_count, 1, memory_order_relaxed);
+}
+
 /* ── Minor GC ────────────────────────────────────────────────────────────── */
 
 static pthread_mutex_t minor_gc_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -941,6 +1074,13 @@ static void gen_register_thread(void) {
     GC_get_stack_base(&sb);
     GC_register_my_thread(&sb);
     alloc_thread_nursery();
+    /* Issue #200 Phase A: see gc_gen_thread_count's own declaration
+     * comment. Paired with gc_gen_unregister_thread(), this backend's
+     * gc_ops_t.unregister_thread implementation -- reached only through
+     * the backend-dispatched public gc_unregister_thread() (src/gc.c),
+     * called from every registered thread's exit path (src/actors.c,
+     * src/workpool.c, modules/mcp/mcp.c), never called directly. */
+    atomic_fetch_add_explicit(&gc_gen_thread_count, 1, memory_order_relaxed);
 }
 
 static void *gen_promote(void *obj, size_t bytes, bool has_ptrs) {
@@ -963,6 +1103,7 @@ gc_ops_t gc_gen_ops = {
     .alloc_raw_pinned  = gen_alloc_raw_pinned,
     .collect           = gen_collect,
     .register_thread   = gen_register_thread,
+    .unregister_thread = gc_gen_unregister_thread,
     .pin               = gen_pin,
     .unpin             = gen_unpin,
     .register_root     = gen_register_root,
@@ -991,6 +1132,12 @@ void gc_gen_init(size_t nursery_bytes) {
      * match (their Boehm allocations land outside this slab). */
     gc_main_nursery_base  = gc_nursery.base;
     gc_main_nursery_limit = gc_nursery.limit;
+
+    /* Issue #200 Phase A: the main thread never goes through
+     * gen_register_thread (it sets up its own nursery directly, above),
+     * so it needs its own count increment here to be included in
+     * gc_gen_thread_count -- see that variable's declaration comment. */
+    atomic_fetch_add_explicit(&gc_gen_thread_count, 1, memory_order_relaxed);
 }
 
 /*

--- a/src/stm.c
+++ b/src/stm.c
@@ -181,8 +181,13 @@ static void tx_wait_for_change(TxState *tx) {
     }
 
     pthread_mutex_lock(&g_retry_mx);
+    /* Issue #200 Phase A: can block indefinitely until some other
+     * transaction commits a change -- park so a future GC safepoint
+     * doesn't wait on this thread meanwhile. */
+    gc_gen_thread_park();
     while (atomic_load_explicit(&g_vclock, memory_order_acquire) == snap_ver)
         pthread_cond_wait(&g_retry_cv, &g_retry_mx);
+    gc_gen_thread_unpark();
     pthread_mutex_unlock(&g_retry_mx);
 
     for (size_t i = 0; i < tx->rlen; i++) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -749,6 +749,12 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             extern void gc_gen_minor_collect(void);
             gc_gen_minor_collect();
         }
+        /* Issue #200 Phase A: see the identical comment at the computed-goto
+         * L_DISPATCH label above -- same safepoint poll, same gate. */
+        if (__builtin_expect(gc_inhibit_count == 0, 1)) {
+            extern void gc_gen_safepoint(void);
+            gc_gen_safepoint();
+        }
         if (__builtin_expect(vm_debug_active, 0)) vm_debug_hook(frame);
         switch (READ_U8()) {
 #endif
@@ -1952,6 +1958,20 @@ val_t vm_run(BcClosure *top_closure, int argc) {
             gc_minor_pending = false;
             extern void gc_gen_minor_collect(void);
             gc_gen_minor_collect();
+        }
+        /* Issue #200 Phase A: cross-thread safepoint poll, alongside this
+         * thread's own gc_minor_pending self-collection check above. Same
+         * gc_inhibit_count == 0 gate -- a thread mid-primitive-call (which
+         * may transiently hold a subsystem lock like rtab_lock/pinned_lock)
+         * is never asked to pause until it returns here with the inhibit
+         * count back at zero, so a pending gc_gen_stop_the_world() request
+         * naturally waits out any in-flight critical section instead of
+         * racing it. gc_gen_safepoint() itself is a cheap no-op check under
+         * the default Boehm backend (gc_stop_world is never set to 1 by
+         * anything outside the generational backend). */
+        if (__builtin_expect(gc_inhibit_count == 0, 1)) {
+            extern void gc_gen_safepoint(void);
+            gc_gen_safepoint();
         }
         if (__builtin_expect(vm_debug_active, 0)) vm_debug_hook(frame);
         goto *dt[READ_U8()];

--- a/src/workpool.c
+++ b/src/workpool.c
@@ -186,11 +186,20 @@ static void *worker_loop(void *arg) {
             execute_item(item);
         } else {
             atomic_fetch_add(&global_pool->n_parked, 1);
+            /* Issue #200 Phase A: this can block indefinitely with no work
+             * arriving -- park so a future GC safepoint doesn't wait on
+             * this thread for as long as that takes (see gc.h's own
+             * comment on gc_gen_thread_park/unpark; distinct from this
+             * function's own "parked" terminology for idle workers). */
+            gc_gen_thread_park();
             pthread_cond_wait(&global_pool->park_cond, &global_pool->park_mutex);
+            gc_gen_thread_unpark();
             atomic_fetch_sub(&global_pool->n_parked, 1);
             pthread_mutex_unlock(&global_pool->park_mutex);
         }
     }
+    /* Symmetric with gc_register_thread() above. */
+    gc_unregister_thread();
     vm_free();
     return NULL;
 }


### PR DESCRIPTION
## Summary

- Phase A of #200: pure plumbing for a real stop-the-world safepoint on `--gc generational`'s minor GC, which is per-thread today and races any object reachable from more than one actor. Rather than keep patching one type at a time (T_ENV/#198, T_MODULE/#150, rtab-atab/#146 all landed this session, with #200's remaining 4 types and #203 still open), this builds the mechanism to close the whole class at once.
- **No behavior change in this PR** -- nothing sets `gc_stop_world` to 1 anywhere. Phase B (separate future PR) wires it into `gc_gen_minor_collect`'s pinned-object-scan window.
- Ported the safepoint core from `src/gc_generational.c` -- an orphaned, never-compiled earlier GC rewrite (confirmed dead via CMakeLists.txt) -- into the live backend. Added a real live-thread count (didn't exist before), wired the existing `gc_minor_pending` poll points (`vm.c`, `eval.c`) to also check the new flag, and bracketed every blocking call reachable from actor code (mailbox, channels, STM, work-pool, parallel map/reduce, MCP, and several network/sync/mqtt/piper primitives) with park/unpark so a future safepoint doesn't wait on a blocked thread forever.
- Registration is now symmetric and backend-dispatched via a new `unregister_thread` vtable slot + public `gc_unregister_thread()`, mirroring the existing `gc_register_thread()`.
- Two real bugs found and fixed during review before landing: `modules/mcp/mcp.c` independently registers its own threads and was missed by the initial sweep (fixed: single exit funnel + park/unpark on its blocking calls); the unregister call was originally ungated, silently corrupting the thread count under the default Boehm backend (fixed via the vtable slot).
- Filed #205: TSan surfaced one genuine, unrelated pre-existing race in `pinned_add`'s lock-free fast path, confirmed identical on plain `main` via `git stash` A/B -- not fixed here, out of scope.

## Test plan

- [x] `cmake --build build` -- clean
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` -- 127/127 passing
- [x] Manual smoke tests under `--gc generational`: channels (buffered + rendezvous), STM, `(curry sync)` primitives, parallel `map`/`reduce`, actors test suite
- [x] Live MCP SSE client/server round-trip (`curl` against `mcp-serve-sse`) under `--gc generational`
- [x] TSan sanity pass (`-fsanitize=thread`) -- no new races; confirmed via `git stash` A/B that the one race found is pre-existing on `main`
- [x] Two independent code-review passes (fresh subagents) -- found and fixed the two bugs above; final verification pass confirms both fixes correct and complete
- [x] Independent security-review pass -- no findings; confirmed the new public API surface (`curry_gc_thread_park`/`unpark`) adds no new capability beyond what C modules already have, and the plumbing is genuinely inert today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151dxuF9rGDxCxMt1BArPph
