### PR TITLE
fix(modules,docs): snapshot export list under lock (#203) + INSTALL.md module docs

### DIFF
--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation & Building
 
-*v1.2.2 — 2026-06-07*
+*v1.23.7 — 2026-09-09*
 
 ## Install via Homebrew (macOS)
 
@@ -46,48 +46,128 @@ brew install --formula Formula/curry.rb
 ### 1. Install dependencies
 
 ```bash
-# Required
-sudo apt install libgc-dev libgmp-dev cmake build-essential
+# Required — note OpenSSL: the network module (on by default, TLS sockets)
+# links it unconditionally, so CMake's top-level configure fails without it
+# even if you don't touch any module flags.
+sudo apt install libgc-dev libgmp-dev libssl-dev cmake build-essential
 
-# Optional modules
-sudo apt install libsqlite3-dev        # sqlite
-sudo apt install libssl-dev            # crypto
-sudo apt install libcurl4-openssl-dev  # storage, graphql
-sudo apt install libldap-dev           # ldap
-sudo apt install libpng-dev libjpeg-dev # image
-sudo apt install libgit2-dev           # git
-sudo apt install libplplot-dev         # plplot
-sudo apt install libffi-dev            # ffi (BUILD_FFI=ON)
+# Modules that are ON by default need no extra package beyond the above —
+# json, network, redis, sqlite, regex, sync, mcp, lsp, profiling, posix,
+# codesets, f64vector, typedvec, and neo4j all build against system
+# libc/libssl/libsqlite3 alone. (vecdb is OFF by default but also needs
+# no extra package when enabled — see the table below.)
+sudo apt install libsqlite3-dev        # sqlite (on by default)
+
+# Everything else optional — install only what you plan to enable:
+sudo apt install libcurl4-openssl-dev  # http, storage, graphql (all on by default)
+sudo apt install libpng-dev libjpeg-dev # image (on by default)
+sudo apt install libgit2-dev           # git (on by default)
+sudo apt install libplplot-dev         # plplot (on by default)
+sudo apt install libpaho-mqtt-dev      # mqtt (on by default)
+sudo apt install libldap-dev           # ldap (off by default)
+sudo apt install libffi-dev            # general FFI, BUILD_FFI=ON (off by default)
+sudo apt install llvm-18-dev           # LLVM JIT backend, BUILD_LLVM=ON (off by default) — see below
+sudo apt install libgpiod-dev          # rpi (Linux only, off by default) — see docs/guides/RPI.md
+# qt6: see docs/reference/module-qt6.md — needs a full Qt6 dev install (off by default)
+# piper: no apt package yet — build libpiper from source first, see docs/reference/module-piper.md (off by default)
 ```
 
-### 2. Build
+### 2. Build options at a glance
+
+| Module (`-DBUILD_MODULE_...=`) | Default | Extra package needed |
+|---|---|---|
+| `F64VECTOR`, `TYPEDVEC`, `JSON`, `SQLITE`, `NETWORK`, `CRYPTO`, `STORAGE`, `HTTP`, `GRAPHQL`, `NEO4J`, `REDIS`, `IMAGE`, `GIT`, `PLPLOT`, `REGEX`, `SYNC`, `MCP`, `LSP`, `PROFILING`, `POSIX`, `CODESETS` | ON | see table above (most need nothing beyond required deps) |
+| `MQTT` | ON | `libpaho-mqtt-dev` |
+| `LDAP` | OFF | `libldap-dev` |
+| `VECDB` | OFF | none (optional `usearch` for approximate search — see `docs/reference/module-vecdb.md`) |
+| `QT6` | OFF | Qt6 dev packages — see `docs/reference/module-qt6.md` |
+| `PIPER` | OFF | manual `libpiper`/`onnxruntime` build — see `docs/reference/module-piper.md` |
+| `RPI` | OFF (no default value — must pass `=ON` explicitly), Linux only | `libgpiod-dev` — see `docs/guides/RPI.md` |
+
+Plus two build-wide flags that aren't modules: `-DBUILD_FFI=ON` (general C FFI, `libffi-dev`) and `-DBUILD_LLVM=ON` (tiered native JIT backend, LLVM ≥ 15 — see `docs/reference/llvm-jit.md` and the LLVM dependency notes above).
+
+### 3. Build
 
 ```bash
-# Minimal build (core + always-on modules: json, network, redis, regex, sync, vecdb)
+# Minimal build — every default-ON module above, using just the "Required" packages
 cmake -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j$(nproc)
 
-# Full build with all optional modules
+# Full build — every module including the default-OFF ones (excluding piper/rpi,
+# which need extra manual setup — see the table above)
 cmake -B build -DCMAKE_BUILD_TYPE=Debug \
-  -DBUILD_MODULE_CRYPTO=ON \
   -DBUILD_MODULE_LDAP=ON \
-  -DBUILD_MODULE_STORAGE=ON \
-  -DBUILD_MODULE_GRAPHQL=ON \
-  -DBUILD_MODULE_IMAGE=ON \
-  -DBUILD_MODULE_GIT=ON \
-  -DBUILD_MODULE_PLPLOT=ON \
-  -DBUILD_MODULE_MQTT=ON \
+  -DBUILD_MODULE_VECDB=ON \
   -DBUILD_MODULE_QT6=ON \
-  -DBUILD_FFI=ON          # general C FFI (requires libffi-dev)
+  -DBUILD_FFI=ON \
+  -DBUILD_LLVM=ON
 cmake --build build -j$(nproc)
 ```
 
-### 3. Run
+### 4. Run
 
 ```bash
 ./build/curry                          # REPL
 ./build/curry script.scm               # run a script
 ./build/curry -e '(display "𒀭") (newline)'
+```
+
+---
+
+## Building on Linux (Fedora / RHEL)
+
+Package names differ from Debian's (`gc-devel` vs. `libgc-dev`, etc.), but the CMake invocation itself is identical to the Debian/Ubuntu section above — only the package-manager step changes.
+
+### 1. Install dependencies
+
+```bash
+# Required — OpenSSL too: the network module (on by default, TLS sockets)
+# links it unconditionally, so CMake's top-level configure fails without it
+# even if you don't touch any module flags.
+sudo dnf install gc-devel gmp-devel openssl-devel cmake gcc gcc-c++ make pkgconfig
+
+# sqlite (on by default)
+sudo dnf install sqlite-devel
+
+# Everything else optional — install only what you plan to enable:
+sudo dnf install libcurl-devel                # http, storage, graphql (all on by default)
+sudo dnf install libpng-devel libjpeg-turbo-devel # image (on by default)
+sudo dnf install libgit2-devel                # git (on by default)
+sudo dnf install plplot-devel                 # plplot (on by default)
+sudo dnf install paho-c-devel                 # mqtt (on by default; package name may vary by release — build from https://github.com/eclipse/paho.mqtt.c if unavailable)
+sudo dnf install openldap-devel                # ldap (off by default)
+sudo dnf install libffi-devel                 # general FFI, BUILD_FFI=ON (off by default)
+sudo dnf install llvm-devel llvm-static        # LLVM JIT backend, BUILD_LLVM=ON (off by default)
+sudo dnf install libgpiod-devel               # rpi (Linux only, off by default) — see docs/guides/RPI.md
+# qt6: sudo dnf install qt6-qtbase-devel qt6-qtbase-gui — see docs/reference/module-qt6.md (off by default)
+# piper: no dnf package yet — build libpiper from source first, see docs/reference/module-piper.md (off by default)
+```
+
+See the module-flags table in the Debian/Ubuntu section above — it applies here too, just with `dnf` package names instead of `apt` ones.
+
+### 2. Build
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j$(nproc)
+ctest --test-dir build --output-on-failure -j$(nproc)
+```
+
+### 3. Native arm64 verification via container
+
+On an Apple Silicon Mac with Docker Desktop (or `podman`/the `container` CLI), a real Fedora build can be sanity-checked without a physical machine — this pulls and runs a native arm64 Fedora image (not cross-compilation) and is a useful pre-CI check since project CI only covers `ubuntu-latest`/`macos-latest`, not Fedora:
+
+```bash
+docker run --rm --platform linux/arm64 -v "$(pwd)":/src:ro fedora:latest bash -c '
+  set -ex
+  dnf install -y gc-devel gmp-devel openssl-devel cmake gcc gcc-c++ make pkgconfig \
+    sqlite-devel libcurl-devel \
+    libpng-devel libjpeg-turbo-devel libgit2-devel plplot-devel redis mosquitto git
+  cp -r /src /work && cd /work
+  cmake -B build -DCMAKE_BUILD_TYPE=Debug
+  cmake --build build -j$(nproc)
+  ctest --test-dir build --output-on-failure -j$(nproc)
+'
 ```
 
 ---
@@ -103,17 +183,32 @@ xcode-select --install
 ### 2. Install dependencies via Homebrew
 
 ```bash
-# Required
-brew install bdw-gc gmp cmake
+# Required — OpenSSL too: the network module (on by default, TLS sockets)
+# links it unconditionally, so CMake's top-level configure fails without it
+# even if you don't touch any module flags.
+brew install bdw-gc gmp openssl cmake
 
-# Optional modules
-brew install openssl      # crypto
-brew install sqlite       # sqlite
-brew install libgit2      # git
-brew install libpng jpeg-turbo  # image
-brew install plplot             # plplot
-# curl and ldap are bundled with macOS — no extra install needed
+# Modules that are ON by default need no extra package beyond the above —
+# json, network, redis, sqlite, regex, sync, mcp, lsp, profiling, posix,
+# codesets, f64vector, typedvec, and neo4j all build against system
+# libc/openssl/sqlite alone. (vecdb is OFF by default but also needs no
+# extra package when enabled — see the table above.)
+brew install sqlite       # sqlite (on by default)
+
+# Everything else optional — install only what you plan to enable:
+brew install libgit2            # git (on by default)
+brew install libpng jpeg-turbo  # image (on by default)
+brew install plplot             # plplot (on by default)
+brew install libpaho-mqtt       # mqtt (on by default)
+brew install openldap           # ldap (off by default)
+brew install libffi             # general FFI, BUILD_FFI=ON (off by default)
+brew install llvm               # LLVM JIT backend, BUILD_LLVM=ON (off by default) — see below
+# curl is bundled with macOS — no extra install needed for http/storage/graphql
+# qt6: see "Optional: Qt6 module on macOS" below (off by default)
+# piper: no Homebrew formula yet — build libpiper from source first, see docs/reference/module-piper.md (off by default)
 ```
+
+See the module-flags table in the Linux section above for which `-DBUILD_MODULE_...` flag maps to which package — it applies here too, just with Homebrew package names instead of apt ones.
 
 ### 3. Build
 
@@ -139,6 +234,18 @@ cmake --build build -j$(sysctl -n hw.logicalcpu)
 
 > `brew --prefix qt@6` resolves to the umbrella `qt` formula, which doesn't actually ship `Qt6Config.cmake` (only its `qtbase` dependency does) — `CMakeLists.txt` falls back to `brew --prefix qtbase` automatically on macOS if the first `find_package(Qt6 …)` misses, so the command above still works. The module also bakes in Homebrew's Qt plugin directory at build time, so no `QT_QPA_PLATFORM_PLUGIN_PATH` env var is needed to run it.
 
+### 5. Optional: LLVM JIT backend on macOS
+
+```bash
+brew install llvm
+cmake -B build -DCMAKE_BUILD_TYPE=Debug \
+  -DBUILD_LLVM=ON \
+  -DCMAKE_PREFIX_PATH="$(brew --prefix llvm)"
+cmake --build build -j$(sysctl -n hw.logicalcpu)
+```
+
+Homebrew's `llvm` formula is keg-only (not linked into `/usr/local` or `/opt/homebrew` by default), so `-DCMAKE_PREFIX_PATH` is needed the same way it is for Qt6. See `docs/reference/llvm-jit.md` for what the JIT backend actually does at runtime.
+
 ### Notes
 
 - Modules build as `.so` bundles on both Linux and macOS; `(import (curry qt6))` works identically on both platforms.
@@ -149,7 +256,7 @@ cmake --build build -j$(sysctl -n hw.logicalcpu)
 
 GCC and upstream LLVM Clang are both supported. When building a Release build with Clang, the CMake configuration automatically adds `-fno-omit-frame-pointer`. This is required because Boehm GC's conservative stack scanner walks frame-pointer chains to find live heap objects; Clang at `-O2` omits them by default, which breaks the GC and causes segfaults. GCC is unaffected.
 
-### 5. Create a .deb or .rpm package
+### 6. Create a .deb or .rpm package
 
 CPack can produce both a Debian (`.deb`) and an RPM (`.rpm`) package from the same build. Build in Release mode first, then invoke CPack from the build directory:
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -575,15 +575,44 @@ val_t modules_import(val_t spec, val_t env) {
          * each exported name up directly instead of scanning every binding
          * the module happens to define. */
         val_t mod_env_val = vptr(mod->env);
-        /* Issue #150: mod->exports is a field gc_gen.c's scan_pinned_object
-         * (T_MODULE case) can concurrently evacuate on another actor's
-         * minor GC -- snapshot it under the same lock that scan takes,
-         * rather than dereferencing it directly here. */
+        /* Issue #150 / #203: mod->exports is a field gc_gen.c's
+         * scan_pinned_object (T_MODULE case) can evacuate on another
+         * actor's minor GC, and #150's original fix only snapshotted the
+         * head pointer -- the list's own pair cells (vcar/vcdr below)
+         * were still walked with no lock held at all. Issue #200 Phase B
+         * (src/gc_gen.c, gc_gen_stop_the_world()/start_the_world() now
+         * bracketing the whole of gc_gen_minor_collect(), not just the
+         * pinned-object-scan window) has since closed the specific
+         * concurrent-mutation race this guarded against: no other actor
+         * runs at all while a minor GC evacuates this list's cells, so an
+         * un-parked reader here can only ever run entirely before or
+         * entirely after a given collection, never during one. This
+         * snapshot is kept anyway as defense in depth -- issue #208 found
+         * a still-unexplained hang in that same stop-the-world protocol
+         * under a nested-spawn + dynamic define-library/import workload,
+         * so treat the STW guarantee as not yet fully proven for this
+         * exact code path. Same count/allocate-outside-lock/copy pattern
+         * sx_rule_try/sx_rules_list (src/sx_rules.c) already use for the
+         * unrelated "can't hold a lock across arbitrary work" problem --
+         * the copy pass itself must still finish inside the lock, so
+         * GC_MALLOC-ing the buffer has to happen between the two lock
+         * sections, not inside either one. */
         modules_registry_rdlock_for_gc();
-        val_t exports = mod->exports;
+        int export_count = 0;
+        for (val_t es = mod->exports; vis_pair(es); es = vcdr(es)) export_count++;
         modules_registry_unlock_for_gc();
-        for (val_t es = exports; vis_pair(es); es = vcdr(es)) {
-            val_t sym = vcar(es);
+
+        val_t *export_syms = export_count
+            ? (val_t *)GC_MALLOC(sizeof(val_t) * (size_t)export_count) : NULL;
+
+        modules_registry_rdlock_for_gc();
+        int export_n = 0;
+        for (val_t es = mod->exports; vis_pair(es) && export_n < export_count; es = vcdr(es))
+            export_syms[export_n++] = vcar(es);
+        modules_registry_unlock_for_gc();
+
+        for (int i = 0; i < export_n; i++) {
+            val_t sym = export_syms[i];
             val_t *slot = env_lookup_slot(mod_env_val, sym);
             if (!slot) continue; /* declared exported but never defined */
             /* issue #153: mod->env is a root frame (env_new_root()),


### PR DESCRIPTION
## Summary

- Fixes #203: `modules_import`'s traversal of a module's export list walked `vcar`/`vcdr` over the list's own pair cells with no lock held at all -- #150's earlier fix only snapshotted the `mod->exports` *head pointer*, not the cells it points into. Under `--gc generational`, `gc_gen.c`'s concurrent evacuation of those same cells during another actor's minor GC could race this traversal.
- Snapshots the whole list into a plain C array under `modules_registry_rdlock_for_gc()`, using the same count/allocate-outside-lock/copy pattern `sx_rule_try`/`sx_rules_list` (`src/sx_rules.c`) already use for the identical "can't hold a lock across allocating work" problem.
- Issue #200 Phase B (merged, #207) likely already closes the specific race this guards against on its own, since `gc_gen_stop_the_world()` now brackets the *entire* `gc_gen_minor_collect()`, not just the pinned-object-scan window -- confirmed by independent code review during this change. Kept as defense in depth anyway: see #208 below.
- Also brings `docs/guides/INSTALL.md`'s optional-module docs up to date: every `BUILD_MODULE_*` flag's real dependency (several were undocumented entirely -- piper, vecdb, mqtt, neo4j), the top-level OpenSSL requirement (previously listed only under "optional: crypto" despite `CMakeLists.txt`'s unconditional `find_package(OpenSSL REQUIRED)`), a new Fedora/RHEL build section, and an LLVM-JIT-on-macOS section.

## A note on #208

While verifying this fix under TSan with a repro combining nested actor `spawn` and dynamic `define-library`/`import`, I hit an indefinite hang inside `gc_gen_stop_the_world()`. Confirmed via `git stash` A/B on the same TSan binary that this reproduces identically **without** this PR's changes too -- it's a pre-existing issue in the already-merged stop-the-world protocol (#206/#207), not something this PR introduces, and it doesn't reproduce at all outside TSan at the same or higher iteration counts. Filed as #208 rather than blocking this fix on debugging it.

## Test plan

- [x] `cmake --build build` -- clean
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` -- 127/127 passing
- [x] Manual `--gc generational` smoke: `tests/module_isolation_tests.scm` (14/14)
- [x] Manual `--gc generational --gc-nursery-size 4K` run of the exact #203 repro scenario (nested spawn + dynamic `define-library`/`import`) outside TSan -- completes cleanly in ~2s
- [x] TSan verification of this specific fix is blocked by #208 (see above) -- the same workload hangs with or without this change, so TSan couldn't confirm or deny the export-list race specifically. The non-TSan smoke test above and the code-review pass are the verification available for this PR.
- [x] Independent code-review pass (fresh subagent): no correctness issues in the fix itself; flagged that the guarding comment implied an unconditional active race Phase B likely already closed, and a vecdb-default-ON contradiction in INSTALL.md -- both fixed.
- [x] Independent security-review pass (fresh subagent): no findings -- allocation sizing, the TOCTOU between the count and copy lock sections, and both loop bounds (write loop bounded by `export_count`, read loop bounded by the actual copied `export_n`) all correct.

Still confined to the experimental, opt-in `--gc generational` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
