### PR TITLE
fix(gc_gen): make pinned_add fully lock-protected instead of lock-free (#205)

### DIFF
--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -87,76 +87,68 @@ static void init_dirty_slots(void) {
  * may point into the nursery and must be updated during minor GC.  We record
  * them here so gc_gen_minor_collect() can scan them.
  *
- * Lock-free fast path:
- *   pinned_count is _Atomic.  pinned_add() claims a slot with atomic_fetch_add
- *   then writes the pointer without holding pinned_lock.  The only structural
- *   invariant required is that pinned_slots[i] is valid memory for any i that
- *   has been claimed (i < pinned_cap).
+ * Issue #205: this used to have a lock-free fast path (pinned_count claimed
+ * via atomic_fetch_add, the pointer written into pinned_slots without
+ * holding pinned_lock at all) with the resize slow path rewriting
+ * pinned_slots/pinned_cap under the lock. That shape had a real data race
+ * (pinned_cap/pinned_slots read as plain globals) which a first attempt at
+ * fixing -- making them _Atomic with an acquire/release pairing between the
+ * two -- did close, but that rewrite introduced its own follow-on bug: a
+ * resize's memcpy snapshot could run strictly between a fast-path write and
+ * that thread's own post-write recheck, capturing the pre-write value, with
+ * the resize's publish itself landing AFTER the recheck -- silently
+ * dropping the written object from the pinned set forever (found by code
+ * review, confirmed reproducible with only ordinary thread preemption, no
+ * adversarial timing). A hand-rolled retry loop can be made to converge
+ * against a MOVED pointer, but not against this "snapshot ran in between"
+ * shape without reinventing a full seqlock protocol.
  *
- * Resize slow path:
- *   When pinned_count reaches pinned_cap the caller falls back to pinned_lock,
- *   copies the array, and updates pinned_slots/pinned_cap atomically under the
- *   lock.  Fast-path callers already past the capacity check are not affected
- *   (they claimed valid indices before the resize).
+ * Rather than get this exactly right with more lock-free machinery, this
+ * function now just takes pinned_lock for the whole claim+write, mirroring
+ * gc.c's g_roots (register_root_locked) -- the identical growable-
+ * pointer-array-scanned-by-GC problem, already solved correctly there the
+ * simple way. pinned_add is not on any path where lock contention matters
+ * relative to the GC_MALLOC it accompanies (that allocation call itself
+ * already dominates any cost here), so there is no performance reason to
+ * prefer lock-free over provably correct.
  *
  * GC reset:
  *   gc_gen_minor_collect() holds pinned_lock around the step-6 scan and count
- *   reset (pinned_count = 0).  A fast-path add that claimed slot c just before
- *   the reset may write pinned_slots[c] after the count has been zeroed; that
- *   slot is effectively orphaned for one GC cycle.  This is safe because:
- *     (a) Initial fields of all pinned objects are Boehm pointers — they are
- *         set under gc_inhibit_minor(), which prevents the nursery from being
- *         collected while those fields are written.  Skipping their initial
- *         scan therefore loses nothing nursery-live.
- *     (b) Any post-construction mutation that stores a nursery pointer goes
- *         through gc_wb_slot(), which records it in gc_dirty_slots.  The next
- *         minor GC processes gc_dirty_slots and updates those fields regardless
- *         of whether the object was in the pinned scan list.
- *   In practice the race window is <10 CPU cycles; it cannot occur in
- *   single-threaded execution (GC fires on the same thread at L_DISPATCH,
- *   after gc_inhibit_count has already returned to zero).
+ *   reset (pinned_count = 0), the same lock pinned_add now holds for its
+ *   entire body -- so there is no window where an add can land between the
+ *   scan and the reset at all; the old "<10 CPU cycles, orphaned for one GC
+ *   cycle" race this comment used to describe no longer exists.
  */
 #define PINNED_INIT_CAP 256
-static void         **pinned_slots;
-static _Atomic size_t pinned_count;
-static size_t         pinned_cap;
-static size_t         pinned_stable;   /* objects below this index were fully
-                                          scanned in the last minor GC */
+static void          **pinned_slots;
+static size_t           pinned_count;
+static size_t           pinned_cap;
+static size_t           pinned_stable;   /* objects below this index were fully
+                                             scanned in the last minor GC */
 static pthread_mutex_t pinned_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* Exposed so env.c can register the root EnvFrame into the pinned scan list. */
 void gc_gen_pin_permanent(void *obj);
 
 static void pinned_add(void *obj) {
-    /* Fast path: claim a slot without the lock. */
-    size_t c = atomic_fetch_add_explicit(&pinned_count, 1, memory_order_relaxed);
-    if (__builtin_expect(c < pinned_cap, 1)) {
-        pinned_slots[c] = obj;
-        return;
-    }
-
-    /* Slow path: capacity exceeded.  Back out and resize under pinned_lock. */
-    atomic_fetch_sub_explicit(&pinned_count, 1, memory_order_relaxed);
     pthread_mutex_lock(&pinned_lock);
-    /* Re-check after acquiring the lock — another thread may have already
-     * resized.  If capacity is sufficient, just retry the fast path. */
-    if (atomic_load_explicit(&pinned_count, memory_order_relaxed) < pinned_cap) {
-        pthread_mutex_unlock(&pinned_lock);
-        pinned_add(obj);   /* one recursive retry is enough */
-        return;
+    if (__builtin_expect(pinned_count >= pinned_cap, 0)) {
+        size_t nc = pinned_cap * 2;
+        void **ns = GC_MALLOC_UNCOLLECTABLE(nc * sizeof(void *));
+        if (!ns) { fprintf(stderr, "[gc_gen] FATAL: pinned_slots OOM\n"); abort(); }
+        memcpy(ns, pinned_slots, pinned_count * sizeof(void *));
+        memset(ns + pinned_count, 0, (nc - pinned_count) * sizeof(void *));
+        /* Safe to free here (unlike the lock-free design this replaced):
+         * every reader and writer of pinned_slots, including this
+         * function's own fast case below, holds pinned_lock for the
+         * entire time it touches the array, so nothing can still be
+         * referencing `pinned_slots` (the old array) once we're inside
+         * this critical section. */
+        GC_FREE(pinned_slots);
+        pinned_slots = ns;
+        pinned_cap   = nc;
     }
-    size_t nc = pinned_cap * 2;
-    void **ns = GC_MALLOC_UNCOLLECTABLE(nc * sizeof(void *));
-    if (!ns) { fprintf(stderr, "[gc_gen] FATAL: pinned_slots OOM\n"); abort(); }
-    size_t cur = atomic_load_explicit(&pinned_count, memory_order_relaxed);
-    memcpy(ns, pinned_slots, cur * sizeof(void *));
-    memset(ns + cur, 0, (nc - cur) * sizeof(void *));
-    GC_FREE(pinned_slots);
-    pinned_slots = ns;
-    pinned_cap   = nc;
-    /* Claim a slot now that the array is large enough. */
-    c = atomic_fetch_add_explicit(&pinned_count, 1, memory_order_relaxed);
-    pinned_slots[c] = obj;
+    pinned_slots[pinned_count++] = obj;
     pthread_mutex_unlock(&pinned_lock);
 }
 
@@ -1006,13 +998,14 @@ void gc_gen_minor_collect(void) {
 
     if (gc_dirty_overflow) {
         pthread_mutex_lock(&pinned_lock);
-        size_t pc = atomic_load_explicit(&pinned_count, memory_order_acquire);
+        size_t pc = pinned_count;
+        void **slots = pinned_slots;
         for (size_t i = 0; i < pc; i++) {
-            void *obj = pinned_slots[i];
+            void *obj = slots[i];
             if (obj) scan_pinned_object(obj);
-            pinned_slots[i] = NULL;  /* release reference so Boehm can reclaim dead objects */
+            slots[i] = NULL;  /* release reference so Boehm can reclaim dead objects */
         }
-        atomic_store_explicit(&pinned_count, 0, memory_order_release);
+        pinned_count  = 0;
         pinned_stable = 0;
         pthread_mutex_unlock(&pinned_lock);
     } else {
@@ -1021,18 +1014,19 @@ void gc_gen_minor_collect(void) {
             *gc_dirty_slots[i] = evacuate(*gc_dirty_slots[i]);
         /* Scan new pinned objects (those added since the last compact). */
         pthread_mutex_lock(&pinned_lock);
-        size_t pc = atomic_load_explicit(&pinned_count, memory_order_acquire);
+        size_t pc = pinned_count;
+        void **slots = pinned_slots;
         for (size_t i = pinned_stable; i < pc; i++) {
-            void *obj = pinned_slots[i];
+            void *obj = slots[i];
             if (obj) scan_pinned_object(obj);
         }
         /* Null ALL slots [0, pc) so Boehm can reclaim dead objects.  The stable
          * range [0, pinned_stable) was already scanned in a prior cycle but still
          * holds stale pointers; clearing them is necessary now that pinned objects
          * are GC_MALLOC (not GC_MALLOC_UNCOLLECTABLE). */
-        memset(pinned_slots, 0, pc * sizeof(void *));
+        memset(slots, 0, pc * sizeof(void *));
         /* Compact: future mutations tracked via dirty_slots. */
-        atomic_store_explicit(&pinned_count, 0, memory_order_release);
+        pinned_count = 0;
         pinned_stable = 0;
         pthread_mutex_unlock(&pinned_lock);
     }


### PR DESCRIPTION
## Summary

- Fixes #205: `pinned_add()`'s lock-free fast path read plain (non-atomic) globals `pinned_cap`/`pinned_slots` while the resize slow path rewrote both under `pinned_lock` -- a genuine data race under `--gc generational`, TSan-confirmed (3 warnings/run on `tests/actors_tests.scm`).
- Went through two lock-free atomics-based rewrites before landing here, each with its own subtle bug found by independent code review (full story in the commit message): an acquire/release-paired `_Atomic` version closed the original race but left a resize over-read; capping that left a lost-write race where an object's write could land in an array a resize abandons moments later.
- Given the growing complexity of a fully-correct lock-free version, and that `gc.c`'s `g_roots` (`register_root_locked`) already solves the identical problem correctly the simple way, `pinned_add()` now just takes `pinned_lock` for its entire body. No performance reason to prefer lock-free here -- the `GC_MALLOC` each call accompanies already dominates the cost.
- Also found via the same TSan pass: an unrelated, pre-existing race in `stm.c`'s tvar read/write path. Filed as #210 rather than expanding this PR's scope.

## Test plan

- [x] `cmake --build build` -- clean
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` -- 127/127 passing
- [x] TSan (`tests/actors_tests.scm`, `--gc generational`): reliable pre-fix failure at `gc_gen.c`'s `pinned_cap`/`pinned_slots` -> 0 races post-fix (the one remaining warning is #210, unrelated to this file)
- [x] TSan repro forcing `pinned_slots` past its initial 256-entry capacity (24 actors x 60 pinned allocations each): 0 races
- [x] Three independent code-review passes across the iteration (fast-path caching bug -> resize over-read -> lost-write race), and two independent security-review passes on the final design: no findings

Confined to the experimental, opt-in `--gc generational` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
