### PR TITLE
fix(gc_gen): gc_gen_unregister_thread must signal gc_stw_parked (#208)

### DIFF
--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -798,11 +798,13 @@ void gc_gen_safepoint(void) {
 void gc_gen_stop_the_world(void) {
     pthread_mutex_lock(&gc_stw_mutex);
     atomic_store_explicit(&gc_stop_world, 1, memory_order_relaxed);
-    /* Recompute the target each iteration: gc_gen_thread_park() can
-     * decrement gc_gen_thread_count while we wait (a thread that's about
-     * to block on a non-GC condvar doesn't need to reach a safepoint at
-     * all -- see its own comment), which signals gc_stw_parked so we
-     * re-check here rather than waiting on a target that's gone stale. */
+    /* Recompute the target each iteration: gc_gen_thread_park() and
+     * gc_gen_unregister_thread() can both decrement gc_gen_thread_count
+     * while we wait (a thread that's about to block on a non-GC condvar,
+     * or that's exiting for good, doesn't need to reach a safepoint at
+     * all -- see their own comments), each signaling gc_stw_parked when
+     * they do, so we re-check here rather than waiting on a target
+     * that's gone stale. */
     while (atomic_load_explicit(&gc_gen_parked_count, memory_order_relaxed) <
            atomic_load_explicit(&gc_gen_thread_count, memory_order_relaxed) - 1)
         pthread_cond_wait(&gc_stw_parked, &gc_stw_mutex);
@@ -811,6 +813,32 @@ void gc_gen_stop_the_world(void) {
 void gc_gen_start_the_world(void) {
     atomic_store_explicit(&gc_stop_world, 0, memory_order_relaxed);
     pthread_cond_broadcast(&gc_stw_resume);
+    pthread_mutex_unlock(&gc_stw_mutex);
+}
+
+/* Shared by gc_gen_thread_park() and gc_gen_unregister_thread(): both need
+ * to decrement gc_gen_thread_count and signal gc_stw_parked under
+ * gc_stw_mutex, for the identical reason -- gc_gen_stop_the_world()'s wait
+ * predicate (parked_count < thread_count - 1) is a function of this
+ * counter, so any decrement can be the one that satisfies an already-
+ * blocked collector's wait, and pairing the mutation with the signal under
+ * the mutex the waiter also holds during pthread_cond_wait is what makes
+ * that race-free. Issue #208: gc_gen_unregister_thread() used to skip the
+ * signal half of this (a plain atomic decrement, no mutex, no signal) --
+ * a classic missed-wakeup, confirmed via targeted tracing (register/park/
+ * unpark/unregister events plus parked_count/thread_count at each
+ * transition): thread_count dropped via exactly that unsignaled path
+ * while a collector sat blocked in pthread_cond_wait with its predicate
+ * already satisfied, and it never woke up -- reproduced as a genuine hang
+ * (confirmed via sustained near-zero CPU usage, not just slowness) under
+ * nested actor spawn combined with dynamic define-library/import. Having
+ * both call sites share one implementation, rather than hand-duplicating
+ * this exact lock/decrement/signal/unlock sequence, is what keeps them
+ * from drifting apart into this same bug again later. */
+static void gc_gen_thread_leave(void) {
+    pthread_mutex_lock(&gc_stw_mutex);
+    atomic_fetch_sub_explicit(&gc_gen_thread_count, 1, memory_order_relaxed);
+    pthread_cond_signal(&gc_stw_parked);
     pthread_mutex_unlock(&gc_stw_mutex);
 }
 
@@ -826,10 +854,7 @@ void gc_gen_start_the_world(void) {
  * mailbox/socket object itself, since it isn't touching Curry objects at
  * all while parked in the syscall/condvar wait. */
 void gc_gen_thread_park(void) {
-    pthread_mutex_lock(&gc_stw_mutex);
-    atomic_fetch_sub_explicit(&gc_gen_thread_count, 1, memory_order_relaxed);
-    pthread_cond_signal(&gc_stw_parked);
-    pthread_mutex_unlock(&gc_stw_mutex);
+    gc_gen_thread_leave();
 }
 
 /* Re-register BEFORE calling gc_gen_safepoint(): if the safepoint call
@@ -849,9 +874,11 @@ void gc_gen_thread_unpark(void) {
  * this doesn't reclaim the nursery slab (out of scope for Phase A, and
  * Boehm already owns that memory via GC_MALLOC_UNCOLLECTABLE regardless),
  * just keeps gc_gen_thread_count accurate so a future stop_the_world()'s
- * wait target reflects threads that are actually still live. */
+ * wait target reflects threads that are actually still live. See
+ * gc_gen_thread_leave()'s own comment (issue #208) for why this must
+ * signal gc_stw_parked, not just decrement the counter. */
 void gc_gen_unregister_thread(void) {
-    atomic_fetch_sub_explicit(&gc_gen_thread_count, 1, memory_order_relaxed);
+    gc_gen_thread_leave();
 }
 
 /* ── Minor GC ────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Fixes #208: root cause was a missed-wakeup bug in `gc_gen_unregister_thread()`. It decremented `gc_gen_thread_count` -- a value `gc_gen_stop_the_world()`'s wait predicate (`parked_count < thread_count - 1`) depends on -- but, unlike its sibling `gc_gen_thread_park()` (which decrements the same counter for the same reason), never signaled `gc_stw_parked` afterward.
- A collector already blocked in `pthread_cond_wait(&gc_stw_parked, ...)` when the LAST thread it's waiting on exits via this path (an actor finishing normally, not blocking on a mailbox/socket/work-queue via `thread_park()`) has its predicate become true the instant the decrement lands, but nothing wakes it up -- `pthread_cond_wait` only returns on a signal/broadcast (or an unguaranteed spurious wakeup, and none arrived here in practice).
- Confirmed via temporary tracing instrumentation (logging every register/park/unpark/unregister event plus the counters at each transition -- attaching a debugger to the hung TSan process wasn't available in this environment): `gc_gen_thread_count` dropped from 3 to 2 via exactly this unsignaled path while a collector sat blocked with its predicate already satisfied. Confirmed as a genuine hang (not just TSan-induced slowness) via sustained near-zero CPU usage for 90+ seconds, reproduced identically across repeated git-stash A/B runs.
- Fix factors the shared lock/decrement/signal/unlock sequence out of `gc_gen_thread_park()` into a new `gc_gen_thread_leave()`, called by both it and `gc_gen_unregister_thread()` -- both need the identical protocol for the identical reason, and hand-duplicating it is what let them drift apart into this bug in the first place.

## Test plan

- [x] `cmake --build build` -- clean
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` -- 127/127 passing (one unrelated flaky "ros" timeout, confirmed to pass on rerun)
- [x] TSan repro from #208 (nested actor spawn + dynamic `define-library`/`import`, `--gc generational --gc-nursery-size 4K`), with the **original blocking `pthread_cond_wait`**, no polling workaround: 5/5 consecutive clean completions post-fix, vs. reliable indefinite hangs pre-fix
- [x] TSan run of `tests/actors_tests.scm`: 19/19 passing, the one remaining warning is the already-filed, unrelated #210 (`stm.c`)
- [x] Two independent code-review passes and two independent security-review passes across the investigation and the final refactor: no findings beyond a minor DRY suggestion (the `gc_gen_thread_leave()` factoring above), which was applied

Confined to the experimental, opt-in `--gc generational` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
