### PR TITLE
fix(stm): make TVar.value atomic-relaxed, closing a plain-read/write race (#210)

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -557,28 +557,41 @@ static inline void gc_wb_slot(val_t *slot, val_t newval) {
 /*
  * gc_wb_slot_atomic_relaxed — issue #153: same write-barrier bookkeeping
  * as gc_wb_slot, but the actual store is an atomic-relaxed store instead
- * of a plain `*slot = newval`. Use ONLY for a slot that a lock-free
- * reader on another thread can observe without holding any lock -- today
- * that means exactly one thing: GLOBAL_ENV (or another root EnvFrame)'s
- * vals[] array, written from env.c's frame_set_unlocked/
- * frame_define_unlocked (the global-frame branch) and vm.c's
- * OP_STORE_GLOBAL. Every other gc_wb_slot call site (pairs, vectors,
- * local-frame fields, ...) stays on the plain version: those objects are
- * single-thread-owned (see env.c's own top-of-file comment on why local
- * frames never need this), so there is no concurrent reader to protect
- * against and no reason to pay for an atomic store.
+ * of a plain `*slot = newval`. Use for a slot that a lock-free reader on
+ * another thread can observe without holding any lock -- today that's
+ * GLOBAL_ENV (or another root EnvFrame)'s vals[] array, written from
+ * env.c's frame_set_unlocked/frame_define_unlocked (the global-frame
+ * branch) and vm.c's OP_STORE_GLOBAL; and (issue #210) src/stm.c's
+ * TVar.value, written from tx_commit and stm_tvar_write's no-current-
+ * transaction path and read lock-free by stm_tvar_read. Every other
+ * gc_wb_slot call site (pairs, vectors, local-frame fields, ...) stays
+ * on the plain version: those objects are single-thread-owned (see
+ * env.c's own top-of-file comment on why local frames never need this),
+ * so there is no concurrent reader to protect against and no reason to
+ * pay for an atomic store.
  *
  * Relaxed suffices (not acquire/release) because the ordering readers
- * actually need comes from the SEPARATE seqlock version counter
- * (env.c's seq_begin_write/seq_end_write, unchanged by this fix) for the
- * structural (grow/rehash) case, or is simply "read old or new value,
- * both are live, never torn" for the direct value-update case (frame_set/
- * OP_STORE_GLOBAL never bump version at all -- this store's only job is
- * to stop the write from being UB-by-definition against a concurrent
- * plain read, not to add ordering the seqlock doesn't already provide).
+ * actually need comes from a SEPARATE version/seqlock counter each
+ * caller already maintains (env.c's seq_begin_write/seq_end_write for
+ * the structural grow/rehash case; stm.c's per-TVar `version`, released
+ * right after this store in both tx_commit and stm_tvar_write, for the
+ * TL2 case) -- this store's only job is to stop the write from being
+ * UB-by-definition against a concurrent plain read, not to add ordering
+ * the caller's own protocol doesn't already provide.
+ *
+ * gc_dirty_slots/gc_dirty_count bookkeeping below assumes its caller is
+ * always the MAIN thread -- true for env.c/vm.c's call sites (only the
+ * main thread's own top-level code produces nursery pointers in the
+ * first place, per this header's own gc_dirty_slots comment above), but
+ * NOT provably true for stm.c: an actor thread can commit a value it
+ * merely references (e.g. one it read out of GLOBAL_ENV or received in
+ * a message) that still happens to be main-thread-nursery-resident, into
+ * a TVar, hitting this bookkeeping from a non-main thread. Whether that's
+ * a live, exploitable gap (vs. some other invariant ruling it out) wasn't
+ * fully chased down when #210 added this second call site -- see #213.
  *
  * C-only (see the stdatomic.h include guard above): no C++ TU in this
- * codebase touches GLOBAL_ENV's seqlock-protected slots directly. */
+ * codebase touches GLOBAL_ENV's/TVar's seqlock-protected slots directly. */
 #ifndef __cplusplus
 static inline void gc_wb_slot_atomic_relaxed(val_t *slot, val_t newval) {
     atomic_store_explicit((_Atomic val_t *)slot, newval, memory_order_relaxed);

--- a/src/stm.c
+++ b/src/stm.c
@@ -152,7 +152,20 @@ static bool tx_commit(TxState *tx) {
 
     for (size_t i = 0; i < tx->wlen; i++) {
         TVar *tv  = tx->wset[i].tv;
-        gc_wb_slot(&tv->value, tx->wset[i].val);
+        /* Issue #210: tv->value is read lock-free by stm_tvar_read (both
+         * the in-transaction TL2 seqlock path and the no-current-
+         * transaction fast path below) -- gc_wb_slot's plain `*slot =
+         * newval` write, done here under tv->lock but with no
+         * synchronization visible to those lock-free readers, is a
+         * genuine data race under the C11 memory model regardless of the
+         * version-based seqlock logic layered on top (same shape #153
+         * fixed for GLOBAL_ENV's EnvFrame.vals[]). gc_wb_slot_atomic_relaxed
+         * is that exact fix, reused here: same write-barrier bookkeeping,
+         * atomic-relaxed store instead of a plain one. Relaxed suffices
+         * for the same reason it did for #153 -- the real ordering
+         * readers need comes from the separate version counter
+         * (write_ver, released just below), not from this store itself. */
+        gc_wb_slot_atomic_relaxed(&tv->value, tx->wset[i].val);
         atomic_store_explicit(
             (_Atomic uint64_t *)&tv->version, write_ver, memory_order_release);
     }
@@ -221,8 +234,17 @@ val_t stm_tvar_read(val_t v) {
     TVar    *tv = as_tvar(v);
     TxState *tx = current_tx;
 
+    /* Issue #210: plain reads of tv->value here and below raced tx_commit's
+     * (and the no-transaction stm_tvar_write's) write to the same field --
+     * see gc_wb_slot_atomic_relaxed's call site in tx_commit for the full
+     * writer-side reasoning. Matching relaxed atomic load on the reader
+     * side is what makes the pairing well-defined; it adds no ordering
+     * beyond what's already there; the version-based checks below (and,
+     * for this no-transaction case, the caller's own lack of any ordering
+     * requirement beyond "some committed value") are what any real
+     * consistency guarantee actually comes from. */
     if (!tx)
-        return tv->value;
+        return atomic_load_explicit((_Atomic val_t *)&tv->value, memory_order_relaxed);
 
     val_t pending = wset_lookup(tx, tv);
     if (pending != V_UNDEF) return pending;
@@ -246,7 +268,7 @@ val_t stm_tvar_read(val_t v) {
     if (ver > tx->read_ver)
         stm_retry();
 
-    val_t val = tv->value;
+    val_t val = atomic_load_explicit((_Atomic val_t *)&tv->value, memory_order_relaxed);
 
     uint64_t ver2 = atomic_load_explicit(
         (_Atomic uint64_t *)&tv->version, memory_order_acquire);
@@ -265,7 +287,9 @@ void stm_tvar_write(val_t v, val_t val) {
 
     if (!tx) {
         pthread_mutex_lock(&tv->lock);
-        gc_wb_slot(&tv->value, val);
+        /* Issue #210: same race as tx_commit's write -- see its call site
+         * for the full reasoning. */
+        gc_wb_slot_atomic_relaxed(&tv->value, val);
         atomic_fetch_add_explicit(&g_vclock, 1, memory_order_acq_rel);
         uint64_t new_ver = atomic_load_explicit(&g_vclock, memory_order_acquire);
         atomic_store_explicit(


### PR DESCRIPTION
## Summary

- Fixes #210: `TVar.value` was a plain `val_t` field, read lock-free by `stm_tvar_read` (both the in-transaction TL2 seqlock path and the no-current-transaction fast path) while written under `tv->lock` by `tx_commit` and `stm_tvar_write`'s no-current-transaction path -- a plain read racing a mutex-protected but otherwise plain write, UB under C11 regardless of the version-based seqlock logic on top. Same shape #153 fixed for `GLOBAL_ENV`'s `EnvFrame.vals[]`.
- Fix reuses `gc_wb_slot_atomic_relaxed` (built for #153) at both write sites, and switches both reader sites to a matching relaxed atomic load. The TL2 version-check protocol around `tv->version` is unchanged and is what actually provides consistency; this only removes UB from the value access underneath it.
- Updating `gc_wb_slot_atomic_relaxed`'s doc comment to describe the new second call site surfaced a related, **pre-existing** gap: its `gc_dirty_slots`/`gc_dirty_count` bookkeeping assumes main-thread-only callers, which doesn't obviously hold for either call site once actors are involved (confirmed: `GLOBAL_ENV`'s own write path already has this exposure via ordinary cross-thread `(define ...)`/`(set! ...)`, so it's not something this PR introduces). Filed as #213 rather than expanding this PR's scope.

## Test plan

- [x] `cmake --build build` -- clean
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` -- 127/127 passing (one unrelated flaky "ros" timeout, confirmed to pass on rerun)
- [x] TSan (`tests/actors_tests.scm`): reliable pre-fix failure at `gc.h:536`/`stm.c:249`/`stm.c:155` -> 0 races across 3 consecutive post-fix runs
- [x] Confirmed under the default Boehm backend too (the issue noted this wasn't verified either way) -- also clean
- [x] Independent code-review and security-review passes: security review found no findings; code review's two findings (a stale doc comment, and the `gc_dirty_slots` cross-thread concern) were addressed -- the comment fixed here, the cross-thread concern filed as #213 after confirming it's pre-existing

Confined to the STM subsystem; verified not specific to `--gc generational`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
