### PR TITLE
fix(gc): lock gc_dirty_slots/gc_dirty_count bookkeeping (#213)

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -118,13 +118,18 @@ size_t    gc_card_table_ncards = 0;
  * gc_dirty_slots is allocated by gc_gen_init() and stays NULL under Boehm,
  * causing gc_wb_slot to reduce to a bare assignment.
  * gc_main_nursery_base/limit are set once in gc_gen_init to the main thread's
- * nursery slab bounds; gc_wb_slot uses these globals instead of TLS gc_nursery
- * so that actor/worker threads never trigger dirty-slot recording. */
+ * nursery slab bounds; gc_wb_slot's range check against them ensures this
+ * bookkeeping never fires for a value an actor/worker thread itself
+ * allocated (those always go straight to Boehm, per gc_inhibit) -- but does
+ * NOT ensure only the main thread ever executes the bookkeeping itself, since
+ * any thread can write a value that's still main-thread-nursery-resident
+ * (issue #213); gc_dirty_lock is what actually makes concurrent callers safe. */
 val_t  **gc_dirty_slots      = NULL;
 size_t   gc_dirty_count      = 0;
 bool     gc_dirty_overflow   = false;
 uint8_t *gc_main_nursery_base  = NULL;
 uint8_t *gc_main_nursery_limit = NULL;
+pthread_mutex_t gc_dirty_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* ── GC statistics ──────────────────────────────────────────────────────────── */
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -40,6 +40,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <pthread.h>
 #ifndef __cplusplus
 #include <stdatomic.h> /* C++ TUs (qt6.cpp) that include this header never
                          * call gc_wb_slot_atomic_relaxed below -- stdatomic.h
@@ -509,18 +510,37 @@ extern size_t    gc_card_table_ncards;
  * Minor GC iterates these slot addresses to update forwarding pointers instead
  * of scanning the entire pinned list every collection.
  *
- * The buffer is a plain global because only the main thread can produce nursery
- * pointers (actor and worker threads run the tree-walker or hold gc_inhibit, so
- * their allocations go to Boehm).  Using the MAIN thread's nursery bounds
- * (gc_main_nursery_base/limit, set once in gc_gen_init) as the range check
- * ensures no other thread ever matches, making the global non-TLS safe.
- */
+ * Issue #213: the range check below (gc_main_nursery_base/limit, the MAIN
+ * thread's own nursery bounds) does correctly ensure this bookkeeping never
+ * fires for a value an actor/worker thread itself allocated -- those always
+ * go straight to Boehm, per gc_inhibit, never landing in this range. But it
+ * does NOT ensure only the main thread ever EXECUTES this bookkeeping: any
+ * thread whose gc_wb_slot/gc_wb_slot_atomic_relaxed call happens to write a
+ * value that's still main-thread-nursery-resident -- e.g. an actor writing
+ * a value it merely references (read from GLOBAL_ENV, received in a
+ * message) into a TVar or a shared pair/vector -- hits this exact code on
+ * that actor's own thread. Two such threads (or the main thread's own
+ * legitimate call, running concurrently with an actor's) can race the
+ * gc_dirty_count/gc_dirty_slots read-modify-write below. gc_dirty_lock
+ * closes that: held only around this rare branch (fires just for
+ * currently-nursery-resident values, not on every write-barrier call), so
+ * the overwhelmingly common case -- a plain tenured-to-tenured or
+ * tenured-to-Boehm write -- never pays for it. gc_gen_minor_collect's own
+ * dirty-slot processing (the reader side) takes the same lock, though
+ * that side turns out to already be race-free on its own merits: issue
+ * #200 Phase B's stop-the-world brackets the entire minor collection, so
+ * by the time this loop runs every other thread is either fully parked or
+ * hasn't reached this bookkeeping yet -- taking the lock here anyway costs
+ * nothing (collection is already the rare, expensive path) and keeps
+ * "always touched under gc_dirty_lock" a simple, uniform invariant rather
+ * than one arm of it resting on a separate argument. */
 #define GC_DIRTY_CAP 4096
 extern val_t  **gc_dirty_slots;      /* GC_MALLOC_UNCOLLECTABLE array of slot addresses */
 extern size_t   gc_dirty_count;      /* number of valid entries                          */
 extern bool     gc_dirty_overflow;   /* set when buffer is full (fall back to full scan) */
 extern uint8_t *gc_main_nursery_base;  /* set once by gc_gen_init; NULL under Boehm    */
 extern uint8_t *gc_main_nursery_limit; /* ditto                                          */
+extern pthread_mutex_t gc_dirty_lock;  /* guards gc_dirty_count/gc_dirty_slots/gc_dirty_overflow */
 
 /* ── Write barrier ────────────────────────────────────────────────────────── */
 
@@ -534,19 +554,20 @@ extern uint8_t *gc_main_nursery_limit; /* ditto                                 
  */
 static inline void gc_wb_slot(val_t *slot, val_t newval) {
     *slot = newval;
-    /* Only record when the written VALUE is in the MAIN thread's nursery.
-     * Using gc_main_nursery_base/limit (globals set once at init, never
-     * modified) rather than TLS gc_nursery ensures that actor threads and
-     * workpool workers — whose allocations go to Boehm and can never land in
-     * the main-thread slab — never touch gc_dirty_count, eliminating the
-     * need for any lock on the write path. */
+    /* Only record when the written VALUE is in the MAIN thread's nursery
+     * (see gc_dirty_lock's own declaration comment, issue #213, for why
+     * that range check alone doesn't guarantee only the main thread ever
+     * reaches this branch, and why the lock is scoped to just this rare
+     * branch rather than the whole write-barrier call). */
     if (gc_dirty_slots && vis_ptr(newval)) {
         const uint8_t *p = (const uint8_t *)(uintptr_t)newval;
         if (p >= gc_main_nursery_base && p < gc_main_nursery_limit) {
+            pthread_mutex_lock(&gc_dirty_lock);
             if (gc_dirty_count < GC_DIRTY_CAP)
                 gc_dirty_slots[gc_dirty_count++] = slot;
             else
                 gc_dirty_overflow = true;
+            pthread_mutex_unlock(&gc_dirty_lock);
         }
     }
 }
@@ -579,16 +600,10 @@ static inline void gc_wb_slot(val_t *slot, val_t newval) {
  * UB-by-definition against a concurrent plain read, not to add ordering
  * the caller's own protocol doesn't already provide.
  *
- * gc_dirty_slots/gc_dirty_count bookkeeping below assumes its caller is
- * always the MAIN thread -- true for env.c/vm.c's call sites (only the
- * main thread's own top-level code produces nursery pointers in the
- * first place, per this header's own gc_dirty_slots comment above), but
- * NOT provably true for stm.c: an actor thread can commit a value it
- * merely references (e.g. one it read out of GLOBAL_ENV or received in
- * a message) that still happens to be main-thread-nursery-resident, into
- * a TVar, hitting this bookkeeping from a non-main thread. Whether that's
- * a live, exploitable gap (vs. some other invariant ruling it out) wasn't
- * fully chased down when #210 added this second call site -- see #213.
+ * gc_dirty_slots/gc_dirty_count bookkeeping below is shared with
+ * gc_wb_slot and, as of issue #213, guarded by gc_dirty_lock precisely
+ * because it can be reached from more than one thread at once here --
+ * see gc_dirty_lock's own declaration comment for the full reasoning.
  *
  * C-only (see the stdatomic.h include guard above): no C++ TU in this
  * codebase touches GLOBAL_ENV's/TVar's seqlock-protected slots directly. */
@@ -598,10 +613,12 @@ static inline void gc_wb_slot_atomic_relaxed(val_t *slot, val_t newval) {
     if (gc_dirty_slots && vis_ptr(newval)) {
         const uint8_t *p = (const uint8_t *)(uintptr_t)newval;
         if (p >= gc_main_nursery_base && p < gc_main_nursery_limit) {
+            pthread_mutex_lock(&gc_dirty_lock);
             if (gc_dirty_count < GC_DIRTY_CAP)
                 gc_dirty_slots[gc_dirty_count++] = slot;
             else
                 gc_dirty_overflow = true;
+            pthread_mutex_unlock(&gc_dirty_lock);
         }
     }
 }

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -1023,7 +1023,11 @@ void gc_gen_minor_collect(void) {
      * follow-up, not bundled into the PR that first activates
      * stop-the-world. */
 
-    if (gc_dirty_overflow) {
+    pthread_mutex_lock(&gc_dirty_lock);
+    bool dirty_overflow_snapshot = gc_dirty_overflow;
+    pthread_mutex_unlock(&gc_dirty_lock);
+
+    if (dirty_overflow_snapshot) {
         pthread_mutex_lock(&pinned_lock);
         size_t pc = pinned_count;
         void **slots = pinned_slots;
@@ -1036,9 +1040,18 @@ void gc_gen_minor_collect(void) {
         pinned_stable = 0;
         pthread_mutex_unlock(&pinned_lock);
     } else {
-        /* Update the recorded dirty slots in-place. */
+        /* Update the recorded dirty slots in-place. Issue #213: gc_dirty_lock
+         * held here to match "always touched under this lock" now that
+         * gc_wb_slot/gc_wb_slot_atomic_relaxed's bookkeeping isn't provably
+         * main-thread-only -- see gc_dirty_lock's own declaration comment.
+         * Not strictly required for THIS particular read given issue #200
+         * Phase B's stop-the-world already excludes every other thread by
+         * the time this runs, but costs nothing extra on the already-rare
+         * collection path. */
+        pthread_mutex_lock(&gc_dirty_lock);
         for (size_t i = 0; i < gc_dirty_count; i++)
             *gc_dirty_slots[i] = evacuate(*gc_dirty_slots[i]);
+        pthread_mutex_unlock(&gc_dirty_lock);
         /* Scan new pinned objects (those added since the last compact). */
         pthread_mutex_lock(&pinned_lock);
         size_t pc = pinned_count;
@@ -1057,8 +1070,10 @@ void gc_gen_minor_collect(void) {
         pinned_stable = 0;
         pthread_mutex_unlock(&pinned_lock);
     }
+    pthread_mutex_lock(&gc_dirty_lock);
     gc_dirty_count    = 0;
     gc_dirty_overflow = false;
+    pthread_mutex_unlock(&gc_dirty_lock);
 
     /* 7. Call ext_scanner callbacks.
      * minor_gc_lock is non-recursive — ext_scanners must not allocate from


### PR DESCRIPTION
## Summary

- Fixes #213: `gc_wb_slot`/`gc_wb_slot_atomic_relaxed`'s dirty-slot remembered-set (`gc_dirty_slots`/`gc_dirty_count`/`gc_dirty_overflow`) was documented as safe without a lock because "only the main thread can produce nursery pointers" -- true for *allocating* an object, but not for *writing* a value that's currently nursery-resident regardless of who allocated it. An actor thread writing a value it merely read out of `GLOBAL_ENV` or received in a message (into a `TVar`, pair, vector, ...) reaches this exact bookkeeping on its own thread, racing the main thread's own legitimate calls or another actor's.
- Fix: a new `gc_dirty_lock` mutex, taken narrowly around just the bookkeeping block in both `gc_wb_slot` and `gc_wb_slot_atomic_relaxed` -- not the whole write-barrier call, so the common case (a plain write with no nursery-resident value) never pays for it. The reader side in `gc_gen_minor_collect()` takes the same lock too, for a single uniform invariant rather than leaning on a separate (correct, but separate) stop-the-world argument for just that side.
- Updated both call sites' now-stale doc comments to describe the actual invariant.
- Found and filed separately: a genuine, pre-existing crash at very small `--gc-nursery-size` (1K) under heavy multi-actor `tvar-write!` load -- confirmed via git-stash A/B to reproduce identically with or without this fix. Filed as #215 rather than blocking this PR.

## Test plan

- [x] `cmake --build build` -- clean
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` -- 127/127 passing
- [x] New TSan repro targeting the writer-vs-writer scenario directly (16 actors racing `tvar-write!` against a value main keeps re-publishing via a global, `--gc-nursery-size 4K`): 3/3 clean runs post-fix
- [x] TSan run of `tests/actors_tests.scm` (including its STM test, which also exercises #210's fix): 19/19 passing, 0 races
- [x] Independent code-review and security-review passes: both no findings

Confined to the experimental, opt-in `--gc generational` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
