### PR TITLE
fix(main): bracket init_all() in gc_inhibit_minor()/gc_resume_minor() (partial fix for #215)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,29 @@
 
 
 static void init_all(void) {
+    /* Issue #215: every one of these *_init() functions is plain C code
+     * that builds up val_t structures (module registries, alias lists,
+     * etc. -- e.g. modules_init()'s scm_cons() calls building up the
+     * (rnrs X)/(rnrs X Y) name lists) directly, not via apply_arr() (which
+     * brackets every ordinary Scheme-invoked primitive call in
+     * gc_inhibit_minor()/gc_resume_minor() already) and not via eval()'s
+     * tree-walker (which shadow-stacks its own C locals instead). Under
+     * --gc generational with a small enough nursery, a minor GC firing
+     * mid-construction here -- e.g. between allocating a pair and using
+     * its address in the next nested scm_cons() call -- moves an object
+     * whose new location no caller here is prepared to notice, corrupting
+     * state (confirmed: reliably crashes with "unknown GC:MOVE type" at
+     * --gc-nursery-size 1K, deterministically, before any user script
+     * code runs at all -- `curry --gc generational --gc-nursery-size 1K
+     * -e '(display 1)'` alone reproduces it). Bracketing the whole
+     * one-time startup sequence in gc_inhibit_minor()/gc_resume_minor()
+     * closes this the same way apply_arr() already does for ordinary
+     * primitive calls -- see gc.h's own doc comment on this pair of
+     * functions for the general rule this follows. Negligible cost:
+     * this runs once per process, falling back to Boehm-only allocation
+     * for the (small, bounded) startup working set instead of the
+     * nursery, not a hot path. */
+    gc_inhibit_minor();
     gc_init();
     sym_init();
     num_init();
@@ -81,6 +104,7 @@ static void init_all(void) {
 #ifdef BUILD_LLVM
     curry_llvm_init();
 #endif
+    gc_resume_minor();
 }
 
 /* ---- Error reporting ---- */


### PR DESCRIPTION
## Summary

- Partial fix for #215: `init_all()` runs a sequence of `*_init()` functions at startup, including `modules_init()`, which builds R6RS module-name lists via nested `scm_cons()` calls directly in C -- not through `apply_arr()` (already brackets every ordinary Scheme-invoked primitive call in `gc_inhibit_minor()`/`gc_resume_minor()`) and not through the tree-walking evaluator (shadow-stacks its own C locals via `GC_AUTOFRAME` instead). Under `--gc generational` with a small enough nursery, a minor GC firing mid-construction moves an object nothing here is prepared to notice, corrupting state.
- Confirmed via an actual lldb backtrace and deterministic reproduction: `curry --gc generational --gc-nursery-size 1K -e '(display 1)'` alone crashed reliably (5/5) before this fix, entirely inside `modules_init` at startup, before any user script runs. 5/5 clean after.
- Fix wraps the whole `init_all()` body in `gc_inhibit_minor()`/`gc_resume_minor()` -- not narrowly scoped to `modules_init`, since none of the other `*_init()` calls were individually audited for the same hazard.

## This is a partial fix

#215's own original repro (16 actors doing `tvar-write!` under `--gc-nursery-size 1K`) no longer hard-crashes, but still occasionally produces a `wrong-type-argument` error -- milder, but still real corruption, confirming a **separate** bug exists. Narrowing that down found plain single-threaded code (no actors, no STM) -- just a tail-recursive loop accumulating a list -- reliably corrupts memory at `--gc-nursery-size` 4K through at least 64K, inside the tree-walking evaluator's own procedure-application path. Filed as #217 (likely the same root cause as the already-open #144) rather than rushing a fix to core evaluator GC-safety under time pressure. **Not using a closing keyword here** -- #215 should stay open, tracked against #217.

## Test plan

- [x] `cmake --build build` -- clean
- [x] `find tests -name '*.scc' -delete && ctest --test-dir build` -- 127/127 passing (one unrelated flaky "ros" timeout, confirmed to pass on rerun)
- [x] `curry --gc generational --gc-nursery-size 1K -e '(display 1)'`: 5/5 reliable crashes pre-fix (confirmed via git-stash + full rebuild, not a stale-binary artifact), 5/5 clean post-fix
- [x] Independent code-review and security-review passes: security review found no findings. Code review's first finding (disputing the reproduction claim) was independently re-verified and refuted -- re-ran the exact cited repro against a freshly rebuilt pre-fix binary, 5/5 crashes, confirming the finding was a stale/unrebuilt-binary artifact on the reviewer's side. Its second finding (prefer a narrower fix scoped to just `modules_init`) is a reasonable style opinion, not a bug -- kept the broader bracket since it also covers any other un-audited `*_init()` call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
