### PR TITLE
fix(gc_gen,scc): register escaped nursery objects for GC scan; inhibit minor GC while reading .scc constants

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -58,7 +58,7 @@ curry_val curry_make_pair(curry_val car, curry_val cdr) {
  * see the plain value, matching R7RS's own `values` semantics. */
 curry_val curry_make_values(int argc, curry_val *argv) {
     if (argc == 1) return argv[0];
-    Values *mv = (Values *)gc_alloc(sizeof(Values) + (size_t)argc * sizeof(val_t));
+    Values *mv = (Values *)gc_alloc_obj(sizeof(Values) + (size_t)argc * sizeof(val_t));
     mv->hdr.type = T_VALUES;
     mv->hdr.flags = 0;
     mv->count = (uint32_t)argc;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -384,7 +384,7 @@ val_t prim_cons(int ac, val_t *av, void *ud) {
     (void)ac; (void)ud;
     /* Allocate first; av[] points into VM stack so GC can update av[0]/av[1].
      * Re-reading after gc_alloc avoids stale nursery pointers in car/cdr. */
-    Pair *p = (Pair *)gc_alloc(sizeof(Pair));
+    Pair *p = (Pair *)gc_alloc_obj(sizeof(Pair));
     p->hdr.type = T_PAIR; p->hdr.flags = 0;
     p->car = av[0]; p->cdr = av[1];
     return vptr(p);
@@ -1653,7 +1653,7 @@ static val_t prim_truncate_div(int ac, val_t *av, void *ud) {
     (void)ac;(void)ud;
     val_t q = num_quotient(av[0], av[1]);
     val_t r = num_remainder(av[0], av[1]);
-    Values *mv = (Values *)gc_alloc(sizeof(Values) + 2*sizeof(val_t));
+    Values *mv = (Values *)gc_alloc_obj(sizeof(Values) + 2*sizeof(val_t));
     mv->hdr.type = T_VALUES; mv->hdr.flags = 0; mv->count = 2;
     mv->vals[0] = q; mv->vals[1] = r;
     return vptr(mv);
@@ -1669,7 +1669,7 @@ static val_t prim_exact_integer_sqrt(int ac, val_t *av, void *ud) {
         while (s > 0 && s * s > k) s--;
         while ((s+1)*(s+1) <= k) s++;
         intptr_t r = k - s * s;
-        Values *mv = (Values *)gc_alloc(sizeof(Values) + 2*sizeof(val_t));
+        Values *mv = (Values *)gc_alloc_obj(sizeof(Values) + 2*sizeof(val_t));
         mv->hdr.type = T_VALUES; mv->hdr.flags = 0; mv->count = 2;
         mv->vals[0] = vfix(s); mv->vals[1] = vfix(r);
         return vptr(mv);
@@ -1683,7 +1683,7 @@ static val_t prim_exact_integer_sqrt(int ac, val_t *av, void *ud) {
         val_t vs = make_big_from_mpz(s);
         val_t vr = make_big_from_mpz(r);
         mpz_clear(s); mpz_clear(r);
-        Values *mv = (Values *)gc_alloc(sizeof(Values) + 2*sizeof(val_t));
+        Values *mv = (Values *)gc_alloc_obj(sizeof(Values) + 2*sizeof(val_t));
         mv->hdr.type = T_VALUES; mv->hdr.flags = 0; mv->count = 2;
         mv->vals[0] = vs; mv->vals[1] = vr;
         return vptr(mv);
@@ -2811,7 +2811,7 @@ static val_t prim_record_ctor(int ac, val_t *av, void *ud) {
     if (!vis_rtd(av[0])) scm_raise_code(EC_WRONG_TYPE_ARGUMENT, "%%record-ctor: not a record type");
     RecordType *rtd = vunptr(RecordType, av[0]);
     uint32_t n = rtd->nfields;
-    Record *r = (Record *)gc_alloc(sizeof(Record) + n * sizeof(val_t));
+    Record *r = (Record *)gc_alloc_obj(sizeof(Record) + n * sizeof(val_t));
     r->hdr.type=T_RECORD; r->hdr.flags=0;
     r->rtd = rtd;
     for (uint32_t i=0; i<n && (int)(i+1)<ac; i++) r->fields[i] = av[i+1];
@@ -3337,7 +3337,7 @@ static val_t prim_gensym(int ac, val_t *av, void *ud) {
 }
 static val_t prim_values(int ac, val_t *av, void *ud) {
     (void)ud; if(ac==1) return av[0];
-    Values *mv=(Values *)gc_alloc(sizeof(Values)+(size_t)ac*sizeof(val_t));
+    Values *mv=(Values *)gc_alloc_obj(sizeof(Values)+(size_t)ac*sizeof(val_t));
     mv->hdr.type=T_VALUES; mv->hdr.flags=0; mv->count=(uint32_t)ac;
     for(int i=0;i<ac;i++) mv->vals[i]=av[i];
     return vptr(mv);
@@ -3488,7 +3488,7 @@ static val_t prim_floor_div(int ac, val_t *av, void *ud) {
     check_exact_integer(av[0], "floor/");
     check_exact_integer(av[1], "floor/");
     val_t q=prim_floor_quotient(ac,av,ud), r2=num_sub(av[0],num_mul(q,av[1]));
-    Values *mv=(Values *)gc_alloc(sizeof(Values)+2*sizeof(val_t));
+    Values *mv=(Values *)gc_alloc_obj(sizeof(Values)+2*sizeof(val_t));
     mv->hdr.type=T_VALUES; mv->hdr.flags=0; mv->count=2; mv->vals[0]=q; mv->vals[1]=r2;
     return vptr(mv);
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -926,7 +926,7 @@ tail:
     if (op == S_VALUES) {
         int n = list_length(rest);
         if (n == 1) return eval(vcar(rest), env);
-        Values *mv = (Values *)gc_alloc(sizeof(Values) + (size_t)n * sizeof(val_t));
+        Values *mv = (Values *)gc_alloc_obj(sizeof(Values) + (size_t)n * sizeof(val_t));
         mv->hdr.type=T_VALUES; mv->hdr.flags=0; mv->count=(uint32_t)n;
         for (int i = 0; i < n; i++) { mv->vals[i] = eval(vcar(rest), env); rest = vcdr(rest); }
         return vptr(mv);

--- a/src/gc.c
+++ b/src/gc.c
@@ -210,6 +210,71 @@ void *gc_nursery_refill(size_t n, bool has_ptrs) {
     return has_ptrs ? GC_MALLOC(n) : GC_MALLOC_ATOMIC(n);
 }
 
+/*
+ * gc_alloc_obj — issues #144/#215/#217.
+ *
+ * Like gc_alloc(), but for allocations the caller knows will be a proper
+ * Hdr-prefixed GC:MOVE object (T_PAIR, T_VECTOR, T_RECORD, Values, ...) --
+ * i.e. everything CURRY_NEW/CURRY_NEW_FLEX construct, plus the handful of
+ * call sites that build such objects with a raw gc_alloc() call instead of
+ * going through those macros (flexible trailing-array sizing usually).
+ *
+ * gc_nursery_refill()'s Boehm-escape path (this file, just above) hands
+ * back a bare GC_MALLOC block whenever a minor collection wasn't safe to
+ * run at allocation time -- notably, the whole read+compile pipeline runs
+ * under gc_inhibit_count > 0 (main.c wraps it in gc_inhibit_minor()/
+ * gc_resume_minor()), and the tree-walking evaluator runs with
+ * gc_shadow_stack != NULL, both of which take the "defer, fall back to
+ * Boehm" branch above unconditionally, regardless of whether the object
+ * would otherwise have fit in a freshly-collected nursery. Such an escaped
+ * object is invisible to every other GC mechanism: it isn't in the nursery
+ * (so evacuate()/scan_object()'s worklist BFS never reaches it) and it
+ * isn't in pinned_slots (that's only populated by gc_alloc_pinned, a
+ * different allocator for GC:PIN types). Its caller then fills in fields
+ * immediately afterward -- e.g. scm_cons(car, cdr) -- and those fields are
+ * routinely fresh nursery pointers. Before this fix, such a field held a
+ * raw, unscanned nursery address forever: readable only as long as nothing
+ * reset the nursery region behind it, and silently reinterpreted as
+ * whatever unrelated object next legitimately reused that same byte
+ * offset the moment something did. This is the confirmed root cause of
+ * #217's "unknown GC:MOVE type" abort: forensics traced the corrupted
+ * value to exactly a pair built this way while reading/compiling a
+ * define-library form.
+ *
+ * Fix: detect the escape after the fact (the returned pointer, under the
+ * generational backend, always lies either inside the current nursery slab
+ * or nowhere near it -- there's no third option) and register it via the
+ * same pinned_add() gc_alloc_pinned already uses for GC:PIN types, so
+ * gc_gen_minor_collect()'s pinned-object scan visits it exactly once,
+ * walking whatever fields it has by the time that scan runs (strictly
+ * after this call's caller finishes writing them -- a minor collection can
+ * only fire at a gc_shadow_stack==NULL && gc_inhibit_count==0 safepoint,
+ * which is later than any plain-C field write this call's caller makes
+ * immediately upon return). scan_pinned_object's default case (gc_gen.c)
+ * now delegates to scan_object() for exactly this reason: unlike the fixed
+ * set of GC:PIN types it special-cases, an escaped object here is an
+ * ordinary GC:MOVE type and needs the identical per-field evacuate() logic
+ * scan_object() already implements for every such type.
+ *
+ * Deliberately NOT applied to plain gc_alloc(): several call sites use it
+ * for raw val_t[] buffers with no Hdr at all (builtins.c's apply-argv
+ * expansion, eval.c's call-argument buffer, runtime.c's list->vector-ish
+ * helper) or plain non-GC-value C structs (port.c's WSharedMap/
+ * WSharedEntry write-sharing table) -- treating either as Hdr-prefixed and
+ * handing it to scan_pinned_object/scan_object would read whatever
+ * unrelated bits happen to sit at offset 0 as an ObjType tag, which is
+ * exactly the "unexpected type <garbage>" abort this fix was first tried
+ * against before being narrowed to gc_alloc_obj specifically. */
+void *gc_alloc_obj(size_t n) {
+    void *p = gc_nursery_alloc(n, true);
+    if (gc_nursery.base != NULL &&
+        ((uint8_t *)p < gc_nursery.base || (uint8_t *)p >= gc_nursery.limit)) {
+        extern void gc_gen_pin_permanent(void *obj);
+        gc_gen_pin_permanent(p);
+    }
+    return p;
+}
+
 /* C-linkage allocator called from C++ translation units (jit.cpp).
  * C++ code cannot safely reference gc_nursery via 'extern thread_local' because
  * the C++ TLS wrapper symbol (_ZTW…) is ABI-incompatible with the C TLS symbol

--- a/src/gc.h
+++ b/src/gc.h
@@ -155,6 +155,7 @@ void *gc_nursery_refill(size_t n, bool has_ptrs);
 extern "C" {
     void *gc_alloc_impl(size_t n, int has_ptrs);
     void *gc_alloc_pinned_impl(size_t n, int has_ptrs);
+    void *gc_alloc_obj(size_t n);
 }
 #endif
 
@@ -226,11 +227,23 @@ static inline void *gc_alloc_raw_pinned_atomic(size_t n) { return gc_ops->alloc_
 #endif
 static inline void  gc_collect(void)                 { gc_ops->collect(); }
 
+/* Like gc_alloc(), for allocations the caller knows are a proper Hdr-
+ * prefixed GC:MOVE object (as opposed to a raw val_t[] buffer or a plain
+ * non-GC-value C struct) -- see its own doc comment in gc.c (issues
+ * #144/#215/#217) for why the distinction matters: only these can safely
+ * be registered for a later pinned-object scan if they escape straight to
+ * Boehm because a minor collection wasn't safe to run at allocation time.
+ * Declared above (in the C++ extern "C" block) for C++ callers; C sees it
+ * declared here instead since it isn't part of that block. */
+#ifndef __cplusplus
+void *gc_alloc_obj(size_t n);
+#endif
+
 /* ── Allocation macros ────────────────────────────────────────────────────── */
 
 /* Standard (semispace-eligible): */
-#define CURRY_NEW(T)              ((T *)gc_alloc(sizeof(T)))
-#define CURRY_NEW_FLEX(T, n)      ((T *)gc_alloc(sizeof(T) + (n)*sizeof(((T*)0)->data[0])))
+#define CURRY_NEW(T)              ((T *)gc_alloc_obj(sizeof(T)))
+#define CURRY_NEW_FLEX(T, n)      ((T *)gc_alloc_obj(sizeof(T) + (n)*sizeof(((T*)0)->data[0])))
 #define CURRY_NEW_ATOM(T)         ((T *)gc_alloc_atomic(sizeof(T)))
 #define CURRY_NEW_FLEX_ATOM(T, n) ((T *)gc_alloc_atomic(sizeof(T) + (n)*sizeof(((T*)0)->data[0])))
 

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -714,7 +714,20 @@ static void scan_pinned_object(void *obj) {
         break;
     }
     default:
-        /* Unknown pinned type — skip; conservative is safe. */
+        /* Issues #144/#215/#217: this used to silently skip anything not
+         * among the GC:PIN cases above ("conservative is safe") -- but as
+         * of gc_nursery_refill()'s fallback fix (src/gc.c), pinned_slots can
+         * now also hold ordinary GC:MOVE-tagged objects (T_PAIR, T_VECTOR,
+         * ...) that escaped straight to Boehm because a minor collection
+         * wasn't safe to run at allocation time. Those genuinely do have
+         * val_t fields that may point into the nursery and need the exact
+         * per-type evacuate() logic scan_object() already implements for
+         * every GC:MOVE type -- "skip" was never actually safe for them,
+         * it just happened not to matter until an object allocated this way
+         * held a live nursery reference. scan_object()'s own default case
+         * still aborts on a type unrecognized by EITHER switch, so this
+         * isn't a silent behavior change for genuinely unexpected data. */
+        scan_object(obj);
         break;
     }
 }

--- a/src/numtheory.c
+++ b/src/numtheory.c
@@ -524,7 +524,7 @@ static val_t prim_extended_gcd(int ac, val_t *av, void *ud) {
     mpz_gcdext(g, s, t, a, b);
     val_t triple[3] = { z_to_val(g), z_to_val(s), z_to_val(t) };
     mpz_clears(a, b, g, s, t, NULL);
-    Values *vv = (Values *)gc_alloc(sizeof(Values) + 3*sizeof(val_t));
+    Values *vv = (Values *)gc_alloc_obj(sizeof(Values) + 3*sizeof(val_t));
     vv->hdr.type = T_VALUES; vv->hdr.flags = 0; vv->count = 3;
     vv->vals[0] = triple[0]; vv->vals[1] = triple[1]; vv->vals[2] = triple[2];
     return vptr(vv);
@@ -1039,7 +1039,7 @@ static val_t prim_perfect_power_p(int ac, val_t *av, void *ud) {
                 val_t base = z_to_val(root);
                 val_t exp  = num_make_bignum_i((long)e);
                 mpz_clears(n, root, pow, NULL);
-                Values *vv = (Values *)gc_alloc(sizeof(Values) + 2*sizeof(val_t));
+                Values *vv = (Values *)gc_alloc_obj(sizeof(Values) + 2*sizeof(val_t));
                 vv->hdr.type = T_VALUES; vv->hdr.flags = 0; vv->count = 2;
                 vv->vals[0] = base; vv->vals[1] = exp;
                 return vptr(vv);

--- a/src/quantum.c
+++ b/src/quantum.c
@@ -17,7 +17,7 @@ void quantum_init(void) { /* nothing; uses rand() seeded by main */ }
 /* ---- Internal helpers ---- */
 
 static val_t make_quantum(int n, val_t *amps, val_t *vals) {
-    Quantum *q = (Quantum *)gc_alloc(sizeof(Quantum) + (size_t)(2 * n) * sizeof(val_t));
+    Quantum *q = (Quantum *)gc_alloc_obj(sizeof(Quantum) + (size_t)(2 * n) * sizeof(val_t));
     q->hdr.type  = T_QUANTUM;
     q->hdr.flags = 0;
     q->n         = n;

--- a/src/scc.c
+++ b/src/scc.c
@@ -496,7 +496,7 @@ static bool read_const(FILE *f, val_t *out) {
         return true;
     }
     case CTAG_PAIR: {
-        Pair *p = (Pair *)gc_alloc(sizeof(Pair));
+        Pair *p = (Pair *)gc_alloc_obj(sizeof(Pair));
         p->hdr.type = T_PAIR; p->hdr.flags = 0;
         p->car = V_NIL; p->cdr = V_NIL;
         *out = vptr(p);
@@ -509,7 +509,7 @@ static bool read_const(FILE *f, val_t *out) {
     case CTAG_VECTOR: {
         uint32_t len;
         if (!ru32(f, &len)) return false;
-        Vector *vec = (Vector *)gc_alloc(sizeof(Vector) + len * sizeof(val_t));
+        Vector *vec = (Vector *)gc_alloc_obj(sizeof(Vector) + len * sizeof(val_t));
         vec->hdr.type = T_VECTOR; vec->hdr.flags = 0; vec->len = len;
         *out = vptr(vec);
         for (uint32_t i = 0; i < len; i++) {

--- a/src/scc.c
+++ b/src/scc.c
@@ -941,25 +941,59 @@ void scc_clear(const char *src_path) {
     if (fb) { remove(fb); free(fb); }
 }
 
+/* Issues #144/#217 (code-review follow-up on the #217 fix): read_const()/
+ * read_chunk() build up nested Pair/Vector/Chunk structures via plain C
+ * locals (e.g. read_const's own `p`/`vec`, and every recursive `car`/`cdr`/
+ * `elem` in between) with no GC-root registration at all -- unlike
+ * compiler_classic.c's equivalent reader-driven parsing (main.c's
+ * cache-miss branch), which main.c deliberately brackets in
+ * gc_inhibit_minor()/gc_resume_minor() for exactly this reason (see that
+ * call site's own comments). Before this fix, scc_load()/scc_load_direct()
+ * had no equivalent bracket at all: under --gc generational, a minor
+ * collection firing mid-recursion (e.g. while reading a deeply nested
+ * quoted constant, or simply because the .scc being loaded is large enough
+ * to exhaust the nursery partway through) evacuates an already-under-
+ * construction Pair/Vector out from under its own unrooted C local. The
+ * caller then keeps writing through that now-stale pointer (e.g.
+ * read_const's CTAG_PAIR case's `p->car = car; p->cdr = cdr;`, executed
+ * AFTER the recursive read_const() calls that could have triggered the
+ * collection) -- those writes land in the old, already-forwarded nursery
+ * memory instead of the promoted copy, which is what every other live
+ * reference (e.g. the parent chunk's constants[] slot) actually points to.
+ * The promoted copy is left with whatever car/cdr the memcpy captured at
+ * promotion time (typically the CTAG_PAIR case's own placeholder
+ * `V_NIL`/`V_NIL` initialization) forever, while the real values are
+ * silently lost to memory the nursery will reuse for something else on its
+ * next reset. This is very likely the mechanism behind #144's still-
+ * unresolved SIGSEGV (that issue's repro loads a `.scc` compiled ahead of
+ * time via `curry -c`, which is exactly scc_load_direct()'s call path) --
+ * gc_alloc_obj's fix for #217 addressed the Boehm-ESCAPE case (no minor GC
+ * runs at all), not this one, where a minor GC genuinely runs mid-parse
+ * and the caller's own C locals just aren't rooted against it. */
 bool scc_load(const char *src_path, Chunk ***chunks_out, int *n_out) {
+    gc_inhibit_minor();
     char *p = primary_path(src_path);
     if (p && read_scc(p, src_path, chunks_out, n_out)) {
         free(p);
+        gc_resume_minor();
         return true;
     }
     free(p);
     /* Try user cache */
     char *fb = fallback_path(src_path);
-    if (!fb) return false;
+    if (!fb) { gc_resume_minor(); return false; }
     bool hit = read_scc(fb, src_path, chunks_out, n_out);
     free(fb);
+    gc_resume_minor();
     return hit;
 }
 
 bool scc_load_direct(const char *scc_path, Chunk ***chunks_out, int *n_out) {
     FILE *f = fopen(scc_path, "rb");
     if (!f) return false;
+    gc_inhibit_minor();
     bool ok = load_chunks_from_file(f, NULL, chunks_out, n_out);
+    gc_resume_minor();
     fclose(f);
     return ok;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -1015,7 +1015,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
                 /* Allocate first: args still on VM stack so GC (if
                  * triggered) can update them. Re-read from stack after
                  * allocation. */
-                Pair *p = (Pair *)gc_alloc(sizeof(Pair));
+                Pair *p = (Pair *)gc_alloc_obj(sizeof(Pair));
                 p->hdr.type = T_PAIR; p->hdr.flags = 0;
                 p->car = vm->sp[-2]; p->cdr = vm->sp[-1];
                 vm->sp -= 2; *vm->sp++ = vptr(p);
@@ -1753,7 +1753,7 @@ val_t vm_run(BcClosure *top_closure, int argc) {
              * it was applied as ONE argument, so
              * (call-with-values (lambda () (values)) (lambda () ...))
              * failed with "too many arguments (got 1, need 0)". */
-            Values *mv = (Values *)gc_alloc(sizeof(Values) + (size_t)n * sizeof(val_t));
+            Values *mv = (Values *)gc_alloc_obj(sizeof(Values) + (size_t)n * sizeof(val_t));
             mv->hdr.type = T_VALUES; mv->hdr.flags = 0; mv->count = n;
             val_t *base = vm->sp - n;
             for (int i = 0; i < (int)n; i++) mv->vals[i] = base[i];


### PR DESCRIPTION
## Summary

Root-causes and fixes two distinct, confirmed generational-GC (`--gc
generational`, experimental opt-in backend) memory-corruption bugs behind
the #144/#215/#217 cluster:

1. **`gc_nursery_refill()`'s Boehm-escape fallback never registered escaped
   objects for future GC scanning.** Fires whenever a minor collection
   isn't safe to run at allocation time (reader/compiler code under
   `gc_inhibit_count > 0`, or the tree-walking evaluator with
   `gc_shadow_stack != NULL`). An ordinary Hdr-prefixed GC:MOVE object
   (T_PAIR, T_VECTOR, ...) allocated this way had its very-next-written
   fields (e.g. `scm_cons(car, cdr)`, often fresh nursery pointers) go
   completely unscanned forever, dangling the moment the nursery region
   behind them was later reset and reused. Repro from #217 goes from 5/5
   crash to 5/5 clean.

2. **`scc_load()`/`scc_load_direct()` never inhibited minor GC while
   parsing a `.scc` file's constant pool**, unlike the equivalent
   fresh-compile reader path (`main.c`), which deliberately brackets it.
   `read_const()`/`read_chunk()` build nested Pair/Vector/Chunk structures
   via plain, unrooted C locals; a minor collection firing mid-recursion
   evacuates an object out from under its own C local, and the caller's
   subsequent writes land in stale, already-forwarded nursery memory
   instead of the promoted copy every other live reference actually points
   to. This matches #144's repro exactly (it loads a precompiled `.scc`) —
   goes from 3/3 SIGSEGV to clean across multiple runs.

Fix (2) was found via a fresh, independent code-review pass on fix (1) —
that review is what surfaced it, and it turned out to be the actual root
cause still reproducing #144's crash even after fix (1) alone.

Closes #217.
Closes #144.

## What's still open

**#215**'s multi-actor `tvar-write!` repro improves (100%-reproducible
`SIGABRT` → a recoverable Scheme-level error in most runs) but is not
fully resolved by this PR. Root-caused the residual gap — `gc_wb_slot`'s
dirty-slot write barrier only recognizes the *main* thread's nursery
bounds, not an actor's own — and filed it separately as **#220**, since a
correct fix needs to account for `gc_dirty_slots` being a single global
remembered set drained by whichever thread's collection happens to run
next, not a quick patch. #220 also flags `sx_rules.c`/`sx_algebra.c`'s
`rtab`/`atab` (written with no barrier at all, relying entirely on an
ext-scanner generation-counter re-walk) as a related mechanism worth
checking, since it's plausibly the same underlying gap by a different
route. Leaving #215 open, pointed at #220.

## Test plan

- [x] Repro from #217 (`define-library` + 50k-element list build,
      single-threaded, `--gc-nursery-size 4K`) — 5/5 crash → 5/5 clean.
- [x] Repro from #144 (`phase1_only.scm`, 12 actors stressing
      `sx_rules`/`sx_algebra`, compiled via `curry -c` then run from the
      resulting `.scc` with `--gc-nursery-size 8K`) — 3/3 SIGSEGV → clean
      across multiple additional runs, both via the precompiled-`.scc`
      path and the direct auto-compile-cache path.
- [x] Repro from #215 (16-actor `tvar-write!`, `--gc-nursery-size 1K`) —
      SIGABRT eliminated; residual failure mode tracked in #220.
- [x] `ctest --test-dir build` — 125/125 passing (default Boehm backend).
- [x] Independent code-review pass (fresh subagent, no shared context)
      — surfaced fix (2) above.
- [x] Independent security-review pass (fresh subagent) — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
