### PR TITLE
fix(gc_gen): recognize any live thread's nursery during evacuation (#220 Candidate B)

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -523,14 +523,13 @@ extern size_t    gc_card_table_ncards;
  * Minor GC iterates these slot addresses to update forwarding pointers instead
  * of scanning the entire pinned list every collection.
  *
- * Issue #213: the range check below (gc_main_nursery_base/limit, the MAIN
- * thread's own nursery bounds) does correctly ensure this bookkeeping never
- * fires for a value an actor/worker thread itself allocated -- those always
- * go straight to Boehm, per gc_inhibit, never landing in this range. But it
- * does NOT ensure only the main thread ever EXECUTES this bookkeeping: any
- * thread whose gc_wb_slot/gc_wb_slot_atomic_relaxed call happens to write a
- * value that's still main-thread-nursery-resident -- e.g. an actor writing
- * a value it merely references (read from GLOBAL_ENV, received in a
+ * Issue #213: the range check below does correctly ensure this bookkeeping
+ * never fires for a value an actor/worker thread itself allocated -- those
+ * always go straight to Boehm, per gc_inhibit, never landing in this range.
+ * But it does NOT ensure only the main thread ever EXECUTES this
+ * bookkeeping: any thread whose gc_wb_slot/gc_wb_slot_atomic_relaxed call
+ * happens to write a value that's still nursery-resident -- e.g. an actor
+ * writing a value it merely references (read from GLOBAL_ENV, received in a
  * message) into a TVar or a shared pair/vector -- hits this exact code on
  * that actor's own thread. Two such threads (or the main thread's own
  * legitimate call, running concurrently with an actor's) can race the
@@ -546,14 +545,44 @@ extern size_t    gc_card_table_ncards;
  * hasn't reached this bookkeeping yet -- taking the lock here anyway costs
  * nothing (collection is already the rare, expensive path) and keeps
  * "always touched under gc_dirty_lock" a simple, uniform invariant rather
- * than one arm of it resting on a separate argument. */
+ * than one arm of it resting on a separate argument.
+ *
+ * Issue #220 (Candidate B): the range check itself used to compare only
+ * against gc_main_nursery_base/limit -- the MAIN thread's own nursery
+ * bounds -- which meant an ACTOR writing a value resident in its OWN
+ * nursery into an already-tenured slot (issue #220's repro: stm.c's
+ * TVar.value written from an actor's tvar-write!) was silently never
+ * recorded at all: the range check itself was false for every such write,
+ * regardless of locking. gc_gen_ptr_in_any_nursery() (gc_gen.c) replaces
+ * that check with one that recognizes ANY currently-registered thread's
+ * nursery, not just main's -- see its own declaration comment below and
+ * gc_gen.c's ptr_in_other_thread_nursery() for why this remains cheap on
+ * the common case and safe to call without stop-the-world in effect. */
 #define GC_DIRTY_CAP 4096
 extern val_t  **gc_dirty_slots;      /* GC_MALLOC_UNCOLLECTABLE array of slot addresses */
 extern size_t   gc_dirty_count;      /* number of valid entries                          */
 extern bool     gc_dirty_overflow;   /* set when buffer is full (fall back to full scan) */
-extern uint8_t *gc_main_nursery_base;  /* set once by gc_gen_init; NULL under Boehm    */
-extern uint8_t *gc_main_nursery_limit; /* ditto                                          */
+extern uint8_t *gc_main_nursery_base;  /* set once by gc_gen_init; NULL under Boehm.
+                                         * Issue #220: no longer read by gc_wb_slot's own
+                                         * range check (see gc_gen_ptr_in_any_nursery
+                                         * below) -- kept only because other code may
+                                         * still reference the main thread's bounds
+                                         * specifically; not load-bearing for the barrier. */
+extern uint8_t *gc_main_nursery_limit; /* ditto */
 extern pthread_mutex_t gc_dirty_lock;  /* guards gc_dirty_count/gc_dirty_slots/gc_dirty_overflow */
+
+/*
+ * Issue #220 Candidate B: is `p` resident in ANY currently-registered
+ * thread's nursery slab (not just the calling thread's own)? Defined in
+ * gc_gen.c; always returns false under Boehm (harmless -- gc_dirty_slots is
+ * NULL there, so gc_wb_slot never even reaches the call that would use
+ * this). Used in place of the old gc_main_nursery_base/limit range check so
+ * a write from ANY thread of a value resident in THAT thread's own nursery
+ * is correctly recorded, not just writes of main-thread-nursery-resident
+ * values. See gc_gen.c's own declaration comment for the precision
+ * trade-off this makes (deliberately over-inclusive, never under-inclusive)
+ * to stay race-free without requiring stop-the-world. */
+bool gc_gen_ptr_in_any_nursery(const void *p);
 
 /* ── Write barrier ────────────────────────────────────────────────────────── */
 
@@ -574,7 +603,7 @@ static inline void gc_wb_slot(val_t *slot, val_t newval) {
      * branch rather than the whole write-barrier call). */
     if (gc_dirty_slots && vis_ptr(newval)) {
         const uint8_t *p = (const uint8_t *)(uintptr_t)newval;
-        if (p >= gc_main_nursery_base && p < gc_main_nursery_limit) {
+        if (gc_gen_ptr_in_any_nursery(p)) {
             pthread_mutex_lock(&gc_dirty_lock);
             if (gc_dirty_count < GC_DIRTY_CAP)
                 gc_dirty_slots[gc_dirty_count++] = slot;
@@ -625,7 +654,7 @@ static inline void gc_wb_slot_atomic_relaxed(val_t *slot, val_t newval) {
     atomic_store_explicit((_Atomic val_t *)slot, newval, memory_order_relaxed);
     if (gc_dirty_slots && vis_ptr(newval)) {
         const uint8_t *p = (const uint8_t *)(uintptr_t)newval;
-        if (p >= gc_main_nursery_base && p < gc_main_nursery_limit) {
+        if (gc_gen_ptr_in_any_nursery(p)) {
             pthread_mutex_lock(&gc_dirty_lock);
             if (gc_dirty_count < GC_DIRTY_CAP)
                 gc_dirty_slots[gc_dirty_count++] = slot;

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -87,20 +87,41 @@ void gc_gen_set_nursery_size(size_t bytes) {
  * doubling under a lock, mirroring pinned_add's own history -- see that
  * function's comment on issue #205 for why a lock-free version of this
  * exact shape of growable-array-scanned-by-another-thread was tried once
- * already and found to have a real, reproducible data race). Entries are
- * NEVER removed on thread exit: gc_gen_unregister_thread()/
- * gc_gen_thread_leave() already deliberately leave a dead thread's nursery
- * slab allocated forever (see that function's own comment -- Boehm owns
- * the memory regardless via GC_MALLOC_UNCOLLECTABLE, and reclaiming it is
- * out of scope), so leaving the table entry inert costs nothing extra: a
- * dead thread's slab can never again receive a fresh allocation, so it can
- * only ever contain objects already forwarded (harmless re-hit -- GC_FORWARDED
- * short-circuits in evacuate()) or, in the pathological case of a thread
- * that exited while still holding the only reference to a value nobody else
- * ever forwards, an already-unreachable object nothing will ever ask about
- * again. Compacting the array on unregister would need the same lock this
- * read path takes on every table-fallback lookup, for no correctness
- * benefit -- not worth it.
+ * already and found to have a real, reproducible data race).
+ *
+ * CAUTION (found by independent code-review AND security-review of an
+ * earlier version of this patch, both flagging the identical bug): a
+ * slot's `nursery` field is `&gc_nursery`, the address of the OWNING
+ * thread's own `_Thread_local GcNursery` object -- NOT the (deliberately
+ * immortal, GC_MALLOC_UNCOLLECTABLE) slab it points at. Actor threads in
+ * this codebase are detached (src/actors.c); once such a thread's body
+ * returns, the pthread runtime reclaims that thread's ENTIRE TLS block,
+ * including the storage backing its `gc_nursery` struct -- unlike the slab
+ * itself, that struct's storage is NOT immortal. An earlier version of
+ * this table left every entry in place forever after thread exit (on the
+ * theory that only the slab's liveness mattered), which meant
+ * ptr_in_other_thread_nursery() could dereference a dangling pointer into
+ * a since-reclaimed and possibly since-reused TLS block for any actor that
+ * had ever exited -- a genuine use-after-free reachable by ordinary
+ * spawn/exit traffic, not a contrived corner case. Fixed by tombstoning:
+ * unregister_thread_nursery() (called from gc_gen_unregister_thread() --
+ * genuine thread exit -- but deliberately NOT from gc_gen_thread_park(),
+ * whose thread is merely blocked and very much still alive, still owns its
+ * TLS, and will call gc_gen_thread_unpark() and resume) nulls this
+ * thread's own slot under g_thread_nurseries_lock before the thread
+ * actually returns/exits, and ptr_in_other_thread_nursery() skips a NULL
+ * `nursery` field. `my_nursery_table_idx` (thread-local, set once at
+ * registration) makes this an O(1) direct write rather than a search --
+ * cheap enough to not need weighing against the lock it already takes.
+ *
+ * Slots are NOT compacted/reused after being tombstoned: this thread's own
+ * `my_nursery_table_idx` is the only record of "which slot is mine", and
+ * nothing updates that thread-local value from another thread, so shifting
+ * other threads' entries down to fill a hole would silently invalidate
+ * their own cached indices. Leaving a permanent NULL hole is the safe
+ * trade-off -- see the g_nursery_table_min/max comment below for the
+ * follow-on cost this accepts (a monotonically growing scan/bounding-box),
+ * flagged as a known, accepted limitation rather than fixed here.
  *
  * g_nursery_table_min/max is a global bounding box (min base, max limit)
  * updated whenever a new thread registers, checked BEFORE touching the
@@ -108,17 +129,43 @@ void gc_gen_set_nursery_size(size_t bytes) {
  * every live pointer during every minor collection, so the fallback lookup
  * below must stay cheap for the overwhelmingly common case (pointer isn't
  * in ANY nursery, or is in the collecting thread's own -- both handled by
- * cheaper checks before this is ever reached).
+ * cheaper checks before this is ever reached). KNOWN LIMITATION (flagged
+ * during review, accepted rather than fixed here): this box only ever
+ * widens, never shrinks, even for a tombstoned/exited thread's slab -- so
+ * does the array itself (dead slots are nulled, not removed -- see above).
+ * In a long-running process that spawns a great many actors over its
+ * lifetime, both the bounding box's selectivity and the fallback scan's
+ * cost degrade towards "every candidate pointer walks the whole table",
+ * independent of how many threads are live RIGHT NOW. Matches this file's
+ * existing precedent of never freeing a dead thread's nursery slab either
+ * (see gc_gen_thread_leave()'s own comment) -- a real trade-off, not
+ * addressed by this change, worth revisiting if it shows up in practice
+ * (e.g. compacting periodically would need every live thread's own
+ * my_nursery_table_idx re-published under the lock, not attempted here).
  */
 #define THREAD_NURSERY_TABLE_INIT_CAP 64
 typedef struct {
-    GcNursery *nursery;  /* &gc_nursery, taken on the owning thread itself */
+    GcNursery *nursery;  /* &gc_nursery, taken on the owning thread itself;
+                           * NULL once that thread has exited (tombstoned by
+                           * unregister_thread_nursery(), below) -- skipped
+                           * by every scan of this table. */
 } ThreadNurseryEntry;
 
 static ThreadNurseryEntry *g_thread_nurseries;
 static size_t               g_thread_nurseries_count;
 static size_t               g_thread_nurseries_cap;
 static pthread_mutex_t      g_thread_nurseries_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/* This thread's own index into g_thread_nurseries, set once at
+ * registration -- lets unregister_thread_nursery() tombstone this thread's
+ * slot in O(1) under the lock instead of searching for it (a search would
+ * also need SOME way to identify "which entry is mine" -- comparing
+ * `nursery == &gc_nursery` works just as well as an index for that, but the
+ * index is simpler and just as cheap). SIZE_MAX sentinel = never
+ * registered (should not happen for any thread that calls
+ * gc_gen_unregister_thread(), but unregister_thread_nursery() checks
+ * defensively anyway). */
+static CURRY_THREAD_LOCAL size_t my_nursery_table_idx = SIZE_MAX;
 
 static _Atomic uintptr_t g_nursery_table_min = (uintptr_t)UINTPTR_MAX;
 static _Atomic uintptr_t g_nursery_table_max = 0;
@@ -139,7 +186,9 @@ static void register_thread_nursery(void) {
         g_thread_nurseries = ns;
         g_thread_nurseries_cap = nc;
     }
-    g_thread_nurseries[g_thread_nurseries_count++].nursery = &gc_nursery;
+    size_t idx = g_thread_nurseries_count++;
+    g_thread_nurseries[idx].nursery = &gc_nursery;
+    my_nursery_table_idx = idx;
 
     uintptr_t base  = (uintptr_t)gc_nursery.base;
     uintptr_t limit = (uintptr_t)gc_nursery.limit;
@@ -154,6 +203,26 @@ static void register_thread_nursery(void) {
                                                    memory_order_relaxed, memory_order_relaxed))
         ;
     pthread_mutex_unlock(&g_thread_nurseries_lock);
+}
+
+/* Issue #220 Candidate B (post-review fix): tombstone THIS thread's own
+ * table entry. Must be called from gc_gen_unregister_thread() -- genuine,
+ * permanent thread exit, right before the thread's TLS is reclaimed -- and
+ * must NOT be called from gc_gen_thread_park()'s temporary parking (that
+ * thread is merely blocked, not exiting; it still owns its TLS and its
+ * gc_nursery is still a perfectly live, meaningful nursery that other
+ * threads' evacuation/write-barrier checks need to keep recognizing while
+ * it's parked). See the ThreadNurseryEntry struct comment above for what
+ * this fixes: without it, g_thread_nurseries could hold a dangling pointer
+ * into a since-freed (or since-reused) TLS block forever after any actor
+ * exits -- a genuine use-after-free, not a hypothetical one, since actors
+ * routinely spawn and exit as normal operation. */
+static void unregister_thread_nursery(void) {
+    if (my_nursery_table_idx == SIZE_MAX) return;  /* never registered */
+    pthread_mutex_lock(&g_thread_nurseries_lock);
+    g_thread_nurseries[my_nursery_table_idx].nursery = NULL;
+    pthread_mutex_unlock(&g_thread_nurseries_lock);
+    my_nursery_table_idx = SIZE_MAX;
 }
 
 /*
@@ -200,7 +269,9 @@ static bool ptr_in_other_thread_nursery(const void *p, bool precise) {
     pthread_mutex_lock(&g_thread_nurseries_lock);
     for (size_t i = 0; i < g_thread_nurseries_count; i++) {
         GcNursery *gn = g_thread_nurseries[i].nursery;
-        if (gn == &gc_nursery) continue;  /* self -- already checked by caller */
+        if (!gn || gn == &gc_nursery) continue;  /* tombstoned (exited), or
+                                                    * self -- already checked
+                                                    * by caller */
         const uint8_t *hi = precise ? gn->top : gn->limit;
         if ((const uint8_t *)p >= gn->base && (const uint8_t *)p < hi) {
             found = true;
@@ -1071,8 +1142,21 @@ void gc_gen_thread_unpark(void) {
  * just keeps gc_gen_thread_count accurate so a future stop_the_world()'s
  * wait target reflects threads that are actually still live. See
  * gc_gen_thread_leave()'s own comment (issue #208) for why this must
- * signal gc_stw_parked, not just decrement the counter. */
+ * signal gc_stw_parked, not just decrement the counter.
+ *
+ * Issue #220 Candidate B (post-review fix): also tombstones this thread's
+ * g_thread_nurseries entry via unregister_thread_nursery() -- see that
+ * function's own comment and the ThreadNurseryEntry struct comment above
+ * for why this is required (a dangling-pointer/use-after-free otherwise),
+ * and specifically why it belongs HERE and not in gc_gen_thread_leave()
+ * (shared with gc_gen_thread_park(), whose thread is not exiting). Ordered
+ * before gc_gen_thread_leave(): this thread is about to actually return
+ * and have its TLS reclaimed by the pthread runtime regardless of ordering
+ * here, so tombstoning first just means the window during which a
+ * concurrent scan could still (correctly) see this thread's still-valid
+ * nursery is a little longer, never shorter. */
 void gc_gen_unregister_thread(void) {
+    unregister_thread_nursery();
     gc_gen_thread_leave();
 }
 

--- a/src/gc_gen.c
+++ b/src/gc_gen.c
@@ -31,6 +31,7 @@
 #include <pthread.h>
 #include <time.h>
 #include <stdatomic.h>
+#include <stdint.h>
 
 /* ── Pause ring buffer ───────────────────────────────────────────────────── */
 
@@ -62,6 +63,173 @@ void gc_gen_set_nursery_size(size_t bytes) {
 
 /* ── Per-thread nursery slab ──────────────────────────────────────────────── */
 
+/*
+ * Issue #220 Candidate B: shared table of every live thread's nursery, so a
+ * minor collection triggered on one thread can recognize and promote a
+ * pointer that is resident in a DIFFERENT thread's nursery (not just its
+ * own) -- e.g. a value an actor wrote into an already-tenured TVar's field,
+ * or a value received via a mailbox message and bound to a local on the
+ * receiving thread. Safe to read/copy directly from another thread's slab
+ * here because gc_gen_stop_the_world() (issue #200 Phase B) genuinely
+ * pauses every other registered thread for the full duration of a minor
+ * collection -- see gc_gen_minor_collect()'s own comment on that bracket.
+ *
+ * Each entry stores a POINTER to the owning thread's own `gc_nursery` TLS
+ * instance (taken from &gc_nursery while running ON that thread, inside
+ * alloc_thread_nursery() below) rather than a copy of its bounds -- TLS
+ * storage is ordinary per-thread-backed memory, valid to dereference from
+ * any thread once its address is known, so this lets a reader always see
+ * that thread's CURRENT base/top/limit (in particular `top`, which only
+ * that thread's own future collection ever resets) without needing a
+ * separate update path every time a thread allocates.
+ *
+ * The array only ever grows (GC_MALLOC_UNCOLLECTABLE + realloc-style
+ * doubling under a lock, mirroring pinned_add's own history -- see that
+ * function's comment on issue #205 for why a lock-free version of this
+ * exact shape of growable-array-scanned-by-another-thread was tried once
+ * already and found to have a real, reproducible data race). Entries are
+ * NEVER removed on thread exit: gc_gen_unregister_thread()/
+ * gc_gen_thread_leave() already deliberately leave a dead thread's nursery
+ * slab allocated forever (see that function's own comment -- Boehm owns
+ * the memory regardless via GC_MALLOC_UNCOLLECTABLE, and reclaiming it is
+ * out of scope), so leaving the table entry inert costs nothing extra: a
+ * dead thread's slab can never again receive a fresh allocation, so it can
+ * only ever contain objects already forwarded (harmless re-hit -- GC_FORWARDED
+ * short-circuits in evacuate()) or, in the pathological case of a thread
+ * that exited while still holding the only reference to a value nobody else
+ * ever forwards, an already-unreachable object nothing will ever ask about
+ * again. Compacting the array on unregister would need the same lock this
+ * read path takes on every table-fallback lookup, for no correctness
+ * benefit -- not worth it.
+ *
+ * g_nursery_table_min/max is a global bounding box (min base, max limit)
+ * updated whenever a new thread registers, checked BEFORE touching the
+ * lock or walking the table -- evacuate()/in_nursery() fires on essentially
+ * every live pointer during every minor collection, so the fallback lookup
+ * below must stay cheap for the overwhelmingly common case (pointer isn't
+ * in ANY nursery, or is in the collecting thread's own -- both handled by
+ * cheaper checks before this is ever reached).
+ */
+#define THREAD_NURSERY_TABLE_INIT_CAP 64
+typedef struct {
+    GcNursery *nursery;  /* &gc_nursery, taken on the owning thread itself */
+} ThreadNurseryEntry;
+
+static ThreadNurseryEntry *g_thread_nurseries;
+static size_t               g_thread_nurseries_count;
+static size_t               g_thread_nurseries_cap;
+static pthread_mutex_t      g_thread_nurseries_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static _Atomic uintptr_t g_nursery_table_min = (uintptr_t)UINTPTR_MAX;
+static _Atomic uintptr_t g_nursery_table_max = 0;
+
+static void register_thread_nursery(void) {
+    pthread_mutex_lock(&g_thread_nurseries_lock);
+    if (g_thread_nurseries_count == g_thread_nurseries_cap) {
+        size_t nc = g_thread_nurseries_cap ? g_thread_nurseries_cap * 2
+                                            : THREAD_NURSERY_TABLE_INIT_CAP;
+        ThreadNurseryEntry *ns = GC_MALLOC_UNCOLLECTABLE(nc * sizeof(ThreadNurseryEntry));
+        if (!ns) { fprintf(stderr, "[gc_gen] FATAL: thread_nurseries OOM\n"); abort(); }
+        if (g_thread_nurseries)
+            memcpy(ns, g_thread_nurseries, g_thread_nurseries_count * sizeof(ThreadNurseryEntry));
+        /* Safe to free: every reader/writer holds g_thread_nurseries_lock for
+         * its entire touch of this array, mirroring pinned_add's own fix
+         * (issue #205) for the identical shape of bug. */
+        if (g_thread_nurseries) GC_FREE(g_thread_nurseries);
+        g_thread_nurseries = ns;
+        g_thread_nurseries_cap = nc;
+    }
+    g_thread_nurseries[g_thread_nurseries_count++].nursery = &gc_nursery;
+
+    uintptr_t base  = (uintptr_t)gc_nursery.base;
+    uintptr_t limit = (uintptr_t)gc_nursery.limit;
+    uintptr_t old_min = atomic_load_explicit(&g_nursery_table_min, memory_order_relaxed);
+    while (base < old_min &&
+           !atomic_compare_exchange_weak_explicit(&g_nursery_table_min, &old_min, base,
+                                                   memory_order_relaxed, memory_order_relaxed))
+        ;
+    uintptr_t old_max = atomic_load_explicit(&g_nursery_table_max, memory_order_relaxed);
+    while (limit > old_max &&
+           !atomic_compare_exchange_weak_explicit(&g_nursery_table_max, &old_max, limit,
+                                                   memory_order_relaxed, memory_order_relaxed))
+        ;
+    pthread_mutex_unlock(&g_thread_nurseries_lock);
+}
+
+/*
+ * Is `p` resident in some OTHER currently-registered thread's nursery slab
+ * (the calling thread's own bounds are checked separately, and more
+ * cheaply, by each caller before this is ever reached)? Cheap global range
+ * pre-check first (single pair of atomic loads, no lock) so the common case
+ * -- pointer isn't in any nursery, e.g. an ordinary Boehm-tenured object --
+ * never touches g_thread_nurseries_lock at all.
+ *
+ * `precise` selects which bound to check a candidate thread's slab against:
+ *
+ *   - true  (used by in_nursery(), below, during a minor collection only):
+ *     bound against that thread's CURRENT `top`. Every other registered
+ *     thread is parked under stop-the-world for the full duration of a
+ *     collection (see gc_gen_minor_collect()'s own comment), so reading
+ *     another thread's `top` with a plain load is race-free and gives an
+ *     exact answer -- important here because a false positive would hand
+ *     evacuate() a bogus header to interpret from unallocated/zeroed nursery
+ *     space (obj_size()/scan_object() would abort on the garbage type tag).
+ *
+ *   - false (used by gc_gen_ptr_in_any_nursery(), below, for gc_wb_slot's
+ *     recording-side check -- issue #220 point 5): bound against that
+ *     thread's `limit` instead. This runs from ordinary mutator code with
+ *     NO stop-the-world in effect, so another thread's `top` can be
+ *     concurrently advancing via its own lock-free bump-pointer allocator
+ *     (gc_nursery_alloc's plain `gc_nursery.top = next`) -- reading it here
+ *     would be a data race. `base`/`limit` are written exactly once, at
+ *     that thread's own registration, and never touched again, so they are
+ *     always safe to read cross-thread. Bounding against `limit` instead of
+ *     `top` is over-inclusive (may treat some not-yet-allocated tail bytes
+ *     as "nursery-resident"), but that is harmless here: gc_wb_slot never
+ *     dereferences the header itself, it only records the SLOT address into
+ *     gc_dirty_slots for evacuate() to re-examine later, under the precise/
+ *     stop-the-world check above, at the next minor GC -- a spurious record
+ *     just costs one redundant (and safe) evacuate() call on a value that
+ *     turns out not to be nursery-resident after all. */
+static bool ptr_in_other_thread_nursery(const void *p, bool precise) {
+    uintptr_t addr = (uintptr_t)p;
+    if (addr < atomic_load_explicit(&g_nursery_table_min, memory_order_relaxed) ||
+        addr >= atomic_load_explicit(&g_nursery_table_max, memory_order_relaxed))
+        return false;
+    bool found = false;
+    pthread_mutex_lock(&g_thread_nurseries_lock);
+    for (size_t i = 0; i < g_thread_nurseries_count; i++) {
+        GcNursery *gn = g_thread_nurseries[i].nursery;
+        if (gn == &gc_nursery) continue;  /* self -- already checked by caller */
+        const uint8_t *hi = precise ? gn->top : gn->limit;
+        if ((const uint8_t *)p >= gn->base && (const uint8_t *)p < hi) {
+            found = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&g_thread_nurseries_lock);
+    return found;
+}
+
+/* gc_wb_slot/gc_wb_slot_atomic_relaxed's recording-side check (src/gc.h,
+ * issue #220 point 5): is `p` resident in ANY currently-registered thread's
+ * nursery, including the calling thread's own? Previously that check only
+ * recognized the MAIN thread's own nursery bounds (gc_main_nursery_base/
+ * limit), so an actor writing a value resident in ITS OWN nursery into an
+ * already-tenured slot (the exact shape of issue #220's repro) was silently
+ * never recorded -- the dirty-slot mechanism is what makes a minor GC look
+ * at that slot again at all (a "stable" pinned object is not re-scanned by
+ * type), so under-recording here is NOT made moot by evacuate()'s own
+ * any-thread fix above: that fix only helps once something actually asks
+ * evacuate() to look at the slot's value again, and dirty-slot recording is
+ * what causes that ask for an already-stable tenured object. The two
+ * mechanisms are complementary, not redundant -- both are required. */
+bool gc_gen_ptr_in_any_nursery(const void *p) {
+    if ((const uint8_t *)p >= gc_nursery.base && (const uint8_t *)p < gc_nursery.limit)
+        return true;
+    return ptr_in_other_thread_nursery(p, false);
+}
+
 static void alloc_thread_nursery(void) {
     size_t sz = gen_nursery_size;
     uint8_t *slab = (uint8_t *)GC_MALLOC_UNCOLLECTABLE(sz);
@@ -70,6 +238,7 @@ static void alloc_thread_nursery(void) {
     gc_nursery.base  = slab;
     gc_nursery.top   = slab;
     gc_nursery.limit = slab + sz;
+    register_thread_nursery();
 }
 
 /* ── Dirty-slot buffer allocation ────────────────────────────────────────── */
@@ -156,9 +325,19 @@ static void pinned_add(void *obj) {
 
 static uint8_t *collect_top;  /* snapshot of nursery.top at collection start */
 
+/*
+ * Issue #220 Candidate B: fast path checks the COLLECTING thread's own
+ * nursery first (cheap TLS reads, no lock) -- this is the overwhelmingly
+ * common case (an object a thread itself allocated and is now evacuating
+ * via its own roots) and MUST stay this cheap since it fires on essentially
+ * every live pointer touched during every minor collection. Only on a miss
+ * does this fall back to ptr_in_other_thread_nursery(), which checks every
+ * OTHER live thread's nursery (see that function's own comment for why that
+ * fallback itself stays cheap on ITS common case too). */
 static inline bool in_nursery(const void *p) {
-    return (const uint8_t *)p >= gc_nursery.base &&
-           (const uint8_t *)p <  collect_top;
+    if ((const uint8_t *)p >= gc_nursery.base && (const uint8_t *)p < collect_top)
+        return true;
+    return ptr_in_other_thread_nursery(p, true);
 }
 
 /* ── Work list (BFS queue of promoted objects to scan) ───────────────────── */


### PR DESCRIPTION
## Summary

Implements Candidate B for #220: `evacuate()`/`in_nursery()` (`src/gc_gen.c`)
previously only recognized the *collecting* thread's own nursery bounds, so
a pointer resident in a *different* live thread's nursery -- an actor's
`tvar-write!` writing a still-nursery-resident value into an already-tenured
`TVar.value`, or a value received via a mailbox message and bound to a local
on the receiving thread -- was never promoted correctly during another
thread's minor collection. Once that owning thread's own nursery later
cycled, the stale reference silently pointed at whatever unrelated object
now occupied that memory (`Error [wrong-type-argument]: #<object 0>` and
worse, per #220's repro).

- Adds a shared, lock-guarded table mapping each live thread to its own
  `GcNursery` TLS instance. `evacuate()`'s `in_nursery()` check now tries the
  calling thread's own bounds first (unchanged fast path -- cheap TLS reads,
  no lock), and only on a miss falls back to walking every *other* live
  thread's nursery, gated by a global min/max bounding-box pre-check so the
  common case (pointer isn't in any nursery) never touches the lock.
- Safe to read/copy directly from another thread's slab because
  `gc_gen_stop_the_world()` (#200 Phase B, already on `main`) genuinely
  pauses every other registered thread for the full duration of a minor
  collection.
- Forwarding is stamped in place in the *owning* thread's slab -- exactly
  like the existing same-thread case. That thread's own future minor
  collection naturally recognizes the `GC_FORWARDED` stub via its own
  same-thread fast path once resumed, so the origin slab needs no extra
  bookkeeping and is NOT reset by a collection it didn't itself trigger.
- `gc_wb_slot`/`gc_wb_slot_atomic_relaxed`'s own recording-side check
  (`src/gc.h`) previously compared only against `gc_main_nursery_base/limit`
  -- main-thread-only -- so an actor's write of a value resident in *its
  own* nursery into a tenured slot was silently never recorded at all. Fixed
  via a new `gc_gen_ptr_in_any_nursery()`, reusing the same any-thread
  table with a deliberately over-inclusive (never under-inclusive) bound so
  it stays race-free without requiring stop-the-world. The dirty-slot
  mechanism and `evacuate()`'s fix are **complementary, not redundant**:
  dirty-slot recording is what causes a minor GC to look at an
  already-"stable" tenured slot again at all; `evacuate()`'s fix is what
  makes that second look actually correct once it happens. Both were
  required.

### Post-review fix (second commit)

Independent code-review and security-review passes (fresh subagents, no
shared context with the implementation session, per `CLAUDE.md`) both
independently flagged the same real bug in the first commit: the new table
stored `&gc_nursery` -- the address of each thread's own `_Thread_local`
struct -- not the (deliberately immortal) nursery slab it points at. Actor
threads run detached; once one exits, the pthread runtime reclaims its
entire TLS block, including that struct's storage, but the original design
left the table entry in place forever ("harmless, the slab is immortal"),
which missed that the *struct itself* is not. That's a genuine
use-after-free reachable via ordinary actor spawn/exit traffic (see
`src/actors.c`), not a contrived corner case.

Fixed by tombstoning: each thread records its own table index
(`my_nursery_table_idx`, thread-local) at registration, and
`gc_gen_unregister_thread()` -- genuine, permanent thread exit -- nulls
that slot under the table's lock before the thread actually returns.
`gc_gen_thread_park()` (temporary parking for a blocking call, *not* an
exit) deliberately does **not** tombstone, since that thread is still alive
and still owns its TLS. `ptr_in_other_thread_nursery()` skips null entries.

A second, lower-severity finding from the same reviews (the table/bounding
box only ever grows, never compacts, so scan cost trends toward "every
candidate pointer walks the whole table" in a very long-running process
that has spawned very many actors) is documented as a known, accepted
trade-off rather than fixed here -- matches this file's own existing
precedent of never freeing a dead thread's nursery slab either, and
compacting would need every live thread's own cached table index
re-published under the lock, which isn't free either.

## Validation

All runs use `--clear-cache` per `CLAUDE.md`'s own caveat about the
content-hash-keyed `.scc` cache silently serving stale bytecode.

- **#220's own 16-actor `tvar-write!` repro**
  (`--gc generational --gc-nursery-size 1K`): **15/15 clean** (`done`
  printed every time) on the final commit; was ~3/5 failing with
  `wrong-type-argument` before this fix, confirmed by reverting the fix and
  reproducing again.
- **Full `ctest`**: **125/125 passing**, same count as `main` -- no
  regression, no count change.
- **#144's repro** (`phase1_only.scm`, `--gc-nursery-size 8K`, 12-actor
  `sx_rules`/`sx_algebra` stress): clean, no hang/crash, on both the direct
  `--clear-cache` path and a separately-compiled `.scc` run (5 total runs
  across both commits).
- **Message-passing-specific stress test** (built new for this PR --
  Candidate A, a write-barrier-only fix, would have missed this shape
  entirely since no tenured object's *field* is ever written, only local
  variables and mailbox queues): actors receiving a value via `send!` that
  is still resident in the *sender's* nursery, bound to a local, with GC
  pressure on the receiving side. **0/20 runs showed any corruption** (no
  `wrong-type-argument`, no crash) across two script sizes; a majority of
  runs hit a **separate, pre-existing** deadlock (actor `receive`/`send!`
  vs. stop-the-world, filed as #223, confirmed present on unmodified `main`
  too) rather than completing, which is why the pass count looks lower than
  the TVar repro's -- see #223 for the full diagnosis. No corruption was
  ever observed in either the runs that completed or the runs that hung.
- **Rough perf sanity check** (8 actors, CPU-bound loops, no message
  passing): `user` time ~0.79-0.87s pre-fix vs. ~0.86-0.88s post-fix across
  3 runs each -- within noise for this workload size, no gross regression.

## Filed separately (not fixed here -- out of scope / different subsystem)

- **#222**: the transparent `.scc` auto-cache load path crashes reliably
  under this same actor/TVar workload -- confirmed **pre-existing on
  `main`**, unrelated to this fix (reproduced with this branch's changes
  reverted). This is why all validation above uses `--clear-cache`.
- **#223**: actor `receive`/`send!` can deadlock with `gc_gen_stop_the_world()`
  -- `mailbox_pop_wait` calls `gc_gen_thread_unpark()` (which can block)
  while still holding the mailbox's mutex, and `mailbox_push`'s mutex
  acquisition isn't safepoint-aware. Confirmed **pre-existing on `main`**
  via the same revert-and-reproduce method. Full thread-dump diagnosis and
  suggested fix direction in the issue.

## Process notes

- Commits are split so the post-review fix is visible as its own step,
  per `CLAUDE.md`'s "commit after each meaningful step" guidance.
- Not merging this myself -- please review and merge when ready.
