### PR TITLE
fix(scc): allocate Chunk.code/name from stable memory under --gc generational

### DIFF
--- a/src/scc.c
+++ b/src/scc.c
@@ -599,8 +599,13 @@ static bool read_chunk(FILE *f, Chunk *c) {
         if (!nbuf) return false;
         if (fread(nbuf, 1, nlen, f) != nlen) { free(nbuf); return false; }
         nbuf[nlen] = '\0';
-        /* Store in GC-managed memory so the pointer stays valid */
-        char *gc_name = (char *)gc_alloc_atomic(nlen + 1);
+        /* Store in GC-managed memory so the pointer stays valid.  c->name is a
+         * plain `const char *` field on Chunk, not a val_t -- unlike the
+         * constant-pool entries above, nothing in scan_pinned_object's T_CHUNK
+         * case (or anywhere else) ever evacuates/updates it, exactly like
+         * c->code just below.  It must come from stable (non-nursery) memory;
+         * see c->code's own comment for the full mechanism this fixes. */
+        char *gc_name = (char *)gc_alloc_raw_pinned_atomic(nlen + 1);
         memcpy(gc_name, nbuf, nlen + 1);
         free(nbuf);
         c->name = gc_name;
@@ -610,7 +615,34 @@ static bool read_chunk(FILE *f, Chunk *c) {
     if (!ri32(f, &c->code_len)) return false;
     if (c->code_len < 0) return false;
     c->code_cap = c->code_len;
-    c->code = (uint8_t *)gc_alloc_atomic((size_t)c->code_len + 1);
+    /* c->code is a raw `uint8_t *` field on Chunk, not a val_t -- unlike the
+     * constant pool (c->constants[], scanned every minor GC via the T_CHUNK
+     * case in scan_pinned_object/gc_gen.c), nothing ever evacuates or
+     * updates this pointer. The normal compiler path (chunk.c's
+     * chunk_reserve, compiler.c/compiler_classic.c) grows this buffer via
+     * GC_REALLOC directly -- stable, non-moving Boehm memory -- never
+     * through the nursery. gc_alloc_atomic(), by contrast, is nursery-
+     * eligible under --gc generational: a small bytecode buffer easily
+     * lands inside the loading thread's nursery slab, and the FIRST minor
+     * GC that thread runs afterward (gc_gen_minor_collect resets
+     * gc_nursery.top = gc_nursery.base unconditionally, regardless of
+     * whether this buffer's bytes are still "live" by any tracked
+     * reachability -- they never were reachable via any val_t root in the
+     * first place) silently reuses that memory for new allocations while
+     * an actor thread may still be executing bytecode straight out of
+     * c->code -- a genuine use-after-free/data corruption, not merely a
+     * stale read. This was the root cause of issue #222 (16-actor
+     * tvar-write! repro crashing reliably via the transparent .scc
+     * auto-cache / precompiled .scc load path, but never via
+     * --clear-cache): the main thread's own unrelated allocation traffic
+     * (e.g. a busy loop consing on the main thread) is exactly what drives
+     * its nursery to overflow and collect while spawned actors are
+     * concurrently running bytecode loaded from this exact buffer.
+     * gc_alloc_raw_pinned_atomic() matches GC_REALLOC's stability
+     * guarantee (never nursery-resident, never moved) without requiring
+     * every Chunk consumer to also learn to evacuate a raw byte pointer
+     * that was never part of the tracked object graph to begin with. */
+    c->code = (uint8_t *)gc_alloc_raw_pinned_atomic((size_t)c->code_len + 1);
     if (!c->code) return false;
     if (c->code_len && fread(c->code, 1, (size_t)c->code_len, f) != (size_t)c->code_len)
         return false;


### PR DESCRIPTION
## Summary

Root-causes and fixes #222: the transparent `.scc` auto-cache load path (and explicit `curry -c` + run against the resulting `.scc`) crashed reliably (about 9-10/10, varying SIGSEGV/SIGBUS/SIGTRAP/SIGFPE) under `--gc generational` whenever actor threads execute bytecode loaded from a `.scc` file, while `--clear-cache` (never loading a `.scc`) stayed clean.

## Root cause

`read_chunk()` (`src/scc.c`) allocated `c->code` (the deserialized bytecode buffer) and the `c->name` copy via `gc_alloc_atomic()`, which is nursery-eligible under the generational backend's per-thread bump-pointer allocator. Both are plain C pointer fields on `Chunk` (`uint8_t *code`, `char *name`), not `val_t` constant-pool entries — nothing in `scan_pinned_object`'s `T_CHUNK` case (`src/gc_gen.c`), or anywhere else, ever evacuates or updates them, unlike `c->constants[]`.

The normal (non-`.scc`) compiler path never has this problem: `chunk.c`'s `chunk_reserve` grows `c->code` via `GC_REALLOC` directly — stable, non-moving Boehm memory, never nursery-resident.

When `c->code` landed in the loading (main) thread's nursery, the first minor GC that thread ran afterward reset the nursery unconditionally (`gc_nursery.top = gc_nursery.base`) and let that memory be reused for new allocations — while a spawned actor thread could still be executing bytecode straight out of the same buffer. #222's own repro busy-work loop (2000 conses on the main thread while 16 actors run `tvar-write!`) is exactly what drives that reset to fire concurrently with actor execution.

## Fix

Switch both allocations to `gc_alloc_raw_pinned_atomic()`, matching `GC_REALLOC`'s stability guarantee (never nursery-resident, never moved) — the same allocator `scc.c` already correctly uses for `c->lines`, `c->constants`, `c->local_debug`, and `c->upval_names` in the same function.

## Validation

- #222's own repro (16-actor `tvar-write!`, `--gc generational --gc-nursery-size 1K`):
  - Transparent `.scc` auto-cache path: **10/10 clean** (was ~9/10 crashing before this fix)
  - Explicit `curry -c` + run against the resulting `.scc`: **10/10 clean** (was ~9-10/10 crashing before this fix)
  - `--clear-cache` sanity check: **10/10 clean** (unaffected, as before)
- Full `ctest --test-dir build`: **125/125 passing** (parity with `main`)
- #220's own repro (same 16-actor `tvar-write!` script, `--clear-cache`): clean, no regression
- #144's repro (`phase1_only.scm`, 12-actor sx_rules/sx_algebra stress, compiled ahead-of-time via `curry -c` then run under `--gc generational --gc-nursery-size 8K`): **3/3 clean**, no regression

## Review

- Independent fresh-context code review (`/code-review --level high`): no findings — confirmed the fix matches the established pattern already used for `c->lines`/`c->constants`/`c->local_debug`/`c->upval_names` in the same function, and that `read_chunk` populates no other raw-pointer `Chunk` field needing the same treatment.
- Independent fresh-context security review: no findings — this is a pure GC-allocator-stability fix (closes a use-after-free, introduces no new attack surface or trust-boundary change).

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
