### PR TITLE
fix(actors): resolve mailbox-mutex / stop-the-world deadlock (#223)

### DIFF
--- a/src/actors.c
+++ b/src/actors.c
@@ -442,6 +442,17 @@ void actor_send(val_t actor_val, val_t msg) {
     mailbox_push(a->mailbox, msg, a);
 }
 
+/* Issue #223 security review note: mailbox_pop_wait's unlock/unpark/
+ * re-lock sequence relies on "only the owning actor's own thread ever
+ * calls mailbox_pop_wait on that actor's mailbox" to skip re-checking
+ * m->q.head == m->q.tail after the re-lock (nothing else can drain the
+ * queue in that window). That invariant holds today because this is the
+ * ONLY call site reaching mailbox_pop_wait, and it's only ever reached
+ * from builtins.c's `receive` primitive with actor_val defaulting to
+ * the CALLING thread's own current_actor -- i.e. every actor can only
+ * ever receive() on itself. If a future caller ever lets one thread
+ * request another actor's mailbox here, that assumption breaks; keep
+ * this comment and mailbox_pop_wait's own in sync with any such change. */
 val_t actor_receive(val_t actor_val, long timeout_ms) {
     Actor *a = vis_actor(actor_val) ? as_actor(actor_val) : current_actor;
     if (!a) return V_FALSE;

--- a/src/actors.c
+++ b/src/actors.c
@@ -170,19 +170,15 @@ static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
      * genuine 3-way deadlock, confirmed via a `sample` thread dump
      * matching this exact cycle before this fix.
      *
-     * Fix: track whether we parked, and defer gc_gen_thread_unpark()
-     * until AFTER m->mutex is released. Nothing between the wait loop and
-     * the unlock below still needs the lock beyond what was already true
-     * before this change -- the message is dequeued (m->q.head advanced)
-     * under the lock exactly as before; only the unpark() call itself
-     * moves to after pthread_mutex_unlock(). This cannot make the message
-     * visible to a concurrent mailbox_push() any earlier than before: the
-     * dequeue still happens strictly before the unlock, in the same
-     * relative order as the original code, so there is no new window
-     * where a sender could observe a half-updated queue or duplicate a
-     * receive -- moving the unpark() call across the unlock does not
-     * reorder anything touching m->q itself. */
-    int parked = 0;
+     * Fix: once a wait loop below confirms a message is actually waiting,
+     * release m->mutex, call gc_gen_thread_unpark(), then re-acquire the
+     * mutex before touching m->q at all (see the per-branch comments).
+     * gc_gen_thread_unpark() is thus never called while holding the
+     * mutex, closing the deadlock -- and the dequeue itself still always
+     * happens fully unparked, exactly as in the pre-#223 code, so a
+     * concurrent GC scan of this (or any) Mailbox never races this
+     * thread's mutation of m->q (see the re-lock comment below for why
+     * that second property matters just as much as the first). */
     if (timeout_ms < 0) {
         if (m->q.head == m->q.tail) {
             /* Issue #200 Phase A: this can block for an unbounded time
@@ -192,9 +188,43 @@ static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
              * heap pointers while blocked here beyond what the pinned
              * Mailbox object itself already exposes. */
             gc_gen_thread_park();
-            parked = 1;
             while (m->q.head == m->q.tail)
                 pthread_cond_wait(&m->cond, &m->mutex);
+            /* Message now available, m->mutex held (pthread_cond_wait
+             * re-acquires it before returning). Release it before
+             * calling gc_gen_thread_unpark() -- see the #223 comment
+             * above -- then re-acquire before touching m->q below.
+             *
+             * This re-lock is required, not just for the unpark-while-
+             * holding-the-lock deadlock: a fresh code-review pass on an
+             * earlier version of this fix (which unparked AFTER the
+             * dequeue instead of before) found that it let the dequeue
+             * itself -- m->q.head advancing, m->q.msgs[head] being read
+             * -- happen while this thread was still "parked" (excluded
+             * from gc_gen_thread_count). gc_gen.c's T_MAILBOX scan under
+             * a concurrent gc_gen_stop_the_world() reads m->q WITHOUT
+             * taking m->mutex, relying entirely on every live thread
+             * being either past a safepoint or genuinely parked (i.e.
+             * provably not touching Curry-managed state) -- a parked
+             * thread that's still mutating m->q under the mutex breaks
+             * that invariant: an unsynchronized data race between this
+             * thread's write and the collector's read of the same
+             * fields, on a mailbox that could belong to any actor, not
+             * just this one. Re-acquiring after unpark() means the
+             * dequeue always happens fully unparked (registered, and
+             * already past any safepoint that was active), exactly
+             * matching the original code's ordering relative to m->q --
+             * only the unpark() call itself is now done without holding
+             * the lock. Not a lost-message risk: mailbox_pop_wait is
+             * only ever called by this actor's own thread (one reader
+             * per mailbox), so nothing else can drain the queue while
+             * we're unlocked here -- a concurrent mailbox_push() can
+             * only add messages or grow m->q.msgs (which preserves
+             * m->q.head's logical position), never remove the one we
+             * already confirmed is waiting. */
+            pthread_mutex_unlock(&m->mutex);
+            gc_gen_thread_unpark();
+            pthread_mutex_lock(&m->mutex);
         }
     } else if (m->q.head == m->q.tail) {
         /* Bounded by timeout_ms, but still park -- the timeout can be
@@ -202,7 +232,6 @@ static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
          * stop-the-world request wait out someone else's receive
          * timeout when this thread isn't touching Curry objects. */
         gc_gen_thread_park();
-        parked = 1;
         while (m->q.head == m->q.tail) {
             struct timespec ts;
             clock_gettime(CLOCK_REALTIME, &ts);
@@ -216,12 +245,17 @@ static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
                 return V_FALSE;  /* timeout */
             }
         }
+        /* Same reasoning as the infinite-timeout case above: release,
+         * unpark, and re-acquire before the shared dequeue code below
+         * touches m->q. */
+        pthread_mutex_unlock(&m->mutex);
+        gc_gen_thread_unpark();
+        pthread_mutex_lock(&m->mutex);
     }
     val_t msg = m->q.msgs[m->q.head];
     m->q.head = (m->q.head + 1) % m->q.cap;
     uint32_t depth = (uint32_t)((m->q.tail - m->q.head + m->q.cap) % m->q.cap);
     pthread_mutex_unlock(&m->mutex);
-    if (parked) gc_gen_thread_unpark();
 
     if (current_actor) {
         atomic_fetch_add_explicit(&current_actor->msgs_received, 1, memory_order_relaxed);

--- a/src/actors.c
+++ b/src/actors.c
@@ -95,6 +95,38 @@ static Mailbox *mailbox_new(void) {
 }
 
 static void mailbox_push(Mailbox *m, val_t msg, Actor *target) {
+    /* Issue #223: deliberately NOT bracketed with gc_gen_thread_park()/
+     * gc_gen_thread_unpark(), unlike mailbox_pop_wait's genuinely
+     * unbounded message-arrival wait. Bracketing THIS lock acquisition
+     * was tried and reverted -- it reintroduces the exact same deadlock
+     * class in a new spot: gc_gen_thread_unpark() calls
+     * gc_gen_safepoint(), which can itself BLOCK for the duration of a
+     * concurrent gc_gen_stop_the_world(); parking before the lock and
+     * unparking only after acquiring it (mirroring gc_gen_minor_collect's
+     * minor_gc_lock pattern) means that block happens WHILE THIS THREAD
+     * STILL HOLDS m->mutex -- reproduced concretely: the main thread then
+     * sits in mailbox_push -> gc_gen_thread_unpark -> gc_gen_safepoint
+     * still holding the mutex, while a receiving actor blocks acquiring
+     * that same mutex in mailbox_pop_wait, never reaching its own
+     * safepoint poll, so the collector's stop_the_world() waits on that
+     * receiver forever. gc_gen_minor_collect's minor_gc_lock bracket
+     * avoids this because minor_gc_lock has at most one holder and that
+     * holder can't be mid-STW-request against itself; m->mutex has no
+     * such structural guarantee -- it's contended by arbitrary unrelated
+     * sender/receiver threads, any of which might be the very thread a
+     * third actor's stop-the-world is waiting on.
+     *
+     * This is safe left unbracketed precisely because of the fix applied
+     * to mailbox_pop_wait below: m->mutex is now NEVER held across a call
+     * that can block on a safepoint, by either function, so contending
+     * for it here is always a bounded, fast wait -- pthread_cond_wait
+     * (mailbox_pop_wait's actual unbounded wait) releases the mutex
+     * internally while blocked, per POSIX semantics, so it doesn't count.
+     * A thread mid this bounded critical section, not yet parked and not
+     * yet at its next safepoint poll, is exactly the case
+     * gc_gen_safepoint()'s own comment describes as already safe: a
+     * concurrent gc_gen_stop_the_world() simply waits for it to finish
+     * and reach its next real poll point, instead of racing it. */
     pthread_mutex_lock(&m->mutex);
     size_t next = (m->q.tail + 1) % m->q.cap;
     if (next == m->q.head) {
@@ -124,6 +156,33 @@ static void mailbox_push(Mailbox *m, val_t msg, Actor *target) {
 
 static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
     pthread_mutex_lock(&m->mutex);
+    /* Issue #223: gc_gen_thread_unpark() calls gc_gen_safepoint(), which
+     * can itself BLOCK (if a gc_gen_stop_the_world() is active right now)
+     * until the collector calls gc_gen_start_the_world(). The original
+     * code called gc_gen_thread_unpark() while still holding m->mutex --
+     * so a receiving actor could end up parked mid-safepoint while still
+     * holding its own mailbox's mutex, and a concurrent mailbox_push()
+     * from another thread (blocked acquiring that same mutex) would then
+     * itself be stuck on a plain, non-safepoint-aware pthread_mutex_lock,
+     * never reaching a safepoint of its own -- so the stop-the-world
+     * request that's parking the receiver wound up waiting forever on the
+     * sender, and the sender waited forever on the receiver's mutex: a
+     * genuine 3-way deadlock, confirmed via a `sample` thread dump
+     * matching this exact cycle before this fix.
+     *
+     * Fix: track whether we parked, and defer gc_gen_thread_unpark()
+     * until AFTER m->mutex is released. Nothing between the wait loop and
+     * the unlock below still needs the lock beyond what was already true
+     * before this change -- the message is dequeued (m->q.head advanced)
+     * under the lock exactly as before; only the unpark() call itself
+     * moves to after pthread_mutex_unlock(). This cannot make the message
+     * visible to a concurrent mailbox_push() any earlier than before: the
+     * dequeue still happens strictly before the unlock, in the same
+     * relative order as the original code, so there is no new window
+     * where a sender could observe a half-updated queue or duplicate a
+     * receive -- moving the unpark() call across the unlock does not
+     * reorder anything touching m->q itself. */
+    int parked = 0;
     if (timeout_ms < 0) {
         if (m->q.head == m->q.tail) {
             /* Issue #200 Phase A: this can block for an unbounded time
@@ -133,9 +192,9 @@ static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
              * heap pointers while blocked here beyond what the pinned
              * Mailbox object itself already exposes. */
             gc_gen_thread_park();
+            parked = 1;
             while (m->q.head == m->q.tail)
                 pthread_cond_wait(&m->cond, &m->mutex);
-            gc_gen_thread_unpark();
         }
     } else if (m->q.head == m->q.tail) {
         /* Bounded by timeout_ms, but still park -- the timeout can be
@@ -143,6 +202,7 @@ static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
          * stop-the-world request wait out someone else's receive
          * timeout when this thread isn't touching Curry objects. */
         gc_gen_thread_park();
+        parked = 1;
         while (m->q.head == m->q.tail) {
             struct timespec ts;
             clock_gettime(CLOCK_REALTIME, &ts);
@@ -151,17 +211,17 @@ static val_t mailbox_pop_wait(Mailbox *m, long timeout_ms) {
             if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
             int rc = pthread_cond_timedwait(&m->cond, &m->mutex, &ts);
             if (rc != 0 && m->q.head == m->q.tail) {
-                gc_gen_thread_unpark();
                 pthread_mutex_unlock(&m->mutex);
+                gc_gen_thread_unpark();
                 return V_FALSE;  /* timeout */
             }
         }
-        gc_gen_thread_unpark();
     }
     val_t msg = m->q.msgs[m->q.head];
     m->q.head = (m->q.head + 1) % m->q.cap;
     uint32_t depth = (uint32_t)((m->q.tail - m->q.head + m->q.cap) % m->q.cap);
     pthread_mutex_unlock(&m->mutex);
+    if (parked) gc_gen_thread_unpark();
 
     if (current_actor) {
         atomic_fetch_add_explicit(&current_actor->msgs_received, 1, memory_order_relaxed);


### PR DESCRIPTION
## Summary

Fixes #223 — a genuine 3-way deadlock under the experimental `--gc generational` backend: a receiving actor could end up parked mid-safepoint while still holding its own mailbox's mutex, deadlocking a concurrent sender against the collector's stop-the-world.

- **Root cause, verified against current code** (not just the issue's excerpt): `mailbox_pop_wait` (`src/actors.c`) called `gc_gen_thread_unpark()` — which calls `gc_gen_safepoint()`, capable of blocking for the duration of an active `gc_gen_stop_the_world()` — while still holding `m->mutex`. A concurrent `mailbox_push()` blocked acquiring that same mutex never reaches its own safepoint poll, so the collector's stop-the-world waits on it forever. Reproduced and confirmed via `sample <pid> 3` thread-dump analysis matching the issue's diagnosis exactly (main thread stuck in `mailbox_push → pthread_mutex_lock`; a receiver stuck in `mailbox_pop_wait → gc_gen_thread_unpark → gc_gen_safepoint → pthread_cond_wait` while holding the mutex; the collector stuck in `gc_gen_stop_the_world`).

## What changed and why

**`mailbox_pop_wait`** (`src/actors.c`): once a wait loop confirms a message is available, release `m->mutex`, call `gc_gen_thread_unpark()`, then re-acquire the mutex before touching the queue at all. This:
1. Never calls `gc_gen_thread_unpark()` while holding `m->mutex` (closes the deadlock).
2. Keeps the dequeue itself (`m->q.head` advance, `m->q.msgs[head]` read) strictly *after* unpark completes — i.e. always fully "unparked"/registered — matching the pre-#223 code's ordering relative to the queue.

(2) matters because the first version of this fix (commit `c088faa`) got it wrong: it deferred `gc_gen_thread_unpark()` until after *both* the dequeue and the unlock, which let the dequeue mutate `m->q` while the thread was still "parked" (excluded from `gc_gen_thread_count`) — racing `gc_gen.c`'s unsynchronized `T_MAILBOX` scan during a concurrent stop-the-world (that scan doesn't take `m->mutex`, relying on every live thread being provably not touching Curry state while parked). An independent code-review pass caught this; commit `3283a6a` is the correction, re-validated from scratch afterward.

**One suggested fix deliberately NOT applied**: bracketing `mailbox_push`'s `pthread_mutex_lock(&m->mutex)` with `gc_gen_thread_park()`/`gc_gen_thread_unpark()` (the issue's secondary, defense-in-depth suggestion). Tried it, and it reintroduced an equivalent deadlock in a new spot (verified the same way): `gc_gen_thread_unpark()`'s safepoint block then happens while `mailbox_push` holds `m->mutex`. Unlike `gc_gen_minor_collect`'s `minor_gc_lock` (held by at most one thread, which structurally can't be mid-STW against itself), `m->mutex` is contended by arbitrary unrelated actor threads, so there's no equivalent guarantee. Left unbracketed with a comment explaining why: `m->mutex` is only ever held for bounded O(1) critical sections once `mailbox_pop_wait`'s bug is fixed (`pthread_cond_wait`/`_timedwait` release the mutex internally while actually blocked, per POSIX), so `gc_gen_stop_the_world()` already safely waits out any in-flight bounded call per `gc_gen_safepoint()`'s own documented contract.

**Docs-only follow-up** (`6b1b6aa`): a security-review pass flagged that the fix relies on "only the owning actor's thread ever calls `mailbox_pop_wait` on its own mailbox" (true today — `prim_receive` always passes `actor_self()` — but enforced only by convention). Documented the invariant at `actor_receive` for future maintainers.

## Validation

- **#223's own repro** (issue body's exact script + `--gc generational --gc-nursery-size 1K`), looped:
  - Pre-fix: hung within 1-2 iterations, reproducibly. Confirmed via `sample` thread dump matching the issue's diagnosis exactly.
  - Post-fix (final, corrected code): **100/100 clean iterations**, `mailbox-stress done` every time.
  - Widened to `--gc-nursery-size 512` (tighter than the issue's 1K): **20/20 clean iterations**.
- **Other-direction stress** (many concurrent sender actors / few receivers): found this shape reliably hits a *different, pre-existing* GC corruption bug (filed separately as #226 — confirmed independent of this fix by testing both with and without it applied). Did not further pursue that shape for #223 validation since it's a different failure mode entirely (SIGABRT/heap corruption, not a hang) — no instance of the #223 deadlock signature was observed in any of that testing.
- **Full `ctest --test-dir build`: 125/125 passing** (parity with `main`; `actors` and `dynamic_wind` suites included), run with all `.scc` caches cleared per CLAUDE.md's testing caveat.
- **#220 regression repro**: issue's own script (16 actors, `tvar-write!`, `--gc-nursery-size 1K`), **10/10 clean** (`done` printed every run, no `#<object 0>` corruption).
- **#144 regression repro**: issue's own `phase1_only.scm` compiled ahead-of-time and run from `.scc` (`--gc-nursery-size 8K`), **3/3 clean** (no SIGSEGV, `Phase 1 complete` every run).

## Review

- Two independent code-review passes (fresh subagents, no shared context with the writing session): first pass caught the dequeue-while-parked bug in `c088faa` described above; second pass (after the `3283a6a` correction) confirmed the corrected code is race-free across all `mailbox_pop_wait` code paths, verified the single-reader invariant, and found no remaining bounds/off-by-one issues.
- Two independent security-review passes: first pass on `c088faa` found no issues (before the correctness bug was caught by code review); second pass on the corrected code confirmed no use-after-free/dangling-pointer risk (Mailbox is GC-managed/pinned, no manual free path), correct ring-buffer arithmetic across the unlock/re-lock window, no public-API/embedding exposure, and no park/unpark counter-imbalance risk via exception unwinding — plus the single-reader-invariant observation addressed in `6b1b6aa`.

## Other bugs found along the way

Filed **#226** (separate, pre-existing GC corruption bug — `[gc_gen] FATAL: unknown GC:MOVE type` abort + spurious actor exceptions under heavy concurrent actor churn with a small nursery) — confirmed independent of this fix by reproducing it identically with `src/actors.c` reverted to the pre-#223 commit. Not fixed here; out of scope for this PR.

Closes #223.
