### PR TITLE
fix(symbolic): scope sx_simplify memoization to per-operator/per-variable deps

### DIFF
--- a/src/builtins_curry.c
+++ b/src/builtins_curry.c
@@ -149,13 +149,14 @@ static val_t prim_assume(int ac, val_t *av, void *ud) {
     uint32_t flag = sx_assumption_flag(av[1]);
     if (flag) {
         as_symvar(av[0])->hdr.flags |= flag;
-        /* Issue #137 follow-up: sx_simplify's memoization cache is
-         * keyed on rule/algebra generation only; simplification results
-         * also depend on SymVar assumption flags (sqrt(x^2) -> |x| vs.
-         * x), so a change here must invalidate the cache too -- see
-         * eval.c's S_WITH_ASSUMPTIONS's identical fix for the same
-         * class of mutation via a different entry point. */
-        sx_invalidate_simplify_cache();
+        /* Issue #137/#195 follow-up: sx_simplify's memoization cache
+         * tracks per-variable dependencies now (not a single global
+         * generation); simplification results also depend on SymVar
+         * assumption flags (sqrt(x^2) -> |x| vs. x), so a change here
+         * must invalidate this specific variable's slot -- see eval.c's
+         * S_WITH_ASSUMPTIONS's identical fix for the same class of
+         * mutation via a different entry point. */
+        sx_invalidate_simplify_cache_var(as_symvar(av[0])->name);
     }
     return V_VOID;
 }
@@ -171,7 +172,7 @@ static val_t prim_drop_assumption(int ac, val_t *av, void *ud) {
     uint32_t flag = sx_assumption_flag(av[1]);
     if (flag) {
         as_symvar(av[0])->hdr.flags &= ~flag;
-        sx_invalidate_simplify_cache(); /* see prim_assume's identical comment */
+        sx_invalidate_simplify_cache_var(as_symvar(av[0])->name); /* see prim_assume's identical comment */
     }
     return V_VOID;
 }
@@ -190,14 +191,14 @@ static val_t prim_assumption_set(int ac, val_t *av, void *ud) {
     (void)ud; (void)ac;
     if (!vis_symvar(av[0])) return V_VOID;
     as_symvar(av[0])->hdr.flags |= (uint32_t)vunfix(av[1]);
-    sx_invalidate_simplify_cache(); /* see prim_assume's identical comment */
+    sx_invalidate_simplify_cache_var(as_symvar(av[0])->name); /* see prim_assume's identical comment */
     return V_VOID;
 }
 static val_t prim_assumption_restore(int ac, val_t *av, void *ud) {
     (void)ud; (void)ac;
     if (!vis_symvar(av[0])) return V_VOID;
     as_symvar(av[0])->hdr.flags = (uint32_t)vunfix(av[1]);
-    sx_invalidate_simplify_cache(); /* see prim_assume's identical comment */
+    sx_invalidate_simplify_cache_var(as_symvar(av[0])->name); /* see prim_assume's identical comment */
     return V_VOID;
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -1387,15 +1387,18 @@ tail:
             nv++;
             cl = vcdr(cl);
         }
-        /* Issue #137 follow-up (found by independent code review):
+        /* Issue #137/#195 follow-up (found by independent code review):
          * sx_simplify's own memoization cache is keyed only on rule/
          * algebra registration generation, not on SymVar assumption
          * flags -- but simplification results (e.g. sqrt(x^2) -> |x|
          * vs. x) also depend on those flags. Without invalidating here,
          * a node simplified before entering this form could be served
          * stale from cache inside the body, even though its variable's
-         * assumptions just changed. */
-        if (nv > 0) sx_invalidate_simplify_cache();
+         * assumptions just changed. Scoped per-variable (by NAME, since
+         * that's how the rest of symbolic.c treats same-named SymVars
+         * as the same logical variable) rather than a global bump. */
+        for (int i = 0; i < nv; i++)
+            sx_invalidate_simplify_cache_var(as_symvar(saved_vars[i])->name);
 
         val_t result = V_VOID;
         ExnHandler h;
@@ -1411,12 +1414,14 @@ tail:
             /* Restore flags before re-raising */
             for (int i = 0; i < nv; i++)
                 as_symvar(saved_vars[i])->hdr.flags = saved_flags[i];
-            if (nv > 0) sx_invalidate_simplify_cache();
+            for (int i = 0; i < nv; i++)
+                sx_invalidate_simplify_cache_var(as_symvar(saved_vars[i])->name);
             scm_raise_val(h.exn);
         }
         for (int i = 0; i < nv; i++)
             as_symvar(saved_vars[i])->hdr.flags = saved_flags[i];
-        if (nv > 0) sx_invalidate_simplify_cache();
+        for (int i = 0; i < nv; i++)
+            sx_invalidate_simplify_cache_var(as_symvar(saved_vars[i])->name);
         return result;
     }
 

--- a/src/object.h
+++ b/src/object.h
@@ -712,17 +712,24 @@ typedef struct {
     Hdr      hdr;
     val_t    op;       /* a symbol: "+", "*", "expt", "sin", ... */
     uint32_t nargs;
-    /* Issue #140: sx_simplify's memoization generation stamp. Was
-     * packed into hdr.flags (a uint32_t shared with every other heap
-     * object type) by #137 -- that width let the global generation
-     * counter wrap in ~3 minutes under tight invalidation (repeated
-     * define-rule/define-algebra/assume! calls), letting a stale
-     * cached node get served as current. SymExpr is its own dedicated
-     * struct (not a shared layout), so a wider, PRIVATE field is just
-     * as easy as reusing hdr.flags was -- this is that field. See
-     * symbolic.c's sx_simplify/g_sx_simplify_generation for the full
-     * scheme; hdr.flags is no longer used by this type (left 0). */
-    uint64_t simplify_gen;
+    /* Issue #195 (per-operator/per-variable scoped memoization, superseding
+     * #140's single global generation counter): op_deps/var_deps are
+     * membership bitmasks into symbolic.c's op_generation_table (256 slots,
+     * 4 words) and var_generation_table (128 slots, 2 words) -- one bit per
+     * slot, the last slot of each table reserved as a safe "overflow"
+     * catch-all (see symbolic.c). max_gen is the max, AT THE TIME this node
+     * was cached, of every tracked slot's generation counter (all counters
+     * are monotonic, so a single scalar max suffices for a sound validity
+     * check -- see sx_simplify's cache-hit path). 0 means "never cached"
+     * (sx_make_expr zero-initializes everything, and every real generation
+     * value starts at 1 and skips 0 on wraparound, matching #140's
+     * convention, so 0 can never collide with a genuine cached value).
+     * Replaces #137/#140's single simplify_gen field + global
+     * g_sx_simplify_generation counter -- see symbolic.c's long comment
+     * above sx_simplify_impl for the full history and rationale. */
+    uint64_t op_deps[4];
+    uint64_t var_deps[2];
+    uint64_t max_gen;
     val_t    args[];   /* flex array of sub-expressions */
 } SymExpr;
 

--- a/src/sx_algebra.c
+++ b/src/sx_algebra.c
@@ -78,11 +78,12 @@ void sx_algebra_define(val_t op, bool commutative, bool associative,
                 atomic_load_explicit(&atab_generation, memory_order_relaxed) + 1,
                 memory_order_relaxed);
             pthread_rwlock_unlock(&atab_lock);
-            /* Issue #137: same reasoning as sx_rule_add's identical
+            /* Issue #137/#195: same reasoning as sx_rule_add's identical
              * call -- a node cached as "fully simplified" before this
              * operator's algebra properties were (re-)defined must not
-             * keep being served stale now that they've changed. */
-            sx_invalidate_simplify_cache();
+             * keep being served stale now that they've changed. Scoped
+             * to just this operator (plus the shared overflow slot). */
+            sx_invalidate_simplify_cache_op(op);
             return;
         }
     }

--- a/src/sx_rules.c
+++ b/src/sx_rules.c
@@ -5,7 +5,7 @@
 #include "gc.h"
 #include "builtins.h"  /* scm_cons */
 #include "eval.h"      /* apply_arr */
-#include "symbolic.h"  /* sx_invalidate_simplify_cache */
+#include "symbolic.h"  /* sx_invalidate_simplify_cache_op */
 #include <pthread.h>
 
 /* ---- Rule struct ---- */
@@ -149,11 +149,12 @@ void sx_rule_add(val_t pattern, val_t pvars,
         memory_order_relaxed);
     pthread_rwlock_unlock(&rtab_lock);
 
-    /* Issue #137: a node sx_simplify already cached as "fully
+    /* Issue #137/#195: a node sx_simplify already cached as "fully
      * simplified" before this rule existed must not keep being served
      * stale from that cache now that a new rule could change what
-     * simplifying its operator actually does. */
-    sx_invalidate_simplify_cache();
+     * simplifying its operator actually does -- scoped to just this
+     * operator (plus the shared overflow slot), not the whole cache. */
+    sx_invalidate_simplify_cache_op(op);
 }
 
 /* Fields sx_rule_try actually needs, copied out from under rtab_lock
@@ -331,29 +332,47 @@ void sx_rules_clear(val_t ruleset) {
      * cached as "simplified" under the removed rule's rewrite may no
      * longer be a fixpoint once the rule is gone), so this needs the
      * same invalidation sx_rule_add already does for the opposite
-     * (adding) direction. */
-    sx_invalidate_simplify_cache();
+     * (adding) direction.
+     *
+     * Issue #195: scoped, not global -- for a whole-table clear
+     * (ruleset == V_FALSE) every op currently present in rtab needs
+     * invalidating (this loop already walks the array either way, so
+     * that's mechanical); for a scoped ruleset clear, only the ops of
+     * slots that ACTUALLY had a rule unlinked. Collect the affected ops
+     * while under rtab_lock (rtab[i].op is stable, never reassigned
+     * once claimed -- see rtab's own declaration comment -- so reading
+     * it here is safe), then invalidate each after releasing the lock,
+     * matching this file's existing convention of never calling out to
+     * other subsystems while still holding rtab_lock. */
+    val_t affected[RTAB_SIZE];
+    int n_affected = 0;
     pthread_rwlock_wrlock(&rtab_lock);
     for (int i = 0; i < RTAB_SIZE; i++) {
         if (rtab[i].op == V_VOID) continue;
         if (ruleset == V_FALSE) {
+            if (rtab[i].head != NULL) affected[n_affected++] = rtab[i].op;
             rtab[i].head = NULL;
         } else {
             /* Remove rules belonging to this ruleset */
+            bool unlinked_any = false;
             SxRule **prev = &rtab[i].head;
             SxRule  *cur  = rtab[i].head;
             while (cur) {
                 if (cur->ruleset == ruleset) {
                     *prev = cur->next;
                     cur   = *prev;
+                    unlinked_any = true;
                 } else {
                     prev = &cur->next;
                     cur  = cur->next;
                 }
             }
+            if (unlinked_any) affected[n_affected++] = rtab[i].op;
         }
     }
     pthread_rwlock_unlock(&rtab_lock);
+
+    for (int i = 0; i < n_affected; i++) sx_invalidate_simplify_cache_op(affected[i]);
 }
 
 void sx_rules_gc_scan(void) {

--- a/src/symbolic.c
+++ b/src/symbolic.c
@@ -127,7 +127,11 @@ val_t sx_make_expr(val_t op, int nargs, val_t *args) {
     e->hdr.flags = 0;
     e->op        = op;
     e->nargs     = (uint32_t)nargs;
-    e->simplify_gen = 0; /* zero-init is automatic via GC too; explicit for clarity */
+    /* zero-init (op_deps/var_deps/max_gen all 0, "never cached") is
+     * automatic via GC too; explicit for clarity -- see object.h. */
+    memset(e->op_deps, 0, sizeof(e->op_deps));
+    memset(e->var_deps, 0, sizeof(e->var_deps));
+    e->max_gen = 0;
     for (int i = 0; i < nargs; i++) e->args[i] = args[i];
     return vptr(e);
 }
@@ -239,121 +243,447 @@ static bool decompose_trig_sq(val_t term,
  * threshold, confirmed during #134's own testing to burn 20-30+ seconds
  * of CPU under a generous stack ulimit before the guard ever engages.
  *
- * Fixed with a generation-tagged memoization cache: SymExpr's own
- * dedicated simplify_gen field (see object.h -- issue #140 moved this
- * off hdr.flags, see below) stores the g_sx_simplify_generation value
- * in effect the last time this exact node was fully simplified;
- * sx_simplify (the public entry point, below sx_simplify_impl) checks
- * that tag first and returns the node UNCHANGED with no recursion at
- * all if it matches the CURRENT generation -- turning the "wrap an
- * already-simplified result" pattern back into O(depth) total, since
- * each wrap only ever simplifies the ONE new outer node, never
- * re-walking the (already-tagged) tree beneath it.
+ * Fixed with a generation-tagged memoization cache, originally (per
+ * #137/#140) a single global counter -- simple, but #140 found it let
+ * one cheap define-rule/define-algebra call interleaved per step of an
+ * otherwise-cheap deep-expression build defeat memoization ENTIRELY
+ * (invalidating the whole cache, not just nodes touching the operator
+ * that actually changed), reintroducing the O(depth^2) DoS this cache
+ * exists to close.
  *
- * The generation counter exists because simplification is not a fixed
- * function of an expression's own shape alone: `define-rule`/
- * `define-algebra` register new rules/algebra properties at runtime
- * (sx_rule_add / sx_algebra_define), which can change what "fully
- * simplified" even means for operators already in use. A bare one-bit
- * "already simplified" tag would let a node simplified BEFORE a new
- * rule was registered keep being served stale from cache after the
- * registration, if a script kept building on top of it -- a real
- * correctness regression, not just a missed optimization. Both
- * registration functions call sx_invalidate_simplify_cache() (declared
- * in symbolic.h), which bumps this counter, so every previously-cached
- * tag stops matching and the next sx_simplify call on each affected
- * node redoes the full pass under the new rule set.
+ * Issue #195 replaces the single global counter with PER-OPERATOR and
+ * PER-VARIABLE scoped generation tracking:
  *
- * Issue #140 found two follow-up problems with this scheme, both from
- * independent review of #137's own fix:
+ *   - op_generation_table / var_generation_table (below): fixed-size,
+ *     open-addressed tables mirroring sx_rules.c's rtab / sx_algebra.c's
+ *     atab -- slot never reassigned once claimed, rwlock guards
+ *     claiming only, reads are lock-free atomic loads once a slot
+ *     exists. Keyed by operator symbol / SymVar NAME symbol (not SymVar
+ *     object identity -- multiple distinct SymVars can share a name and
+ *     are the same logical variable elsewhere in this file, e.g.
+ *     sx_equal's vis_symvar case), both permanently-interned symbols
+ *     (GC_MALLOC_UNCOLLECTABLE, never moved -- see symbol.c), so unlike
+ *     rtab/atab these tables need no GC scanner.
+ *   - Each SymExpr node records which slots its OWN simplification
+ *     actually depended on (op_deps/var_deps bitmasks, object.h) and the
+ *     max generation those slots had AT CACHE TIME (max_gen). A cache
+ *     hit re-checks: is the CURRENT generation of every tracked slot
+ *     still <= max_gen? Bounded by table capacity, not tree depth --
+ *     the key property that closes the O(depth^2) DoS, since a deep but
+ *     narrow expression touches only a handful of distinct operators
+ *     regardless of its depth.
+ *   - Soundness (this is the fix for a gap #195's own design review
+ *     caught before any code was written): a node's operator dependency
+ *     must be the operator sx_simplify() actually QUERIED for that
+ *     node -- se->op, read and locked in via op_gen_touch() BEFORE
+ *     sx_simplify_impl runs any rule/algebra lookup for it -- never
+ *     derived from the shape of whatever the lookup rewrites it to.
+ *     E.g. `(- a 0)` rewrites to a `neg(a)` node; if the dependency were
+ *     derived from the RESULT's own top-level op (neg) instead of the
+ *     op actually queried (sub), a later `define-rule` for `-` would
+ *     never invalidate this cached rewrite -- exactly the silent-
+ *     staleness class #140 exists to prevent. sx_simplify implements
+ *     this via a thread-local stack of per-call-frame dependency
+ *     accumulators (g_sx_deps_stack, below): every nested sx_simplify()
+ *     call made WHILE processing node N's own frame -- whether a plain
+ *     child recursion or a rule/algebra rewrite's own recursive
+ *     re-simplify -- merges its contribution into N's frame, with no
+ *     change needed to sx_simplify_impl's own (large, rewrite-heavy)
+ *     body: it already calls sx_simplify(), not sx_simplify_impl(),
+ *     for every recursive step, including every rewrite continuation.
+ *   - Structural limitation (not a bug -- cannot be closed by any
+ *     design in this category, per #195's own design-validation pass):
+ *     sx_rule_add/sx_algebra_define register arbitrary Scheme closures
+ *     (guard_fn/action_fn/relations_fn). A closure that closes over a
+ *     SymVar NOT among the expression's own args, and branches on that
+ *     variable's assumption flags, creates a dependency invisible to
+ *     any args-tree-based tracking scheme, this one included. Accepted,
+ *     documented limitation -- do not attempt to "fix" this without a
+ *     fundamentally different (non-tree-based) design.
+ *   - Capacity (#195 finding 3): op_generation_table's real domain is
+ *     every operator symbol ever SEEN during simplification, not just
+ *     ones with a registered rule -- confirmed much larger than rtab's
+ *     own domain (rtab only grows via actual sx_rule_add calls). Sized
+ *     generously (256 op slots / 128 var slots) rather than made
+ *     growable, with the LAST slot of each table permanently reserved
+ *     as a safe overflow/catch-all: an operator or variable that can't
+ *     claim a real slot (table genuinely exhausted -- implausible under
+ *     256/128 slots outside a deliberately adversarial workload) is
+ *     tracked via the overflow slot instead, which every mutation of
+ *     that kind (op or var) bumps unconditionally -- an always-correct,
+ *     if coarser, fallback for just the overflowing operator/variable,
+ *     never for the whole cache. A fixed table was chosen over a
+ *     growable one for simplicity: growing rtab/atab-style tables under
+ *     their own rwlock is well-precedented in this codebase, but doing
+ *     it for tables consulted on literally every sx_simplify call (not
+ *     just rule-bearing operators) adds real complexity for a case 256/
+ *     128 slots already covers comfortably.
  *
- *   1. Invalidation is GLOBAL, not scoped to the operator/variable that
- *      actually changed -- interleaving one cheap define-rule/
- *      define-algebra call per step of an otherwise-cheap deep-
- *      expression construction defeats memoization entirely,
- *      reintroducing the O(depth^2) DoS this whole cache exists to
- *      close. A proper fix needs per-operator AND per-variable scoped
- *      invalidation (assumption changes are per-SymVar, not
- *      per-operator, so the two invalidation sources need reconciling
- *      too). Deliberately NOT attempted here: a design was drafted and
- *      independently validated in the session that produced this fix,
- *      and while directionally buildable, it surfaced a real soundness
- *      gap (a node's tracked operator-dependency set must be derived
- *      from the operator sx_simplify_impl actually QUERIED via
- *      sx_rule_try/sx_algebra_lookup, not the operator of whatever
- *      result it rewrites to -- e.g. `(- a 0)` rewrites to a `neg(a)`
- *      node, silently losing the tracked dependency on SUB if derived
- *      from the result's own top-level op instead) and a structural
- *      ceiling no design in this category can close (sx_rule_add/
- *      sx_algebra_define register arbitrary Scheme closures; one that
- *      closes over a SymVar not among the expression's own args and
- *      branches on its assumption flags creates a dependency invisible
- *      to any args-tree-based tracking scheme). Filed as its own
- *      follow-up issue with the validated design, the soundness fix,
- *      and the capacity-sizing findings (a 128-slot per-operator table
- *      is plausibly exhausted by an ORDINARY program's operator
- *      vocabulary, not just an adversarial one) preserved for whoever
- *      picks it up.
- *
- *   2. The generation counter itself was only 32 bits (constrained by
- *      living inside SymExpr's shared hdr.flags field), and reliably
- *      wrapped in ~3 minutes under tight invalidation (confirmed via a
- *      repro driving ~22M cheap rule-registration calls/sec) -- letting
- *      a stale cached node get served as CURRENT after wraparound, a
- *      silent correctness bug, not just a missed optimization. THIS is
- *      what this change fixes: SymExpr is its own dedicated struct (not
- *      a layout shared with other heap object types the way hdr.flags
- *      is), so a wider, private field costs nothing to add. At 64 bits,
- *      wrapping the SAME workload that reached 2^32 in ~3 minutes would
- *      take on the order of tens of thousands of years -- computationally
- *      infeasible. */
-/* Plain uint64_t, NOT _Atomic-qualified: __atomic_load_n/__atomic_add_fetch
- * require a plain type (see runtime.c's identical convention/comment for
- * g_jit_arith_tainted et al.) -- curry's own actors are real OS threads,
- * so a script running define-rule/define-algebra/assume! on one actor
- * while another is mid-sx_simplify needs at least a non-torn read/write
- * here, even though the two-generations-out-of-sync worst case is just a
- * transient over-eager cache miss (an extra full simplify pass), not a
- * memory-safety issue -- SymExpr's own simplify_gen tag is a plain word
- * write with no such cross-thread guarantee, matching how every other
- * per-object flags field in this codebase is handled (see review notes
- * on issue #137: no crash found in an actor stress test). Skipping 0 on
- * increment reserves it for "never simplified" (sx_make_expr always
- * zero-initializes simplify_gen), so a 2^64 wraparound (already
- * computationally infeasible on its own, see above) still couldn't make
- * a fresh, never-simplified node read as cache-valid even in principle.
- *
- * The skip-0 step uses a compare-exchange retry loop rather than a plain
- * fetch-add followed by a corrective second fetch-add: a second review
- * round found that two separate atomic RMW ops leave a real window, right
- * when the counter lands on 0 after wraparound, during which another
- * thread's concurrent load can observe 0 before the corrective add runs --
- * reintroducing the exact "never-simplified node misread as cached" bug
- * this skip exists to prevent. A CAS loop makes the "then skip 0" step
- * atomic with the increment itself, so no other thread ever observes an
- * intermediate 0.
- *
- * Ordering is acquire/release, not relaxed: this generation counter is
- * the only thing establishing a happens-before edge between "a rule/
- * algebra/assumption mutation just happened" (an ordinary, non-atomic
- * store, e.g. prim_assume's `hdr.flags |= flag`) and "another actor
- * thread observes the resulting generation bump and therefore knows to
- * recompute." Relaxed ordering would let a weakly-ordered CPU (this
- * codebase explicitly targets arm64) reorder that ordinary store past
- * the atomic bump, so a thread could see the new generation while still
- * reading the OLD assumption flags/rule table -- matches the
- * release/acquire pattern runtime.c already uses for g_jit_arith_tainted
- * for the identical cross-thread-visibility reason, not relaxed. */
-static uint64_t g_sx_simplify_generation = 1;
+ * Generation counters keep #140's already-fixed conventions: uint64_t
+ * (not _Atomic-qualified -- __atomic_load_n/compare_exchange require a
+ * plain type, matching runtime.c's g_jit_arith_tainted convention),
+ * skip-0-on-wraparound via a CAS retry loop (0 is reserved for "slot
+ * never bumped" / max_gen==0 is reserved for "node never cached"),
+ * acquire/release ordering (establishes happens-before between an
+ * ordinary, non-atomic mutation like prim_assume's `hdr.flags |= flag`
+ * and another actor thread observing the resulting generation bump and
+ * therefore knowing to recompute -- relaxed ordering would let a
+ * weakly-ordered CPU, e.g. arm64, reorder that plain store past the
+ * atomic bump). See #140's original PR for why each of these choices
+ * matters on its own (32-bit wraparound reached in ~3 minutes under
+ * tight invalidation; a plain fetch-add-then-corrective-add left a
+ * window where a concurrent load could observe an intermediate 0). */
 
-void sx_invalidate_simplify_cache(void) {
-    uint64_t cur = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_RELAXED);
+#define SX_OP_GEN_TABLE_SIZE   256
+#define SX_OP_GEN_OVERFLOW_IDX (SX_OP_GEN_TABLE_SIZE - 1)
+#define SX_OP_GEN_USABLE       (SX_OP_GEN_TABLE_SIZE - 1)
+#define SX_OP_MASK_WORDS       4   /* 256 bits: 255 usable slots + 1 overflow */
+
+#define SX_VAR_GEN_TABLE_SIZE   128
+#define SX_VAR_GEN_OVERFLOW_IDX (SX_VAR_GEN_TABLE_SIZE - 1)
+#define SX_VAR_GEN_USABLE       (SX_VAR_GEN_TABLE_SIZE - 1)
+#define SX_VAR_MASK_WORDS       2  /* 128 bits: 127 usable slots + 1 overflow */
+
+typedef struct { val_t key; uint64_t gen; } SxGenSlot;
+
+static SxGenSlot sx_op_gen_table[SX_OP_GEN_TABLE_SIZE];
+static SxGenSlot sx_var_gen_table[SX_VAR_GEN_TABLE_SIZE];
+static pthread_rwlock_t sx_op_gen_lock  = PTHREAD_RWLOCK_INITIALIZER;
+static pthread_rwlock_t sx_var_gen_lock = PTHREAD_RWLOCK_INITIALIZER;
+static pthread_once_t sx_gen_tables_once = PTHREAD_ONCE_INIT;
+
+static void sx_gen_tables_init_once(void) {
+    for (int i = 0; i < SX_OP_GEN_TABLE_SIZE; i++) {
+        sx_op_gen_table[i].key = V_VOID;
+        sx_op_gen_table[i].gen = 0;
+    }
+    for (int i = 0; i < SX_VAR_GEN_TABLE_SIZE; i++) {
+        sx_var_gen_table[i].key = V_VOID;
+        sx_var_gen_table[i].gen = 0;
+    }
+    /* Code-review finding: unlike every normal slot (which gets a real,
+     * clock-drawn nonzero gen the MOMENT it's first claimed -- see
+     * sx_op_gen_index/sx_var_gen_index's own "Issue #195 correctness fix"
+     * comments), the reserved overflow slot is never "claimed" at all --
+     * it's always index SX_OP_GEN_OVERFLOW_IDX/SX_VAR_GEN_OVERFLOW_IDX,
+     * fixed from the start. Left at the 0 init value, a node whose entire
+     * dependency set resolves only to the overflow slot (i.e., every
+     * operator/variable it touches happens to have overflowed its table)
+     * would get max_gen==0 the first time it's cached -- indistinguishable
+     * from object.h's own "never cached" sentinel, silently defeating
+     * memoization for that node specifically until the overflow slot
+     * happens to be bumped by some unrelated invalidation. Benign in
+     * effect (the node is just never served from cache, always
+     * recomputed -- never a WRONG answer), but it contradicts this file's
+     * own stated invariant for every other slot. Giving it a real,
+     * hardcoded nonzero gen here closes the gap the same way a claim
+     * would, without needing sx_gen_clock_next() (not yet declared at this
+     * point in the file) -- 1 is guaranteed distinct from and older than
+     * every value sx_gen_clock_next() itself can ever return (its first
+     * call returns 2: g_sx_gen_clock starts at 1, is incremented, then
+     * returned), so any later real invalidation of the overflow slot
+     * still correctly compares as newer. */
+    sx_op_gen_table[SX_OP_GEN_OVERFLOW_IDX].gen  = 1;
+    sx_var_gen_table[SX_VAR_GEN_OVERFLOW_IDX].gen = 1;
+}
+
+/* Both independent code-review and security-review passes flagged this as a
+ * genuine (if benign-in-practice) data race: a plain, unlocked int flag
+ * guarding first-use initialization of tables that every actor thread reads
+ * and writes, in a file otherwise meticulous about atomics/rwlocks for
+ * cross-actor visibility (see g_sx_gen_clock's own comment). Every racing
+ * writer stored the same values, so no divergence was ever observable on
+ * common platforms -- but it's still UB under C11 and would be flagged by
+ * ThreadSanitizer. pthread_once gives the same "run exactly once, visible
+ * to every thread before any of them proceeds past this call" guarantee
+ * `rtab_init`/`atab_init` already provide their own tables via a distinct
+ * mechanism (a one-time init call from modules_init(), not first-use lazy
+ * init) -- pthread_once is used here instead since this table's first use
+ * can genuinely come from any actor thread, not just startup. */
+static void sx_gen_tables_init(void) {
+    pthread_once(&sx_gen_tables_once, sx_gen_tables_init_once);
+}
+
+/* Issue #195 correctness fix (found while validating this exact design
+ * against sx_algebra_tests.scm's own pre-existing #137 regression test --
+ * "a rule registered AFTER caching still fires on the cached node"): op
+ * and var slots CANNOT each keep independent, self-relative generation
+ * counters (e.g. each doing its own skip-0 CAS increment starting from
+ * a shared initial value) if a node's single max_gen scalar is compared
+ * against the CURRENT max over several DIFFERENT tracked slots. Concrete
+ * failure: a node depends on op slot A (gen 1) and var slot B (gen 6,
+ * already bumped several times by earlier unrelated assume!/with-
+ * assumptions calls) -- max_gen recorded at cache time is max(1,6)=6.
+ * Later, ONLY slot A is bumped, 1 -> 2. The revalidation check computes
+ * current max(2,6)=6, which still equals the stored 6 -- a false HIT,
+ * silently serving a result that predates a real, relevant rule change.
+ * The stored single-scalar max is only a sound proxy for "did anything
+ * tracked change" when every slot's generation values are drawn from
+ * ONE shared, globally monotonic sequence -- so a slot being bumped
+ * ALWAYS receives a value strictly greater than every generation number
+ * issued anywhere before it, regardless of which specific slot (op or
+ * var, and regardless of that slot's own prior value) receives it. This
+ * restores the property the design relies on ("all counters are
+ * monotonic" only actually implies what's needed here if it's the SAME
+ * counter sequence backing every tracked slot). g_sx_gen_clock is that
+ * shared source; sx_gen_bump draws the next value from it and stores it
+ * (a plain assignment of a fresh, already-unique value, not a
+ * read-modify-write on the destination slot itself -- no CAS needed
+ * there). Table slots initialise to 0 (below the clock's own starting
+ * value of 1), which doubles as a harmless edge case: a node whose
+ * ENTIRE dependency set has never been bumped even once ends up with
+ * max_gen==0, indistinguishable from "never cached" -- always a safe,
+ * if slightly wasteful (one missed optimization, not a wrong answer),
+ * outcome; see max_gen's own field comment in object.h. */
+static uint64_t g_sx_gen_clock = 1;
+
+static uint64_t sx_gen_clock_next(void) {
+    uint64_t cur = __atomic_load_n(&g_sx_gen_clock, __ATOMIC_RELAXED);
     uint64_t next;
     do {
         next = cur + 1;
         if (next == 0) next = 1;
-    } while (!__atomic_compare_exchange_n(&g_sx_simplify_generation, &cur, next,
+    } while (!__atomic_compare_exchange_n(&g_sx_gen_clock, &cur, next,
                                           0 /* not weak */, __ATOMIC_RELEASE, __ATOMIC_RELAXED));
+    return next;
+}
+
+static void sx_gen_bump(uint64_t *genp) {
+    __atomic_store_n(genp, sx_gen_clock_next(), __ATOMIC_RELEASE);
+}
+
+/* Find-or-claim a table slot for `key`, mirroring rtab/atab's open-
+ * addressing find_chain/atab_slot pattern exactly: fast read-locked scan
+ * first (the hot path -- every sx_simplify call on a SymExpr touches
+ * this for its own operator), falling back to a write-locked claim only
+ * the first time a given op/var is ever seen. Returns the reserved
+ * overflow index if the table is genuinely full. */
+static int sx_op_gen_index(val_t op) {
+    unsigned h = (unsigned)((uintptr_t)op >> 3);
+    int start = (int)(h % (unsigned)SX_OP_GEN_USABLE);
+
+    pthread_rwlock_rdlock(&sx_op_gen_lock);
+    for (int i = 0; i < SX_OP_GEN_USABLE; i++) {
+        int idx = (start + i) % SX_OP_GEN_USABLE;
+        val_t cur = sx_op_gen_table[idx].key;
+        if (cur == op) { pthread_rwlock_unlock(&sx_op_gen_lock); return idx; }
+        if (cur == V_VOID) break;
+    }
+    pthread_rwlock_unlock(&sx_op_gen_lock);
+
+    pthread_rwlock_wrlock(&sx_op_gen_lock);
+    int result = SX_OP_GEN_OVERFLOW_IDX;
+    for (int i = 0; i < SX_OP_GEN_USABLE; i++) {
+        int idx = (start + i) % SX_OP_GEN_USABLE;
+        if (sx_op_gen_table[idx].key == op) { result = idx; break; }
+        if (sx_op_gen_table[idx].key == V_VOID) {
+            /* Issue #195 correctness fix: a slot's gen must become a real,
+             * nonzero, clock-ordered value the MOMENT it's first claimed,
+             * not stay at its 0 init placeholder until some later explicit
+             * invalidation. Otherwise a node whose entire dependency set
+             * (op AND every var it touches) has never been invalidated
+             * even once ends up with max_gen==0 -- indistinguishable from
+             * "never cached" (object.h's own sentinel), silently defeating
+             * memoization for the common case of a program that never
+             * calls define-rule/define-algebra/assume! at all. See
+             * op_deps's field comment in object.h and this file's
+             * g_sx_gen_clock comment for the full reasoning. */
+            sx_op_gen_table[idx].key = op;
+            sx_op_gen_table[idx].gen = sx_gen_clock_next();
+            result = idx;
+            break;
+        }
+    }
+    pthread_rwlock_unlock(&sx_op_gen_lock);
+    return result;
+}
+
+static int sx_var_gen_index(val_t name) {
+    unsigned h = (unsigned)((uintptr_t)name >> 3);
+    int start = (int)(h % (unsigned)SX_VAR_GEN_USABLE);
+
+    pthread_rwlock_rdlock(&sx_var_gen_lock);
+    for (int i = 0; i < SX_VAR_GEN_USABLE; i++) {
+        int idx = (start + i) % SX_VAR_GEN_USABLE;
+        val_t cur = sx_var_gen_table[idx].key;
+        if (cur == name) { pthread_rwlock_unlock(&sx_var_gen_lock); return idx; }
+        if (cur == V_VOID) break;
+    }
+    pthread_rwlock_unlock(&sx_var_gen_lock);
+
+    pthread_rwlock_wrlock(&sx_var_gen_lock);
+    int result = SX_VAR_GEN_OVERFLOW_IDX;
+    for (int i = 0; i < SX_VAR_GEN_USABLE; i++) {
+        int idx = (start + i) % SX_VAR_GEN_USABLE;
+        if (sx_var_gen_table[idx].key == name) { result = idx; break; }
+        if (sx_var_gen_table[idx].key == V_VOID) {
+            /* See sx_op_gen_index's identical fix for why a freshly-
+             * claimed slot needs a real clock-drawn gen immediately,
+             * not the 0 init placeholder. */
+            sx_var_gen_table[idx].key = name;
+            sx_var_gen_table[idx].gen = sx_gen_clock_next();
+            result = idx;
+            break;
+        }
+    }
+    pthread_rwlock_unlock(&sx_var_gen_lock);
+    return result;
+}
+
+static inline void sx_bit_set(uint64_t *mask, int idx) {
+    mask[idx >> 6] |= ((uint64_t)1 << (idx & 63));
+}
+
+/* Claims (if needed) the slot for `op`, sets its bit in `mask_out`, and
+ * returns its CURRENT generation -- called by sx_simplify() BEFORE
+ * sx_simplify_impl runs any rule/algebra lookup for this exact op (see
+ * the soundness note in the long comment above), so the returned value
+ * can never be newer than whatever state that lookup actually saw. */
+static uint64_t sx_op_gen_touch(val_t op, uint64_t mask_out[SX_OP_MASK_WORDS]) {
+    sx_gen_tables_init();
+    int idx = sx_op_gen_index(op);
+    sx_bit_set(mask_out, idx);
+    return __atomic_load_n(&sx_op_gen_table[idx].gen, __ATOMIC_ACQUIRE);
+}
+static uint64_t sx_var_gen_touch(val_t name, uint64_t mask_out[SX_VAR_MASK_WORDS]) {
+    sx_gen_tables_init();
+    int idx = sx_var_gen_index(name);
+    sx_bit_set(mask_out, idx);
+    return __atomic_load_n(&sx_var_gen_table[idx].gen, __ATOMIC_ACQUIRE);
+}
+
+/* Cache-hit validity check: current generation of every tracked slot,
+ * lock-free (slots are never reassigned once claimed, so reading .gen
+ * without the rwlock is safe -- only claiming a NEW slot needs it). */
+static uint64_t sx_op_gen_current_max(const uint64_t mask[SX_OP_MASK_WORDS]) {
+    uint64_t m = 0;
+    for (int w = 0; w < SX_OP_MASK_WORDS; w++) {
+        uint64_t bits = mask[w];
+        while (bits) {
+            int b = __builtin_ctzll(bits);
+            bits &= bits - 1;
+            uint64_t g = __atomic_load_n(&sx_op_gen_table[w * 64 + b].gen, __ATOMIC_ACQUIRE);
+            if (g > m) m = g;
+        }
+    }
+    return m;
+}
+static uint64_t sx_var_gen_current_max(const uint64_t mask[SX_VAR_MASK_WORDS]) {
+    uint64_t m = 0;
+    for (int w = 0; w < SX_VAR_MASK_WORDS; w++) {
+        uint64_t bits = mask[w];
+        while (bits) {
+            int b = __builtin_ctzll(bits);
+            bits &= bits - 1;
+            uint64_t g = __atomic_load_n(&sx_var_gen_table[w * 64 + b].gen, __ATOMIC_ACQUIRE);
+            if (g > m) m = g;
+        }
+    }
+    return m;
+}
+
+void sx_invalidate_simplify_cache_op(val_t op) {
+    sx_gen_tables_init();
+    int idx = sx_op_gen_index(op);
+    sx_gen_bump(&sx_op_gen_table[idx].gen);
+    if (idx != SX_OP_GEN_OVERFLOW_IDX)
+        sx_gen_bump(&sx_op_gen_table[SX_OP_GEN_OVERFLOW_IDX].gen);
+}
+
+void sx_invalidate_simplify_cache_var(val_t var_name) {
+    sx_gen_tables_init();
+    int idx = sx_var_gen_index(var_name);
+    sx_gen_bump(&sx_var_gen_table[idx].gen);
+    if (idx != SX_VAR_GEN_OVERFLOW_IDX)
+        sx_gen_bump(&sx_var_gen_table[SX_VAR_GEN_OVERFLOW_IDX].gen);
+}
+
+void sx_invalidate_simplify_cache(void) {
+    /* True global invalidation -- every claimed slot in both tables,
+     * plus both overflow slots. O(table size), not O(cache size); kept
+     * for callers that don't know (or don't want to compute) exactly
+     * which operator/variable changed. Nothing in this codebase calls
+     * this anymore as of #195 (sx_rule_add/sx_algebra_define/
+     * sx_rules_clear/assume!/with-assumptions all now use the scoped
+     * variants above), but it's kept available and genuinely global,
+     * not repurposed to mean something narrower, so it can never become
+     * a silent-unsoundness trap for a future caller that assumes the
+     * old global-invalidation contract. */
+    sx_gen_tables_init();
+    pthread_rwlock_wrlock(&sx_op_gen_lock);
+    for (int i = 0; i < SX_OP_GEN_TABLE_SIZE; i++) sx_gen_bump(&sx_op_gen_table[i].gen);
+    pthread_rwlock_unlock(&sx_op_gen_lock);
+    pthread_rwlock_wrlock(&sx_var_gen_lock);
+    for (int i = 0; i < SX_VAR_GEN_TABLE_SIZE; i++) sx_gen_bump(&sx_var_gen_table[i].gen);
+    pthread_rwlock_unlock(&sx_var_gen_lock);
+}
+
+/* ---- Per-call-frame dependency accumulator stack (see the soundness
+ * note in the long comment above) ----
+ *
+ * Heap-backed (not a fixed on-stack/TLS array of raw pointers), grown
+ * on demand, per-thread: most actor threads never touch symbolic code
+ * at all, so a lazily-allocated pointer costs nothing for them, and a
+ * growable buffer avoids picking one fixed depth that's either wasteful
+ * for the common case or too shallow for a legitimately deep (if
+ * unusual) expression tree.
+ *
+ * Indexed by depth rather than holding raw pointers into this
+ * function's own C stack frame is a deliberate exception-safety choice:
+ * a rule's guard_fn/action_fn or an algebra's relations_fn is arbitrary
+ * Scheme, free to call `error`/raise and unwind via longjmp through
+ * sx_simplify's own C stack frame without running its cleanup code. If
+ * the accumulator lived in THAT frame, an unwind would leave
+ * g_sx_deps_depth (thread-local, so it retains its value across the
+ * jump) pointing at a slot that's still perfectly valid storage --
+ * because it's in this static/heap buffer, not on the collapsed C
+ * stack -- but was never popped back down. The only consequence is a
+ * bounded, self-limiting "leak" of unused depth accounting for the rest
+ * of that thread's life (capped by SX_DEPS_STACK_HARD_MAX, at which
+ * point sx_simplify falls back to not caching at all rather than ever
+ * indexing out of bounds); a later, unrelated top-level call simply
+ * starts pushing frames at a higher starting depth than 0, which is
+ * internally self-consistent (each push/pop pair within one call still
+ * nests correctly relative to ITSELF) and never corrupts another
+ * thread's or another call's state, since g_sx_deps_stack is per-thread
+ * and each active call only ever reads/writes the slot(s) it pushed. */
+typedef struct {
+    uint64_t op[SX_OP_MASK_WORDS];
+    uint64_t var[SX_VAR_MASK_WORDS];
+    uint64_t max_gen;
+} SxDeps;
+
+#define SX_DEPS_STACK_HARD_MAX 65536
+
+static CURRY_THREAD_LOCAL SxDeps *g_sx_deps_stack = NULL;
+static CURRY_THREAD_LOCAL int     g_sx_deps_cap   = 0;
+static CURRY_THREAD_LOCAL int     g_sx_deps_depth = 0;
+
+/* Ensures g_sx_deps_stack has room for index `depth`; returns false (and
+ * leaves the stack untouched) if that would require growing past
+ * SX_DEPS_STACK_HARD_MAX -- the caller's job is to fall back to the
+ * always-safe "don't tag this node" path in that case. */
+static bool sx_deps_stack_reserve(int depth) {
+    if (depth < g_sx_deps_cap) return true;
+    if (depth >= SX_DEPS_STACK_HARD_MAX) return false;
+    int new_cap = g_sx_deps_cap ? g_sx_deps_cap * 2 : 64;
+    if (new_cap <= depth) new_cap = depth + 1;
+    if (new_cap > SX_DEPS_STACK_HARD_MAX) new_cap = SX_DEPS_STACK_HARD_MAX;
+    SxDeps *grown = (SxDeps *)realloc(g_sx_deps_stack, (size_t)new_cap * sizeof(SxDeps));
+    if (!grown) return false; /* OOM: safe fallback, same as hitting the hard cap */
+    g_sx_deps_stack = grown;
+    g_sx_deps_cap = new_cap;
+    return true;
+}
+
+static void sx_deps_merge_into_current(const uint64_t op_mask[SX_OP_MASK_WORDS],
+                                        const uint64_t var_mask[SX_VAR_MASK_WORDS],
+                                        uint64_t max_gen) {
+    if (g_sx_deps_depth <= 0) return;
+    SxDeps *cur = &g_sx_deps_stack[g_sx_deps_depth - 1];
+    for (int w = 0; w < SX_OP_MASK_WORDS; w++)  cur->op[w]  |= op_mask[w];
+    for (int w = 0; w < SX_VAR_MASK_WORDS; w++) cur->var[w] |= var_mask[w];
+    if (max_gen > cur->max_gen) cur->max_gen = max_gen;
 }
 
 static val_t sx_simplify_impl(val_t expr) {
@@ -1067,19 +1397,136 @@ static val_t sx_simplify_impl(val_t expr) {
     return sx_make_expr(op, n, sa);
 }
 
-/* Public entry point: the memoization fast-path for issue #137 (see the
- * long comment above sx_simplify_impl for the full rationale). Every
- * recursive call INSIDE sx_simplify_impl's own body calls this function
- * (not sx_simplify_impl directly), so a subexpression already tagged at
- * the current generation is returned unchanged with no further
- * recursion at any depth, not just at the top level. */
+/* Public entry point: the memoization fast-path for issue #137, scoped
+ * per-operator/per-variable as of #195 (see the long comment above
+ * sx_simplify_impl for the full rationale). Every recursive call INSIDE
+ * sx_simplify_impl's own body calls this function (not
+ * sx_simplify_impl directly) -- both plain child recursion and every
+ * rule/algebra rewrite's own re-simplify -- so a subexpression already
+ * cached and still valid is returned unchanged with no further
+ * recursion at any depth, not just at the top level, and every such
+ * call correctly contributes its own tracked dependencies to whichever
+ * node's frame is currently being computed (see
+ * sx_deps_merge_into_current / g_sx_deps_stack above). */
 val_t sx_simplify(val_t expr) {
-    uint64_t gen = __atomic_load_n(&g_sx_simplify_generation, __ATOMIC_ACQUIRE);
-    if (vis_symexpr(expr) && as_symexpr(expr)->simplify_gen == gen)
+    if (vis_symvar(expr)) {
+        /* Bare variables are always already "simplified"; still record
+         * a dependency on this var's own name into whatever frame is
+         * currently active, since the ENCLOSING node's own dispatch
+         * (sym_is_positive/sym_is_negative etc., a few lines further
+         * into sx_simplify_impl) may branch on its assumption flags. */
+        uint64_t var_mask[SX_VAR_MASK_WORDS] = {0};
+        uint64_t g = sx_var_gen_touch(as_symvar(expr)->name, var_mask);
+        static const uint64_t no_op_bits[SX_OP_MASK_WORDS] = {0};
+        sx_deps_merge_into_current(no_op_bits, var_mask, g);
         return expr;
+    }
+    if (!vis_symexpr(expr)) {
+        if (vis_tuple(expr)) return sx_simplify_impl(expr);
+        return expr; /* numbers, etc: nothing to track */
+    }
+
+    SymExpr *se0 = as_symexpr(expr);
+
+    /* Cache-hit check: is every slot this node's OWN prior computation
+     * depended on still at (or below) the generation recorded then?
+     *
+     * A SymExpr node returned unchanged by a rewrite elsewhere (e.g.
+     * `(- a 0)` simplifying straight to the pre-existing node `a`) can
+     * be a SHARED object multiple concurrent sx_simplify() calls (on
+     * different actor threads, or nested within the same thread) tag at
+     * once -- see the cache-store side below. max_gen is read with
+     * ACQUIRE and op_deps/var_deps with RELAXED, in that order: the
+     * store side always publishes mask updates (RELAXED fetch_or)
+     * strictly before its own max_gen update (RELEASE CAS), so an
+     * ACQUIRE load of max_gen that observes a given bump makes every
+     * mask bit set before that bump visible here too (release-sequence
+     * happens-before), without needing every individual word access to
+     * be a full acquire itself. */
+    uint64_t stored_max = __atomic_load_n(&se0->max_gen, __ATOMIC_ACQUIRE);
+    if (stored_max != 0) {
+        uint64_t op_mask[SX_OP_MASK_WORDS], var_mask[SX_VAR_MASK_WORDS];
+        for (int w = 0; w < SX_OP_MASK_WORDS; w++)
+            op_mask[w] = __atomic_load_n(&se0->op_deps[w], __ATOMIC_RELAXED);
+        for (int w = 0; w < SX_VAR_MASK_WORDS; w++)
+            var_mask[w] = __atomic_load_n(&se0->var_deps[w], __ATOMIC_RELAXED);
+        uint64_t cur_max = sx_op_gen_current_max(op_mask);
+        uint64_t var_max  = sx_var_gen_current_max(var_mask);
+        if (var_max > cur_max) cur_max = var_max;
+        if (cur_max <= stored_max) {
+            /* HIT: this node's own already-recorded deps become part of
+             * whatever the caller's frame is (if any) -- the caller's
+             * own eventual result transitively depends on everything
+             * this cached subtree depends on. */
+            sx_deps_merge_into_current(op_mask, var_mask, stored_max);
+            return expr;
+        }
+    }
+
+    /* MISS (or never cached): push a fresh frame for THIS node, seeded
+     * with the operator sx_simplify_impl is ABOUT to query (soundness:
+     * read before, never derived from the rewritten result's shape). */
+    int depth = g_sx_deps_depth;
+    if (!sx_deps_stack_reserve(depth)) {
+        /* Capacity fallback (see g_sx_deps_stack's comment): skip
+         * precise tracking for this node. Nested sx_simplify() calls
+         * made while computing it still merge into whatever frame WAS
+         * active (if any), which is conservative-safe; this node itself
+         * is simply never tagged/cached (max_gen stays 0 on the fresh
+         * node sx_make_expr allocates), so it's always recomputed. */
+        return sx_simplify_impl(expr);
+    }
+    {
+        SxDeps *frame0 = &g_sx_deps_stack[depth];
+        memset(frame0, 0, sizeof *frame0);
+        uint64_t g = sx_op_gen_touch(se0->op, frame0->op);
+        frame0->max_gen = g;
+    }
+    g_sx_deps_depth = depth + 1;
+
     val_t result = sx_simplify_impl(expr);
-    if (vis_symexpr(result))
-        as_symexpr(result)->simplify_gen = gen;
+
+    g_sx_deps_depth = depth; /* pop (frame's contents are still valid) */
+
+    /* Re-derive the frame pointer AFTER sx_simplify_impl returns, not
+     * before: a nested sx_simplify() call made WHILE computing `expr`
+     * (any child, or a rule/algebra rewrite's own recursive re-simplify)
+     * can itself need a deeper frame than g_sx_deps_stack currently has
+     * room for, triggering sx_deps_stack_reserve()'s realloc -- which
+     * can MOVE the whole array. A `frame` pointer captured before that
+     * call would then dangle; re-indexing by `depth` here always finds
+     * this call's own slot at its current (possibly relocated) address,
+     * since `depth` itself is a stable index, not a pointer. */
+    SxDeps *frame = &g_sx_deps_stack[depth];
+
+    if (vis_symexpr(result)) {
+        /* result may be a freshly-allocated node (the common case, not
+         * yet visible to any other thread -- these writes could be
+         * plain stores) OR a pre-existing SHARED node a rewrite path
+         * returned unchanged (e.g. `(- a 0)` -> `a`, see the cache-hit
+         * comment above) -- always use atomic RMW so a concurrent
+         * tagging of the SAME shared node from another call never loses
+         * an update. Masks (RELAXED fetch_or) are published strictly
+         * before max_gen (RELEASE CAS): see the cache-hit check's
+         * comment for why that specific order is what makes an ACQUIRE
+         * read of max_gen there see these bits too. */
+        SymExpr *rs = as_symexpr(result);
+        for (int w = 0; w < SX_OP_MASK_WORDS; w++)
+            if (frame->op[w]) __atomic_fetch_or(&rs->op_deps[w], frame->op[w], __ATOMIC_RELAXED);
+        for (int w = 0; w < SX_VAR_MASK_WORDS; w++)
+            if (frame->var[w]) __atomic_fetch_or(&rs->var_deps[w], frame->var[w], __ATOMIC_RELAXED);
+        uint64_t cur = __atomic_load_n(&rs->max_gen, __ATOMIC_RELAXED);
+        while (frame->max_gen > cur) {
+            if (__atomic_compare_exchange_n(&rs->max_gen, &cur, frame->max_gen,
+                                            1 /* weak */, __ATOMIC_RELEASE, __ATOMIC_RELAXED))
+                break;
+        }
+    }
+    /* Propagate this node's own contribution up into the (now-restored)
+     * enclosing frame too, if this call was itself made while an outer
+     * node's own frame was active. */
+    sx_deps_merge_into_current(frame->op, frame->var, frame->max_gen);
+
     return result;
 }
 

--- a/src/symbolic.h
+++ b/src/symbolic.h
@@ -264,14 +264,39 @@ val_t sx_diff(val_t expr, val_t var);                        /* ∂/∂var (real
 val_t sx_wirtinger(val_t expr, val_t var, bool is_dbar);     /* ∂/∂z or ∂/∂z̄ */
 val_t sx_integrate(val_t expr, val_t var);                   /* antiderivative ∫ ... dx */
 val_t sx_simplify(val_t expr);                               /* algebraic simplification */
-/* Bumps sx_simplify's own memoization generation counter (issue #137),
- * invalidating every SymExpr node's cached "already fully simplified"
- * tag. Must be called by anything that changes what simplification
- * actually DOES for existing operators -- currently sx_rule_add
- * (sx_rules.c) and sx_algebra_define (sx_algebra.c) -- so a node
- * simplified before a new rule/algebra property was registered doesn't
- * get silently served stale from cache after the registration. */
+/* Issue #195: scoped memoization invalidation, superseding #137/#140's
+ * single global generation counter. Bumps EVERY tracked operator and
+ * variable slot -- a true, unconditionally-safe global invalidation,
+ * kept for callers that don't know (or don't want to compute) which
+ * specific operator/variable actually changed. Prefer the scoped
+ * variants below when the affected operator/variable is known, since
+ * this one defeats memoization for the WHOLE cache, not just nodes
+ * that actually depended on what changed (see #195 for the DoS this
+ * distinction closes). */
 void  sx_invalidate_simplify_cache(void);
+/* Scoped invalidation: bumps only the generation slot for this specific
+ * operator symbol (plus the shared, always-safe overflow slot -- see
+ * symbolic.c's op_generation_table). Call whenever a rule/algebra
+ * registration changes what simplifying THIS operator does
+ * (sx_rule_add/sx_rules_clear in sx_rules.c, sx_algebra_define in
+ * sx_algebra.c). A SymExpr node's cached result stays valid across this
+ * call unless the node actually consulted this exact operator (directly,
+ * or transitively through a subexpression that did) during its own
+ * simplification. */
+void  sx_invalidate_simplify_cache_op(val_t op);
+/* Scoped invalidation: bumps only the generation slot for this specific
+ * variable NAME (plus the shared overflow slot). Variables are tracked
+ * by NAME, not SymVar object identity, matching how the rest of
+ * symbolic.c already treats same-named SymVars as the same logical
+ * variable (see symbolic.c:sx_equal and friends). Call whenever a
+ * SymVar's assumption flags change (eval.c's S_WITH_ASSUMPTIONS,
+ * builtins_curry.c's assume!/drop-assumption!/with-assumptions codegen
+ * support). Structural limitation (documented, not a bug): a registered
+ * rule/algebra closure that closes over a SymVar not among an
+ * expression's own args, and branches on that variable's assumption
+ * flags, creates a dependency this scheme cannot see -- no args-tree-
+ * based tracking scheme can close this gap; see #195. */
+void  sx_invalidate_simplify_cache_var(val_t var_name);
 val_t sx_substitute(val_t expr, val_t var, val_t val);       /* substitute var=val */
 bool  sx_equal(val_t a, val_t b);                            /* structural equality */
 bool  sx_depends_on(val_t expr, val_t var);                  /* true if expr contains var */

--- a/tests/sx_algebra_tests.scm
+++ b/tests/sx_algebra_tests.scm
@@ -336,6 +336,119 @@
   (sym->string (simplify cached-before-rule)) "111 * x")
 
 ;;; ============================================================
+;;; 5b. sx_simplify memoization: PER-OPERATOR/PER-VARIABLE scoped
+;;;     invalidation (issue #195), superseding #140's single global
+;;;     generation counter.
+;;; ============================================================
+
+;;; ---- 5b-i. Soundness fix: a node's tracked operator dependency must
+;;; be the operator actually QUERIED, not the operator of whatever the
+;;; rewrite produces (e.g. `(- a 0)` rewrites to `a` itself, and `(- 0
+;;; a)` rewrites to a BUILT-IN neg(a) dispatch -- both scenarios lose
+;;; every trace of "-" from the resulting shape). A rewrite that
+;;; collapses an operator out of the tree entirely can't be used to
+;;; observe this directly by re-simplifying the collapsed result alone
+;;; (there's nothing left pointing back at the vanished operator to
+;;; re-consult) -- so this uses two SYNTHETIC operators one level
+;;; apart instead, where the rewrite target ITSELF remains a visible,
+;;; distinctly-tagged SymExpr: sx195-a(v), wrapped by an outer
+;;; sx195wrap node (which sym-expr caches, so this exercises real
+;;; memoization, not just a fresh build), rewrites to sx195-b(v) once a
+;;; rule for sx195-a is registered AFTER the wrapper was already
+;;; cached. If sx195-b(v)'s own tracked deps only reflected its own
+;;; top-level op (sx195-b) -- the bug this fix closes -- the wrapper
+;;; would never notice a later sx195-a registration and would keep
+;;; serving the stale pre-rule sx195-a(v) content.
+(define x195sound (sym-var 'x195sound))
+(define inner195  (sym-expr 'sx195-a x195sound))
+(define wrapped195 (sym-expr 'sx195wrap inner195))
+(assert-equal "issue #195 soundness: wrapper caches the uninterpreted inner op before any rule exists"
+  (sym->string wrapped195) "sx195wrap(sx195-a(x195sound))")
+(define-rule (sx195-a ?v) -> (sym-expr 'sx195-b ?v))
+(assert-equal "issue #195 soundness: a later rule for the INNER op invalidates the OUTER cached wrapper too"
+  (sym->string (simplify wrapped195)) "sx195wrap(sx195-b(x195sound))")
+
+;;; ---- 5b-ii. Scoped correctness: registering a rule for operator A
+;;; does not disturb an already-cached, unrelated node for operator B.
+(define x195scope (sym-var 'x195scope))
+(define cached-b195 (sym-expr 'sx195-op-b x195scope))
+(assert-equal "issue #195 scoping: op B cached before any op A rule"
+  (sym->string cached-b195) "sx195-op-b(x195scope)")
+(define-rule (sx195-op-a ?a) -> (quote issue-195-op-a-fired))
+(assert-equal "issue #195 scoping: op B's cached node is UNCHANGED by an op A registration"
+  (eq? (simplify cached-b195) cached-b195) #t)
+
+;;; ---- 5b-iii. DoS closed: interleaving cheap rule registrations for
+;;; operators UNRELATED to an in-progress deep chain must not defeat
+;;; that chain's own memoization. Under the pre-#195 single global
+;;; counter (issue #140 finding 1), ANY registration -- even for a
+;;; completely unrelated operator -- invalidated the WHOLE cache,
+;;; reintroducing #137's O(depth^2) blowup; per #140's own repro a
+;;; 60000-deep interleaved chain took ~30s wall/~51s CPU. Scoped
+;;; invalidation should keep the interleaved run within a small
+;;; constant factor of the uninterleaved baseline instead of blowing
+;;; up quadratically. Uses %define-rule! directly (not the define-rule
+;;; special form, which needs a compile-time-literal operator symbol)
+;;; so each interleaved registration can target an operator other than
+;;; "sin" itself (the chain's own operator dependency is never the one
+;;; actually invalidated) -- cycling through a SMALL fixed pool of
+;;; synthetic operator names (not a fresh one per step): rtab
+;;; (sx_rules.c) is a fixed 128-slot table shared with every OTHER test
+;;; in this file, and each distinct operator symbol permanently claims
+;;; one of those slots the first time it's registered (by design, see
+;;; rtab's own comments) -- thousands of distinct one-off names would
+;;; exhaust it and starve every rule/ruleset test that runs after this
+;;; one in the same process. Reusing 8 names still triggers a genuine
+;;; op_gen_table invalidation on every single registration (sx_rule_add
+;;; calls sx_invalidate_simplify_cache_op unconditionally, regardless
+;;; of whether this is that operator's 1st or 2500th registered rule),
+;;; which is all this test actually needs. Tagged with a dedicated
+;;; ruleset and cleared afterward so the (functionally inert, identity)
+;;; rules it leaves behind don't linger for later tests.
+(define (wrap-sin195 n e) (if (= n 0) e (wrap-sin195 (- n 1) (sin e))))
+(define t195-depth 20000)
+(define t195-base-start (current-second))
+(define deep-sin195-base (wrap-sin195 t195-depth (sym-var 'x195base)))
+(define t195-base-elapsed (- (current-second) t195-base-start))
+
+;; Pooled operator names keep rtab's per-operator chain SHORT (each
+;; %define-rule! call appends to the tail of its operator's existing
+;; rule chain, an O(chain length) walk -- an unbounded pool would make
+;; registration itself accumulate quadratic cost across the run, which
+;; has nothing to do with what this test is actually checking). Also
+;; periodically clearing the ruleset keeps each of those 8 chains at a
+;; small, roughly-constant length throughout, rather than growing to
+;; ~2500 entries apiece by the end.
+(define t195-unrelated-pool-size 8)
+(define (wrap-sin195-interleaved n e)
+  (if (= n 0)
+      e
+      (begin
+        (%define-rule! (list (string->symbol
+                                (string-append "sx195-unrelated-"
+                                  (number->string (remainder n t195-unrelated-pool-size))))
+                              '?z)
+                        (list '?z)
+                        #f
+                        (lambda (z) z)
+                        'issue195-interleaved-ruleset)
+        (if (= 0 (remainder n 200)) (clear-rules! 'issue195-interleaved-ruleset))
+        (wrap-sin195-interleaved (- n 1) (sin e)))))
+(define t195-int-start (current-second))
+(define deep-sin195-int (wrap-sin195-interleaved t195-depth (sym-var 'x195int)))
+(define t195-int-elapsed (- (current-second) t195-int-start))
+(clear-rules! 'issue195-interleaved-ruleset)
+
+(assert-equal "issue #195 DoS: interleaved-registration chain still builds to the right op"
+  (sym-expr-op deep-sin195-int) 'sin)
+;; Generous bound: real O(depth^2) behavior at this depth would be many
+;; times slower than the baseline (seconds-to-minutes, not a small
+;; constant factor) -- this just needs to rule out that blowup, not
+;; assert a tight timing budget on possibly-loaded CI hardware.
+(assert-equal "issue #195 DoS: interleaved run stays within a small constant factor of the uninterleaved baseline"
+  (<= t195-int-elapsed (+ (* 15 t195-base-elapsed) 5.0)) #t)
+
+;;; ============================================================
 ;;; 6. rtab/atab concurrency (issue #141) -- concurrent define-rule/
 ;;;    define-algebra/simplify calls across several actors must not
 ;;;    crash or hang. This doesn't assert a specific outcome (the race


### PR DESCRIPTION
## Summary

Implements the validated design from #195, superseding #140/#137's single global generation counter for `sx_simplify`'s memoization cache. The old scheme invalidates the *entire* cache on any `define-rule`/`define-algebra`/`assume!` call, reintroducing an O(depth²) CPU-exhaustion DoS under a workload that interleaves cheap registration calls with deep-expression construction.

- Two new fixed-size registries mirror `rtab`/`atab`'s existing concurrency pattern exactly (open-addressed, never-reassigned-once-claimed, rwlock-guarded claim / lock-free read): `op_generation_table` (256 slots) keyed by operator symbol, `var_generation_table` (128 slots) keyed by `SymVar` name. Each reserves a last slot as a safe overflow catch-all.
- `SymExpr` gains `op_deps`/`var_deps` bitmasks and a single `max_gen` scalar. Dependencies are computed in `sx_simplify()`'s wrapper, seeded with the operator it's **about to query** — before any rewrite happens — not derived from the rewritten result's shape (which would silently lose a dependency: `(- a 0)` → `neg(a)` naively tracked by result-shape would record a dependency on `neg`, not `-`, so a later `define-rule` for `-` would never invalidate it).
- A structural limitation ships as a documented, accepted trade-off: a rule/algebra closure that closes over a `SymVar` not among the expression's own args and branches on its assumption flags creates a dependency no args-tree-based scheme can see.
- `prim_assume`/`prim_drop_assumption`/`prim_assumption_set`/`prim_assumption_restore` (`builtins_curry.c`) and `S_WITH_ASSUMPTIONS` (`eval.c`) now call `sx_invalidate_simplify_cache_var(name)` instead of a global bump.

## Post-review fixes

Both an independent code-review pass and an independent security-review pass (fresh, no shared context) flagged the same finding, plus code-review caught one more:

1. **Real, if benign-in-practice, data race**: `sx_gen_tables_init`'s lazy first-use init used a plain unlocked `int` flag despite running from arbitrary actor threads, in a file otherwise careful about atomics/rwlocks. Fixed with `pthread_once`.
2. **Invariant gap, benign in effect**: the reserved overflow slot in each table never had its own generation bumped off the `0` init value the way every claimed normal slot does, so a node whose entire dependency set resolved only to the overflow slot got `max_gen==0` — indistinguishable from "never cached" (never a wrong answer, just a missed cache hit). Fixed by giving the overflow slot a real, hardcoded nonzero generation at table-init time.

## Validation

- `ctest`: 125/125, parity with `main`.
- Direct repro: a raw, unsimplified `SymExpr` cached *before* a matching `define-rule` is registered correctly picks up the rule on re-simplify after registration (confirms the query-time dependency tracking, not result-shape tracking).
- `tests/sx_algebra_tests.scm` gained a dedicated regression suite for the scoped-invalidation behavior.
- Rebuilt clean and re-validated everything above on top of current `main` (this branch started from an earlier point and was rebased forward through #221/#224/#225/#227 and the 1.23.8 release with no conflicts).

## Process notes

The implementing session hit its account's monthly spend limit mid-validation, before it could run its own review passes or commit. I picked up its (uncommitted, already-125/125-passing) work, rebased it onto current `main`, re-verified the build/tests/repros myself, obtained the two independent review passes above, applied both fixes, and re-validated before committing and opening this PR.

Not merging this myself — please review and merge when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9329wat9ZDJ1Z975YKqm
